### PR TITLE
Remove reference to GoCardless Basic

### DIFF
--- a/app/pages/features/index.html
+++ b/app/pages/features/index.html
@@ -92,7 +92,7 @@
               No setup fees
             </div>
             <p class="u-color-p u-margin-Txs">
-              GoCardless Basic costs just 1% per transaction (capped at £2) with no monthly or setup fees. Scale pricing is also available.
+              GoCardless costs just 1% per transaction (capped at £2) with no monthly or setup fees. Scale pricing is also available.
             </p>
           </div>
           <div class="grid__cell u-size-1of3">


### PR DESCRIPTION
Remove stray reference to GoCardless Basic on the Features page.