### PR TITLE
Fixed inaccuracies in where merchants can be registered to use GoCardless

### DIFF
--- a/app/includes/_sepa_prospect_form_fields.html
+++ b/app/includes/_sepa_prospect_form_fields.html
@@ -11,7 +11,7 @@
   <option value="Estonia">Estonia</option>
   <option value="Finland">Finland</option>
   <option value="France">France</option>
-  <option value="Gremany">Gremany</option>
+  <option value="Germany">Germany</option>
   <option value="Greece">Greece</option>
   <option value="Ireland">Ireland</option>
   <option value="Italy">Italy</option>

--- a/app/pages/faq/merchants/index.html
+++ b/app/pages/faq/merchants/index.html
@@ -489,7 +489,7 @@
             <h3 class="section-heading u-text-heading-light u-color-heading u-margin-Vm u-text-s">
               When will GoCardless be available outside Europe?
             </h3>
-            <p class="para">GoCardless will not be available outside Europe in 2014. We are working very hard to expand to more countries soon.</p>
+            <p class="para">We are working very hard to expand to more countries in 2015.</p>
           </div>
         </article>
 

--- a/app/pages/faq/merchants/index.html
+++ b/app/pages/faq/merchants/index.html
@@ -457,12 +457,12 @@
             <h3 class="section-heading u-text-heading-light u-color-heading u-margin-Vm u-text-s">
               Can only UK businesses use GoCardless?
             </h3>
-            <p class="para">No. You just need to have a GBP bank account so we can pay you. You do not need to be a UK registered business or individual.</p>
+            <p class="para">Yes for the time being, unless you use GoCardless Pro.</p>
 
             <h3 class="section-heading u-text-heading-light u-color-heading u-margin-Vm u-text-s">
               When can I collect from Europe?
             </h3>
-            <p class="para">With GoCardless, any merchant registered in the U.K. or Ireland can collect from the Single Europe Payments Area. You will need to have a Euro account open in the UK or a Eurozone country. <br><br>If you take more than 500 payments a month and want to use our Pro solution, you can be registered anywhere in the world.</p>
+            <p class="para">With GoCardless, any merchant registered in the U.K. can collect from the Single European Payments Area. You will need to have a Euro account open in the UK or a Eurozone country. <br><br>If you take more than 500 payments a month and want to use our Pro solution, you can be registered anywhere in the world.</p>
 
 
             <h3 class="section-heading u-text-heading-light u-color-heading u-margin-Vm u-text-s">


### PR DESCRIPTION
The previous text mentioned that you could use GC even if you were not registered in the UK, which is only true for Pro.