### PR TITLE
Use new sales_fr endpoint for /fr/contactez-nous

### DIFF
--- a/app/pages/fr/contactez-nous/index.html
+++ b/app/pages/fr/contactez-nous/index.html
@@ -23,7 +23,7 @@
 
   <div class="site-container grid grid--center u-margin-Vxl u-padding-Vxl">
     <div class="grid__cell u-size-1of2">
-      <form accept-charset="UTF-8" action="/api/v1/prospects/sales" method="post"
+      <form accept-charset="UTF-8" action="/api/v1/prospects/sales_fr" method="post"
         name="prospectForm"
         ng-gc-form-submit="{
           onCreate: onWatchDemoProspectCreate,


### PR DESCRIPTION
I've added a custom endpoint for lead captures at `/fr/contactez-nous` within GoCardless - this updates the splash pages to use it.