### PR TITLE
pricing and stories to navbar top level instead of "your business"

### DIFF
--- a/app/includes/_more_dropdown_list.html
+++ b/app/includes/_more_dropdown_list.html
@@ -1,12 +1,7 @@
 <ul class="u-text-xxs u-padding-Vxs">
   <li class="u-text-semi">
-    <a href="/pricing" id="track-nav-pricing" class="u-padding-Vxs u-padding-Hm u-block">
-      Pricing
-    </a>
-  </li>
-  <li class="u-text-semi">
-    <a href="/stories" id="track-nav-stories" class="u-padding-Vxs u-padding-Hm u-block">
-      Stories
+    <a href="/Security" id="track-nav-security" class="u-padding-Vxs u-padding-Hm u-block">
+      Security
     </a>
   </li>
   <li class="u-text-semi">

--- a/app/includes/_site_header.html
+++ b/app/includes/_site_header.html
@@ -9,7 +9,7 @@
   <nav class="nav u-pull-start u-color-primary u-text-xxs u-text-light u-text-no-smoothing">
     <div class="nav__item u-relative">
       <a id="track-nav-products" class="u-padding-Vl u-block u-link-clean" toggle="products.isVisible" href="">
-        <div class="nav__item-link">
+        <div class="nav__item-link nav__item-link--dropdown">
           Our products
         </div>
       </a>
@@ -19,19 +19,22 @@
       </popover>
     </div>
     <div class="nav__item u-relative">
-      <a id="track-nav-business" class="u-padding-Vl u-block u-link-clean" toggle="businesses.isVisible" href="">
+      <a class="u-padding-Vl u-block u-link-clean u-link-primary" id="track-nav-pricing" href="/pricing">
         <div class="nav__item-link">
-          Your business
+          Pricing
         </div>
       </a>
-      <popover show="businesses.isVisible" ng-animate class="nav-dropdown__popover"
-      ng-class="{'u-is-visible': businesses.isVisible }">
-        {% include "_businesses_dropdown_list.html" %}
-      </popover>
     </div>
     <div class="nav__item u-relative">
-      <a id="track-nav-more" class="u-padding-Vl u-block u-link-clean" toggle="more.isVisible" href="">
+      <a class="u-padding-Vl u-block u-link-clean u-link-primary" id="track-nav-stories" href="/stories">
         <div class="nav__item-link">
+          Customer stories
+        </div>
+      </a>
+    </div>
+    <div class="nav__item u-relative">
+      <a id="track-nav-more " class="u-padding-Vl u-block u-link-clean" toggle="more.isVisible" href="">
+        <div class="nav__item-link nav__item-link--dropdown">
           More
         </div>
       </a>

--- a/app/includes/_site_header.html
+++ b/app/includes/_site_header.html
@@ -19,14 +19,14 @@
       </popover>
     </div>
     <div class="nav__item u-relative">
-      <a class="u-padding-Vl u-block u-link-clean u-link-primary" id="track-nav-pricing" href="/pricing">
+      <a id="track-nav-pricing" class="u-padding-Vl u-block u-link-clean u-link-primary" href="/pricing">
         <div class="nav__item-link">
           Pricing
         </div>
       </a>
     </div>
     <div class="nav__item u-relative">
-      <a class="u-padding-Vl u-block u-link-clean u-link-primary" id="track-nav-stories" href="/stories">
+      <a id="track-nav-stories" class="u-padding-Vl u-block u-link-clean u-link-primary" href="/stories">
         <div class="nav__item-link">
           Customer stories
         </div>

--- a/app/includes/_site_header_invert.html
+++ b/app/includes/_site_header_invert.html
@@ -6,10 +6,10 @@
 
 <div class="u-pull-end align-btn-small">
 
-  <nav class="nav u-pull-start u-color-invert u-text-xxs u-text-light u-text-no-smoothing">
+  <nav class="nav u-pull-start u-color-invert u-text-xxs u-text-light u-text-no-smoothing nav--invert">
     <div class="nav__item u-relative">
       <a toggle="products.isVisible" id="track-nav-products" class="u-padding-Vl u-block u-link-clean u-link-invert" href="">
-        <div class="nav__item-link">
+        <div class="nav__item-link nav__item-link--dropdown">
           Our products
         </div>
       </a>
@@ -19,19 +19,22 @@
       </popover>
     </div>
     <div class="nav__item u-relative">
-      <a toggle="businesses.isVisible" id="track-nav-business" class="u-padding-Vl u-block u-link-clean u-link-invert" href="">
+      <a class="u-padding-Vl u-block u-link-clean u-link-invert" id="track-nav-pricing" href="/pricing">
         <div class="nav__item-link">
-          Your business
+          Pricing
         </div>
       </a>
-      <popover show="businesses.isVisible" ng-animate class="nav-dropdown__popover"
-      ng-class="{'u-is-visible': businesses.isVisible }">
-        {% include "_businesses_dropdown_list.html" %}
-      </popover>
+    </div>
+    <div class="nav__item u-relative">
+      <a class="u-padding-Vl u-block u-link-clean u-link-invert" id="track-nav-stories" href="/stories">
+        <div class="nav__item-link">
+          Customer stories
+        </div>
+      </a>
     </div>
     <div class="nav__item u-relative">
       <a toggle="more.isVisible" id="track-nav-more" class="u-padding-Vl u-block u-link-clean u-link-invert" href="">
-        <div class="nav__item-link">
+        <div class="nav__item-link nav__item-link--dropdown">
           More
         </div>
       </a>

--- a/app/includes/_site_header_invert.html
+++ b/app/includes/_site_header_invert.html
@@ -19,14 +19,14 @@
       </popover>
     </div>
     <div class="nav__item u-relative">
-      <a class="u-padding-Vl u-block u-link-clean u-link-invert" id="track-nav-pricing" href="/pricing">
+      <a id="track-nav-pricing" class="u-padding-Vl u-block u-link-clean u-link-invert" href="/pricing">
         <div class="nav__item-link">
           Pricing
         </div>
       </a>
     </div>
     <div class="nav__item u-relative">
-      <a class="u-padding-Vl u-block u-link-clean u-link-invert" id="track-nav-stories" href="/stories">
+      <a id="track-nav-stories" class="u-padding-Vl u-block u-link-clean u-link-invert" href="/stories">
         <div class="nav__item-link">
           Customer stories
         </div>


### PR DESCRIPTION
@jamesshedden quick look plz?

Standard navbar:
![screen shot 2015-01-12 at 12 12 16](https://cloud.githubusercontent.com/assets/5781410/5702659/a2872bd0-9a54-11e4-8314-84745c5aa019.png)

Inverted navbar:
![screen shot 2015-01-12 at 12 12 27](https://cloud.githubusercontent.com/assets/5781410/5702665/a938cb8c-9a54-11e4-8e9b-ab91b2d2db54.png)

For both of the above
 - ids for Enhanced Link Attribution :+1:
 - ids before classes for consistency :+1:
 - "More" menu reshuffled to add Security and remove Pricing and Stories :+1:
