### PR TITLE
adding sign up to Pro page

### DIFF
--- a/app/pages/pro/index.html
+++ b/app/pages/pro/index.html
@@ -157,7 +157,6 @@
       <hr class="u-margin-An">
     </div>
 
-
     <div class="site-container u-text-center u-padding-Vxxl">
       <div class="u-padding-Vxl">
         <div class="u-size-1of2 u-center">

--- a/app/pages/pro/index.html
+++ b/app/pages/pro/index.html
@@ -112,6 +112,26 @@
 
         </div>
 
+        <p class="u-color-p u-margin-Txxl u-padding-Tm">Want to easily try our API and dashboard? <a href="https://manage-sandbox.gocardless.com/registrations/new">Sign up for a free sandbox account</a></p>
+
+      </div>
+    </div>
+
+    <hr class="u-margin-An">
+
+    <div class="site-container u-text-center u-padding-Vxxl">
+      <div class="u-padding-Txl">
+        <div class="u-size-1of2 u-center">
+          <h2 class="u-text-heading u-color-heading u-text-light u-text-l">
+            You’re in good company
+          </h2>
+          <p class="u-text-s u-color-p u-margin-Txs">
+            Every day, some of the biggest and most respected businesses in the UK trust GoCardless to power their payments
+          </p>
+        </div>
+        <div class="u-text-center u-margin-Vl u-padding-Vs u-center">
+          <img src="/images/logos/pro-logos@2x.png">
+        </div>
       </div>
     </div>
 
@@ -137,6 +157,7 @@
       <hr class="u-margin-An">
     </div>
 
+
     <div class="site-container u-text-center u-padding-Vxxl">
       <div class="u-padding-Vxl">
         <div class="u-size-1of2 u-center">
@@ -149,24 +170,6 @@
               GoCardless Pro is the only product that enables you to collect Direct Debit payments from the UK and SEPA via one integration. With our API, your business can take payments from over 500 million people.
             </p>
           </div>
-        </div>
-      </div>
-    </div>
-
-    <hr class="u-margin-An">
-
-    <div class="site-container u-text-center u-padding-Vxxl">
-      <div class="u-padding-Txl">
-        <div class="u-size-1of2 u-center">
-          <h2 class="u-text-heading u-color-heading u-text-light u-text-l">
-            You’re in good company
-          </h2>
-          <p class="u-text-s u-color-p u-margin-Txs">
-            Every day, some of the biggest and most respected businesses in the UK trust GoCardless to power their payments
-          </p>
-        </div>
-        <div class="u-text-center u-margin-Vl u-padding-Vs u-center">
-          <img src="/images/logos/enterprise-logos@2x.jpg">
         </div>
       </div>
     </div>
@@ -291,7 +294,8 @@
         <h2 class="u-text-heading u-color-heading u-text-light u-text-l u-margin-Bm">
           Get in touch for a free quote from our team
         </h2>
-        <a href="/contact-sales?s=pro" id="track-cta-contact-sales" class="btn">{{ CTA_PRO }}</a>
+        <a href="/contact-sales?s=pro" id="track-cta-contact-sales" class="btn u-margin-Rm">{{ CTA_PRO }}</a>
+        <a href="https://manage-sandbox.gocardless.com/registrations/new" id="track-cta-contact-sales" class="btn btn--hollow">Try Pro for free</a>
       </div>
     </div>
 


### PR DESCRIPTION
Does what it says on the tin.

Sign up link now in body of pro page (not in header since we already have two CTAs that are more important). There's also a CTA at the bottom.

I've also updated the customer logos and moved them up the page since they're so good now.

![image](https://cloud.githubusercontent.com/assets/1246990/6005484/91a4744e-ab02-11e4-8f1e-74ef7874cbb7.png)

@hmarr @angusbayley 