### PR TITLE
Add schema.org structured data for internationalisation & improved Knowledge Graph

### DIFF
--- a/app/includes/_lead_capture_alternative_contact.html
+++ b/app/includes/_lead_capture_alternative_contact.html
@@ -1,7 +1,7 @@
 <div class="u-margin-Tm u-padding-Tm u-text-center">
   <p>
     <strong>Want to talk to an expert?</strong>
-    Call us on {{ SUPPORT_CONTACT_NUMBER }}
+    Call us on {{ GOCARDLESS.GB.SALES.PHONE_LOCAL }}
   </p>
   <p>
     <a href="https://help.gocardless.com/">Looking for merchant support?</a>

--- a/app/includes/_site_footer.html
+++ b/app/includes/_site_footer.html
@@ -65,8 +65,8 @@
         <p class="u-text-heading u-text-xxs u-color-invert u-margin-Bm">
           GoCardless Ltd. 338-346 Goswell Road,
           London, EC1V 7LQ,
-          020 7183 8674,
-          <a href="mailto:help@gocardless.com" class="u-link-clean u-link-invert">help@gocardless.com</a>
+          {{ CONTACT_POINTS.GB['customer service'].phone_local }},
+          <a href="mailto:{{ CONTACT_POINTS.GB['customer service'].email }}" class="u-link-clean u-link-invert">{{ CONTACT_POINTS.GB['customer service'].email }}</a>
         </p>
         <p class="u-text-heading u-text-xxs u-color-invert">
           GoCardless is a Bacs approved bureau and is regulated by the Financial Conduct Authority as an Authorised Payment Institution.

--- a/app/includes/_site_footer.html
+++ b/app/includes/_site_footer.html
@@ -62,11 +62,17 @@
     </div>
     <div class="grid__cell u-size-1of2">
       <div class="u-size-2of3 u-pull-end">
-        <p class="u-text-heading u-text-xxs u-color-invert u-margin-Bm">
-          GoCardless Ltd. 338-346 Goswell Road,
-          London, EC1V 7LQ,
-          {{ CONTACT_POINTS.GB['customer service'].phone_local }},
-          <a href="mailto:{{ CONTACT_POINTS.GB['customer service'].email }}" class="u-link-clean u-link-invert">{{ CONTACT_POINTS.GB['customer service'].email }}</a>
+        <p class="u-text-heading u-text-xxs u-color-invert u-margin-Bm" itemscope itemtype="http://schema.org/Organization">
+          <span itemprop="name">GoCardless Ltd.</span>
+          <meta itemprop="url" content="{{ GOCARDLESS.GB.HOMEPAGE }}" />
+          <span itemprop="address" itemscope itemtype="http://schema.org/PostalAddress">
+            <span itemprop="streetAddress">{{ GOCARDLESS.GB.POSTAL_ADDRESS.STREET_ADDRESS }}</span>,
+            <span itemprop="addressLocality">{{ GOCARDLESS.GB.POSTAL_ADDRESS.ADDRESS_LOCALITY }}</span>,
+            <span itemprop="postalCode">{{ GOCARDLESS.GB.POSTAL_ADDRESS.POSTAL_CODE }}</span>,
+            <span itemprop="addressCountry" content="{{ GOCARDLESS.GB.POSTAL_ADDRESS.ADDRESS_COUNTRY_ISO }}">{{ GOCARDLESS.GB.POSTAL_ADDRESS.ADDRESS_COUNTRY }}</span>
+          </span>
+          <span itemprop="telephone" content="{{ GOCARDLESS.GB.SUPPORT.PHONE_FULL }}">{{ GOCARDLESS.GB.SUPPORT.PHONE_LOCAL }}</span>,
+          <a href="mailto:{{ GOCARDLESS.GB.SUPPORT.EMAIL }}" class="u-link-clean u-link-invert" itemprop="email">{{ GOCARDLESS.GB.SUPPORT.EMAIL }}</a>
         </p>
         <p class="u-text-heading u-text-xxs u-color-invert">
           GoCardless is a Bacs approved bureau and is regulated by the Financial Conduct Authority as an Authorised Payment Institution.

--- a/app/includes/_site_footer_responsive.html
+++ b/app/includes/_site_footer_responsive.html
@@ -52,11 +52,17 @@
     </div>
   </div>
   <div class="grid u-margin-Ts u-sm-margin-Tn u-md-margin-Tn">
-    <div class="u-text-xs u-size-3of12 u-padding-Vl grid__cell u-sm-size-full u-md-size-full u-sm-text-center u-md-text-center">
-      <b>GoCardless Ltd</b><br>
-      {{ TRADING_ADDRESS }}<br>
-      {{ SUPPORT_CONTACT_NUMBER }}<br>
-      <a href="mailto:{{ SUPPORT_EMAIL }}">{{ SUPPORT_EMAIL }}</a><br>
+    <div class="u-text-xs u-size-3of12 u-padding-Vl grid__cell u-sm-size-full u-md-size-full u-sm-text-center u-md-text-center" itemscope itemtype="http://schema.org/Organization">
+      <strong itemprop="name">GoCardless Ltd</strong><br>
+      <meta itemprop="url" content="{{ GOCARDLESS.GB.HOMEPAGE }}" />
+      <span itemprop="address" itemscope itemtype="http://schema.org/PostalAddress">
+        <span itemprop="streetAddress">{{ GOCARDLESS.GB.POSTAL_ADDRESS.STREET_ADDRESS }}</span><br>
+        <span itemprop="addressLocality">{{ GOCARDLESS.GB.POSTAL_ADDRESS.ADDRESS_LOCALITY }}</span>,
+        <span itemprop="postalCode">{{ GOCARDLESS.GB.POSTAL_ADDRESS.POSTAL_CODE }}</span>
+        <span itemprop="addressCountry" content="{{ GOCARDLESS.GB.POSTAL_ADDRESS.ADDRESS_COUNTRY_ISO }}">{{ GOCARDLESS.GB.POSTAL_ADDRESS.ADDRESS_COUNTRY }}</span>
+      </span><br>
+      <span itemprop="telephone" content="{{ GOCARDLESS.GB.SUPPORT.PHONE_FULL }}">{{ GOCARDLESS.GB.SUPPORT.PHONE_LOCAL }}</span><br>
+      <a href="mailto:{{ GOCARDLESS.GB.SUPPORT.EMAIL }}" class="u-link-clean u-link-invert" itemprop="email">{{ GOCARDLESS.GB.SUPPORT.EMAIL }}</a><br>
     </div>
 
     <div class="u-size-3of12 grid__cell u-text-xs u-padding-Vl u-sm-padding-Vn u-md-padding-Vn u-sm-size-full u-md-size-full u-sm-text-center u-md-text-center">

--- a/app/includes/fr/_site_footer.html
+++ b/app/includes/fr/_site_footer.html
@@ -29,24 +29,30 @@
     </div>
     <div class="grid__cell u-size-1of2">
       <div class="u-pull-end">
-        <div class="u-text-heading u-text-xxs u-color-invert u-margin-Bm">
-          GoCardless Ltd. 338-346 Goswell Road,
-          Londres, EC1V 7LQ <br>
-          FR: {{ CONTACT_POINTS.FR.sales.phone_full }},
-          <a href="mailto:{{ CONTACT_POINTS.FR.sales.email }}" class="u-link-clean u-link-invert u-text-heavy">
-            {{ CONTACT_POINTS.FR.sales.email }}
-          </a><br>
-          BE: {{ CONTACT_POINTS.BE.sales.phone_full }},
-          <a href="mailto:{{ CONTACT_POINTS.BE.sales.email }}" class="u-link-clean u-link-invert u-text-heavy">
-            {{ CONTACT_POINTS.BE.sales.email }}
-          </a>
-        </div>
-        <div class="u-text-heading u-text-xxs u-color-invert">
+        <p class="u-text-heading u-text-xxs u-color-invert u-margin-Bm" itemscope itemtype="http://schema.org/Organization">
+          <span itemprop="name">GoCardless Ltd.</span>
+          <meta itemprop="url" content="{{ GOCARDLESS.FR.HOMEPAGE }}" />
+          <span itemprop="address" itemscope itemtype="http://schema.org/PostalAddress">
+            <span itemprop="streetAddress">{{ GOCARDLESS.FR.POSTAL_ADDRESS.STREET_ADDRESS }}</span>,
+            <span itemprop="addressLocality">{{ GOCARDLESS.FR.POSTAL_ADDRESS.ADDRESS_LOCALITY }}</span>,
+            <span itemprop="postalCode">{{ GOCARDLESS.FR.POSTAL_ADDRESS.POSTAL_CODE }}</span>.
+            <span itemprop="addressCountry" content="{{ GOCARDLESS.FR.POSTAL_ADDRESS.ADDRESS_COUNTRY_ISO }}">{{ GOCARDLESS.FR.POSTAL_ADDRESS.ADDRESS_COUNTRY }}</span>
+          </span>
+          <br>
+          FR: <span itemprop="telephone" content="{{ GOCARDLESS.FR.SALES.PHONE_FULL }}">{{ GOCARDLESS.FR.SALES.PHONE_FULL }}</span>,
+          <a href="mailto:{{ GOCARDLESS.FR.SALES.EMAIL }}" class="u-link-clean u-link-invert" itemprop="email">{{ GOCARDLESS.FR.SALES.EMAIL }}</a>
+          <br>
+          BE: <span itemprop="telephone" content="{{ GOCARDLESS.BE.SALES.PHONE_FULL }}">{{ GOCARDLESS.BE.SALES.PHONE_FULL }}</span>,
+          <a href="mailto:{{ GOCARDLESS.BE.SALES.EMAIL }}" class="u-link-clean u-link-invert" itemprop="email">{{ GOCARDLESS.BE.SALES.EMAIL }}</a>
+        </p>
+        
+        <p class="u-text-heading u-text-xxs u-color-invert u-margin-Bm">
           GoCardless est un Etablissement de Paiement Agréé, régulé par l’autorité britannique FCA (Financial Conduct Authority) et habilité à collecter des paiements à travers l’Union Européenne.
-        </div>
-        <div class="u-text-heading u-text-xxs u-color-invert">
+        </p>
+        
+        <p class="u-text-heading u-text-xxs u-color-invert">
           En continuant votre visite sur notre site vous acceptez nos cookies. <a href="/fr/legal/politique-de-confidentialite?l=2#cookies" class="u-link-clean u-link-invert u-text-heavy">Apprenez-en plus</a>.
-        </div>
+        </p>
       </div>
     </div>
   </div>

--- a/app/includes/fr/_site_footer.html
+++ b/app/includes/fr/_site_footer.html
@@ -32,9 +32,13 @@
         <div class="u-text-heading u-text-xxs u-color-invert u-margin-Bm">
           GoCardless Ltd. 338-346 Goswell Road,
           Londres, EC1V 7LQ <br>
-          +33 (0) 9 75 18 42 95,
-          <a href="mailto:france@gocardless.com" class="u-link-clean u-link-invert u-text-heavy">
-            france@gocardless.com
+          FR: {{ CONTACT_POINTS.FR.sales.phone_full }},
+          <a href="mailto:{{ CONTACT_POINTS.FR.sales.email }}" class="u-link-clean u-link-invert u-text-heavy">
+            {{ CONTACT_POINTS.FR.sales.email }}
+          </a><br>
+          BE: {{ CONTACT_POINTS.BE.sales.phone_full }},
+          <a href="mailto:{{ CONTACT_POINTS.BE.sales.email }}" class="u-link-clean u-link-invert u-text-heavy">
+            {{ CONTACT_POINTS.BE.sales.email }}
           </a>
         </div>
         <div class="u-text-heading u-text-xxs u-color-invert">

--- a/app/pages/contact-sales/index.html
+++ b/app/pages/contact-sales/index.html
@@ -68,4 +68,7 @@ other_languages:
 
 </div>
 
+{# Please don't delete this... it contains machine-readable schema.org organizational data #}
+<script type="application/ld+json">{{ SCHEMA_ORGANIZATION }}</script>
+
 {% endblock %}

--- a/app/pages/faq/customers/index.html
+++ b/app/pages/faq/customers/index.html
@@ -55,7 +55,7 @@
             </a></li>
           </ul>
           <hr class="u-size-11of12">
-          <p class="para u-padding-Txs">Got a question? Call our support team on {{ SUPPORT_CONTACT_NUMBER }}</p>
+          <p class="para u-padding-Txs">Got a question? Call our support team on {{ GOCARDLESS.GB.SUPPORT.PHONE_LOCAL }}</p>
         </div>
       </div>
 
@@ -69,7 +69,7 @@
             </h3>
             <p class="para">GoCardless is an online payments company - we provide online payment services to thousands of Merchants. Our name appears on the bank statements of anyone who pays a Merchant using our service.</p>
             <p class="para">If you do not recognise the transaction there is normally a reference including the name of the Merchant on your bank statement or in the Direct Debit record.</p>
-            <p class="para">If you cannot find this or do not recognise the name email us at <a href="mailto:{{ SUPPORT_EMAIL }}" class="u-link-color-p u-text-underline">{{ SUPPORT_EMAIL }}</a> or call us on {{ SUPPORT_CONTACT_NUMBER }} and we will help you identify the transaction.</p>
+            <p class="para">If you cannot find this or do not recognise the name email us at <a href="mailto:{{ GOCARDLESS.GB.SUPPORT.EMAIL }}" class="u-link-color-p u-text-underline">{{ GOCARDLESS.GB.SUPPORT.EMAIL }}</a> or call us on {{ GOCARDLESS.GB.SUPPORT.PHONE_LOCAL }} and we will help you identify the transaction.</p>
 
             <h3 class="section-heading u-text-heading-light u-color-heading u-margin-Vm u-text-s">
               How do payments through GoCardless work?
@@ -87,7 +87,7 @@
               How do I check transactions made with GoCardless?
             </h3>
             <p class="para">You can check your GoCardless payments anytime by <a href="/users/sign_in" class="u-link-color-p u-text-underline">logging in</a>.</p>
-            <p class="para">For further assistance you can also email us at <a href="mailto:{{ SUPPORT_EMAIL }}" class="u-link-color-p u-text-underline">{{ SUPPORT_EMAIL }}</a> or call on {{ SUPPORT_CONTACT_NUMBER }}.</p>
+            <p class="para">For further assistance you can also email us at <a href="mailto:{{ GOCARDLESS.GB.SUPPORT.EMAIL }}" class="u-link-color-p u-text-underline">{{ GOCARDLESS.GB.SUPPORT.EMAIL }}</a> or call on {{ GOCARDLESS.GB.SUPPORT.PHONE_LOCAL }}.</p>
           </div>
         </article>
 
@@ -108,7 +108,7 @@
             <h3 class="section-heading u-text-heading-light u-color-heading u-margin-Vm u-text-s">
               What do I do if I believe a payment has been taken from my account in error or fraudulently?
             </h3>
-            <p class="para">Let us know immediately by emailing <a href="mailto:{{ SUPPORT_EMAIL }}" class="u-link-color-p u-text-underline">{{ SUPPORT_EMAIL }}</a> or calling {{ SUPPORT_CONTACT_NUMBER }}.</p>
+            <p class="para">Let us know immediately by emailing <a href="mailto:{{ GOCARDLESS.GB.SUPPORT.EMAIL }}" class="u-link-color-p u-text-underline">{{ GOCARDLESS.GB.SUPPORT.EMAIL }}</a> or calling {{ GOCARDLESS.GB.SUPPORT.PHONE_LOCAL }}.</p>
             <p class="para">We can investigate the matter further and arrange for a full refund under the <a href="https://gocardless.com/direct-debit/guarantee/" class="u-link-color-p u-text-underline">Direct Debit Guarantee</a>.</p>
           </div>
         </article>
@@ -126,13 +126,13 @@
             <h3 class="section-heading u-text-heading-light u-color-heading u-margin-Vm u-text-s">
               What do I do if I believe I have been a victim of fraud?
             </h3>
-            <p class="para">Let us know immediately by emailing <a href="mailto:{{ SUPPORT_EMAIL }}" class="u-link-color-p u-text-underline">{{ SUPPORT_EMAIL }}</a> or calling {{ SUPPORT_CONTACT_NUMBER }}.</p>
+            <p class="para">Let us know immediately by emailing <a href="mailto:{{ GOCARDLESS.GB.SUPPORT.EMAIL }}" class="u-link-color-p u-text-underline">{{ GOCARDLESS.GB.SUPPORT.EMAIL }}</a> or calling {{ GOCARDLESS.GB.SUPPORT.PHONE_LOCAL }}.</p>
             <p class="para">We can investigate the matter further and arrange for a full refund under the <a href="https://gocardless.com/direct-debit/guarantee/" class="u-link-color-p u-text-underline">Direct Debit Guarantee</a>.</p>
 
             <h3 class="section-heading u-text-heading-light u-color-heading u-margin-Vm u-text-s">
               How can I cancel my Direct Debit?
             </h3>
-            <p class="para">Email us at <a href="mailto:{{ SUPPORT_EMAIL }}" class="u-link-color-p u-text-underline">{{ SUPPORT_EMAIL }}</a> or call on {{ SUPPORT_CONTACT_NUMBER }} and we can cancel your Direct Debit immediately.</p>
+            <p class="para">Email us at <a href="mailto:{{ GOCARDLESS.GB.SUPPORT.EMAIL }}" class="u-link-color-p u-text-underline">{{ GOCARDLESS.GB.SUPPORT.EMAIL }}</a> or call on {{ GOCARDLESS.GB.SUPPORT.PHONE_LOCAL }} and we can cancel your Direct Debit immediately.</p>
             <p class="para">You can also cancel your Direct Debit directly with your bank or building society.</p>
           </div>
         </article>

--- a/app/pages/faq/merchants/index.html
+++ b/app/pages/faq/merchants/index.html
@@ -97,7 +97,7 @@ other_languages:
             </a></li>
           </ul>
           <hr class="u-size-11of12">
-          <p class="para u-padding-Txs">Got a question? Call our support team on {{ SUPPORT_CONTACT_NUMBER }}</p>
+          <p class="para u-padding-Txs">Got a question? Call our support team on {{ GOCARDLESS.GB.SUPPORT.PHONE_LOCAL }}</p>
         </div>
       </div>
 
@@ -557,7 +557,7 @@ other_languages:
             <h3 class="section-heading u-text-heading-light u-color-heading u-margin-Vm u-text-s">
               Where can I get technical support?
             </h3>
-            <p class="para">You can email us at {{ SUPPORT_EMAIL }}. We also have a live chat room which can be found in <a href="http://webchat.freenode.net/?channels=gocardless&uio=OT10cnVlJjExPTIzNiYxMj10cnVl51" target="_blank" class="u-link-color-p u-text-underline">#gocardless on irc.freenode.net</a>. Our developers are on hand 9am-6pm, Mon-Fri to help with your technical queries.</p>
+            <p class="para">You can email us at {{ GOCARDLESS.GB.SUPPORT.EMAIL }}. We also have a live chat room which can be found in <a href="http://webchat.freenode.net/?channels=gocardless&uio=OT10cnVlJjExPTIzNiYxMj10cnVl51" target="_blank" class="u-link-color-p u-text-underline">#gocardless on irc.freenode.net</a>. Our developers are on hand 9am-6pm, Mon-Fri to help with your technical queries.</p>
             <p class="para">A number of detailed product guides are also available in our <a href="https://help.gocardless.com/" class="u-link-color-p u-text-underline">Help Centre</a>.</p>
           </div>
         </article>
@@ -762,7 +762,7 @@ other_languages:
             <h3 class="section-heading u-text-heading-light u-color-heading u-margin-Vm u-text-s">
               How can I become a partner?
             </h3>
-            <p class="para">Just email us at <a href="mailto:{{ SUPPORT_EMAIL }}" class="u-link-color-p u-text-underline">{{ SUPPORT_EMAIL }}</a> with a short description of your application, and we'll get right back to you.</p>
+            <p class="para">Just email us at <a href="mailto:{{ GOCARDLESS.GB.SUPPORT.EMAIL }}" class="u-link-color-p u-text-underline">{{ GOCARDLESS.GB.SUPPORT.EMAIL }}</a> with a short description of your application, and we'll get right back to you.</p>
 
             <h3 class="section-heading u-text-heading-light u-color-heading u-margin-Vm u-text-s">
               How does it work for my users?

--- a/app/pages/fr/contactez-nous/index.html
+++ b/app/pages/fr/contactez-nous/index.html
@@ -57,7 +57,7 @@ other_languages:
           Contactez nous
         </button>
         <hr>
-        <p class="u-text-center u-color-meta u-margin-Bs"><b>Vous souhaitez parler à un expert tout de suite ?</b><br>Appelez le {{ CONTACT_POINTS.FR.sales.phone_full }} (FR)<br>{{ CONTACT_POINTS.BE.sales.phone_full }} (BE)</p>
+        <p class="u-text-center u-color-meta u-margin-Bs"><b>Vous souhaitez parler à un expert tout de suite ?</b><br>Appelez le {{ GOCARDLESS.FR.SALES.PHONE_FULL }} (FR)<br>{{ GOCARDLESS.BE.SALES.PHONE_FULL }} (BE)</p>
         <hr>
         <p class="u-text-center u-color-meta u-margin-Bs"><b>Vos données sont sécurisées et ne seront jamais vendues ou partagées.</b></p>
       </form>

--- a/app/pages/fr/contactez-nous/index.html
+++ b/app/pages/fr/contactez-nous/index.html
@@ -57,7 +57,7 @@ other_languages:
           Contactez nous
         </button>
         <hr>
-        <p class="u-text-center u-color-meta u-margin-Bs"><b>Vous souhaitez parler à un expert tout de suite ?</b><br>Appelez le +33 (0) 9 75 18 42 95 (FR)<br>+32 78 48 09 94 (BE)</p>
+        <p class="u-text-center u-color-meta u-margin-Bs"><b>Vous souhaitez parler à un expert tout de suite ?</b><br>Appelez le {{ CONTACT_POINTS.FR.sales.phone_full }} (FR)<br>{{ CONTACT_POINTS.BE.sales.phone_full }} (BE)</p>
         <hr>
         <p class="u-text-center u-color-meta u-margin-Bs"><b>Vos données sont sécurisées et ne seront jamais vendues ou partagées.</b></p>
       </form>
@@ -67,5 +67,8 @@ other_languages:
   {% include "fr/_site_footer.html" %}
 
 </div>
+
+{# Please don't delete this... it contains machine-readable schema.org organizational data #}
+<script type="application/ld+json">{{ SCHEMA_ORGANIZATION }}</script>
 
 {% endblock %}

--- a/app/pages/fr/legal/politique-de-confidentialite/index.html
+++ b/app/pages/fr/legal/politique-de-confidentialite/index.html
@@ -90,7 +90,7 @@ other_languages:
             Les appels téléphoniques peuvent être enregistrés pour des raisons de sécurité et réglementaires, et peuvent être évalués dans le cadre de nos procédures de contrôle qualité.
           </li>
           <li>
-            Si vous nous envoyez votre CV, il est possible que nous conservions vos données pour des opportunités professionnelles ultérieures. Si vous souhaitez vous y opposer, veuillez nous en informer en adressant un email à <a href="mailto:{{ SUPPORT_EMAIL }}" class="u-link-color-p u-text-underline">{{ SUPPORT_EMAIL }}</a> et nous supprimerons vos données au plus vite.
+            Si vous nous envoyez votre CV, il est possible que nous conservions vos données pour des opportunités professionnelles ultérieures. Si vous souhaitez vous y opposer, veuillez nous en informer en adressant un email à <a href="mailto:{{ GOCARDLESS.GB.SUPPORT.EMAIL }}" class="u-link-color-p u-text-underline">{{ GOCARDLESS.GB.SUPPORT.EMAIL }}</a> et nous supprimerons vos données au plus vite.
           </li>
         </ul>
         <p class="para">
@@ -202,7 +202,7 @@ other_languages:
           8.  Vos droits
         </h3>
         <p class="para">
-          En application de la loi 78-17 du 6 janvier 1978 relative à l'informatique, aux fichiers et aux libertés, les internautes disposent d’un droit d’accès, de rectification, de modification et de suppression concernant les données qui les concernent personnellement. Ce droit peut être exercé par voie postale auprès de GoCardless Ltd, 338-346 Goswell Road, EC1V 7LQ Londres, Grande Bretagne ou par voie électronique à l’adresse email suivante : <a href="mailto:{{ SUPPORT_EMAIL }}" class="u-link-color-p u-text-underline">{{ SUPPORT_EMAIL }}</a>.
+          En application de la loi 78-17 du 6 janvier 1978 relative à l'informatique, aux fichiers et aux libertés, les internautes disposent d’un droit d’accès, de rectification, de modification et de suppression concernant les données qui les concernent personnellement. Ce droit peut être exercé par voie postale auprès de GoCardless Ltd, 338-346 Goswell Road, EC1V 7LQ Londres, Grande Bretagne ou par voie électronique à l’adresse email suivante : <a href="mailto:{{ GOCARDLESS.GB.SUPPORT.EMAIL }}" class="u-link-color-p u-text-underline">{{ GOCARDLESS.GB.SUPPORT.EMAIL }}</a>.
         </p>
         <p class="para">
           Vous pouvez nous demander de ne pas traiter vos données personnelles à des fins de marketing à tout moment par e-mail. (En pratique, vous aurez généralement soit accepté expressément à l'avance l'utilisation de vos données personnelles à des fins de marketing, soit nous vous donnerons l'opportunité de décider que vos données personnelles ne fassent plus l’objet d’une utilisation à des fins de marketing.) 
@@ -219,7 +219,7 @@ other_languages:
           10. Contact 
         </h3>
         <p class="para">
-          Si vous avez des questions au sujet de cette politique de confidentialité ou de traitement de vos données personnelles, nous vous prions de nous écrire par e-mail en utilisant l’adresse suivante : <a href="mailto:{{ SUPPORT_EMAIL }}" class="u-link-color-p u-text-underline">{{ SUPPORT_EMAIL }}</a>.
+          Si vous avez des questions au sujet de cette politique de confidentialité ou de traitement de vos données personnelles, nous vous prions de nous écrire par e-mail en utilisant l’adresse suivante : <a href="mailto:{{ GOCARDLESS.GB.SUPPORT.EMAIL }}" class="u-link-color-p u-text-underline">{{ GOCARDLESS.GB.SUPPORT.EMAIL }}</a>.
         </p>
 
         <h3 class="u-text-heading-light u-color-heading u-margin-Vm u-text-s">

--- a/app/pages/legal/_sidebar.html
+++ b/app/pages/legal/_sidebar.html
@@ -26,6 +26,6 @@
       </li>
     </ul>
     <hr class="u-size-11of12">
-    <p class="para u-padding-Txs">Got a question? Call our support team on {{ SUPPORT_CONTACT_NUMBER }}</p>
+    <p class="para u-padding-Txs">Got a question? Call our support team on {{ GOCARDLESS.GB.SUPPORT.PHONE_LOCAL }}</p>
   </div>
 </div>

--- a/app/pages/legal/index.html
+++ b/app/pages/legal/index.html
@@ -36,8 +36,8 @@ other_languages:
           </p>
           <p class="para">
             If you have any questions about our terms of service, then please get in
-            touch by emailing <a href="mailto:{{ SUPPORT_EMAIL }}" class="u-link-color-p u-text-underline">{{ SUPPORT_EMAIL }}</a> or calling
-            {{ SUPPORT_CONTACT_NUMBER }}.
+            touch by emailing <a href="mailto:{{ GOCARDLESS.GB.SUPPORT.EMAIL }}" class="u-link-color-p u-text-underline">{{ GOCARDLESS.GB.SUPPORT.EMAIL }}</a> or calling
+            {{ GOCARDLESS.GB.SUPPORT.PHONE_LOCAL }}.
 
             {# FCA requirement. Do not remove. #}
             Customers can also find more details about our transaction structure

--- a/app/pages/legal/merchants/index.html
+++ b/app/pages/legal/merchants/index.html
@@ -146,7 +146,7 @@
           Cancelling payment transactions
         </h3>
         <p class="para">
-          If for any reason you would like to cancel a payment from GoCardless account to you, you can do so at any time until the end of the business day before the day agreed to make the payment.  You can cancel by notifying us by email to <a href="mailto:{{ SUPPORT_EMAIL }}" class="u-link-color-p u-text-underline">{{ SUPPORT_EMAIL }}</a> or by phone using the contact details provided on the GoCardless website.
+          If for any reason you would like to cancel a payment from GoCardless account to you, you can do so at any time until the end of the business day before the day agreed to make the payment.  You can cancel by notifying us by email to <a href="mailto:{{ GOCARDLESS.GB.SUPPORT.EMAIL }}" class="u-link-color-p u-text-underline">{{ GOCARDLESS.GB.SUPPORT.EMAIL }}</a> or by phone using the contact details provided on the GoCardless website.
         </p>
 
         <h3 class="u-text-heading-light u-color-heading u-margin-Vm u-text-s">
@@ -191,7 +191,7 @@
           Unauthorised payment transactions
         </h3>
         <p class="para">
-          Upon becoming aware of any unauthorised or incorrectly executed payment transaction involving funds connected with your use of GoCardless (including any fraudulent payments/attempted payments out of those funds to you or others), you must notify us by email to <a href="mailto:{{ SUPPORT_EMAIL }}" class="u-link-color-p u-text-underline">{{ SUPPORT_EMAIL }}</a> or by phone using the contact details provided on the GoCardless website.
+          Upon becoming aware of any unauthorised or incorrectly executed payment transaction involving funds connected with your use of GoCardless (including any fraudulent payments/attempted payments out of those funds to you or others), you must notify us by email to <a href="mailto:{{ GOCARDLESS.GB.SUPPORT.EMAIL }}" class="u-link-color-p u-text-underline">{{ GOCARDLESS.GB.SUPPORT.EMAIL }}</a> or by phone using the contact details provided on the GoCardless website.
         </p>
         <p class="para">
           In relation to unauthorised payment transactions, you must contact us as set out above without undue delay and in any event no later than 13 months after the date of the relevant payment transaction from your account. Following any investigations that we may undertake, where you have notified us in the above circumstances we will immediately arrange for the refund of the amount of the unauthorised payment transaction to you and any related interest and charges. We will not be liable to make or arrange any further payments to you.
@@ -226,7 +226,7 @@
           Suspected Fraud/Illegal Activity by your Customers
         </h3>
         <p class="para">
-          Occasionally, even the most cautious suppliers can become aware of acts by customers which may appear to be fraudulent, or connected with some other type of illegal activity, such as money laundering or terrorist financing. We ask that you notify us of any such suspicions or concerns that these types of issues may affect any payments to you by email to <a href="mailto:{{ SUPPORT_EMAIL }}" class="u-link-color-p u-text-underline">{{ SUPPORT_EMAIL }}</a> or by phone using the contact details provided on the GoCardless website.
+          Occasionally, even the most cautious suppliers can become aware of acts by customers which may appear to be fraudulent, or connected with some other type of illegal activity, such as money laundering or terrorist financing. We ask that you notify us of any such suspicions or concerns that these types of issues may affect any payments to you by email to <a href="mailto:{{ GOCARDLESS.GB.SUPPORT.EMAIL }}" class="u-link-color-p u-text-underline">{{ GOCARDLESS.GB.SUPPORT.EMAIL }}</a> or by phone using the contact details provided on the GoCardless website.
         </p>
 
 
@@ -467,7 +467,7 @@
           Contact
         </h3>
         <p class="para">
-          If you have any queries or wish to discuss our services, please contact us in writing or by telephone as set out on the GoCardless website or by email at <a href="mailto:{{ SUPPORT_EMAIL }}" class="u-link-color-p u-text-underline">{{ SUPPORT_EMAIL }}</a>.
+          If you have any queries or wish to discuss our services, please contact us in writing or by telephone as set out on the GoCardless website or by email at <a href="mailto:{{ GOCARDLESS.GB.SUPPORT.EMAIL }}" class="u-link-color-p u-text-underline">{{ GOCARDLESS.GB.SUPPORT.EMAIL }}</a>.
         </p>
         <p class="para">
           We will contact you using the contact details you provided when you signed up to this service, or any updated details you have provided to us. It is your responsibility to update us with any new contact information, including any change in address. We will send any correspondence to the most recent email address or postal address that you have provided to us for your account and, therefore, you must advise us promptly of any change of your contact details in the interests of security (including name or address) and provide appropriate supporting evidence as required by us.

--- a/app/pages/legal/partners/index.html
+++ b/app/pages/legal/partners/index.html
@@ -107,7 +107,7 @@
           Suspected Fraud/Illegal Activity by Merchants using your services or their customers
         </h3>
         <p class="para">
-          Occasionally, even the most cautious partners can become aware of acts by their customers which may appear to be fraudulent, or connected with some other type of illegal activity, such as money laundering or terrorist financing. We ask that you notify us of any such suspicions or concerns that these types of issues may affect any payments made through your system by email to <a href="mailto:{{ SUPPORT_EMAIL }}" class="u-link-color-p u-text-underline">{{ SUPPORT_EMAIL }}</a> or by phone using the contact details provided on the GoCardless website.
+          Occasionally, even the most cautious partners can become aware of acts by their customers which may appear to be fraudulent, or connected with some other type of illegal activity, such as money laundering or terrorist financing. We ask that you notify us of any such suspicions or concerns that these types of issues may affect any payments made through your system by email to <a href="mailto:{{ GOCARDLESS.GB.SUPPORT.EMAIL }}" class="u-link-color-p u-text-underline">{{ GOCARDLESS.GB.SUPPORT.EMAIL }}</a> or by phone using the contact details provided on the GoCardless website.
         </p>
         <p class="para">
           You must use your best efforts to assist us in identifying any suspicious or potentially fraudulent use of GoCardless, including making information relating to merchants using your services available to us. To do this, you must retain records and make them available to us relating to each merchant using your services for a minimum of 1 month after they cease using your services.

--- a/app/pages/legal/privacy/index.html
+++ b/app/pages/legal/privacy/index.html
@@ -95,7 +95,7 @@ other_languages:
           Where you are applying to use the GoCardless system, we may also contact credit or identity reference agencies with information you provide to enable us to confirm your identity.
         </p>
         <p class="para">
-          If you send us your CV we may want to keep your details on file in case an opportunity comes up in the future. If you’d rather we didn’t do this, please let us know as soon as possible by emailing <a href="mailto:{{ SUPPORT_EMAIL }}" class="u-link-color-p u-text-underline">{{ SUPPORT_EMAIL }}</a> and we will delete your record as soon as we are able.
+          If you send us your CV we may want to keep your details on file in case an opportunity comes up in the future. If you’d rather we didn’t do this, please let us know as soon as possible by emailing <a href="mailto:{{ GOCARDLESS.GB.SUPPORT.EMAIL }}" class="u-link-color-p u-text-underline">{{ GOCARDLESS.GB.SUPPORT.EMAIL }}</a> and we will delete your record as soon as we are able.
         </p>
         <p class="para">
           The only time we will use your details for any other purpose than those listed above is to provide you with details from time to time about our services. However we will only do this if either (i) you have given us permission to do so, or (ii) you are one of our customers and we are telling you about similar products and services to the ones you have previously purchased or asked us about. In each case you can contact us to opt out of any further marketing communications.
@@ -108,7 +108,7 @@ other_languages:
           Information collection and use
         </h3>
         <p class="para">
-          You have the right to request a copy of the personal information we hold about you, its origin and any recipients of it as well as the purpose of any data processing carried out. Please note that, in accordance with the Data Protection Act 1998, a £10 admin fee is applicable. For further information, please contact us by emailing <a href="mailto:{{ SUPPORT_EMAIL }}" class="u-link-color-p u-text-underline">{{ SUPPORT_EMAIL }}</a> with the subject "Data subject access request".
+          You have the right to request a copy of the personal information we hold about you, its origin and any recipients of it as well as the purpose of any data processing carried out. Please note that, in accordance with the Data Protection Act 1998, a £10 admin fee is applicable. For further information, please contact us by emailing <a href="mailto:{{ GOCARDLESS.GB.SUPPORT.EMAIL }}" class="u-link-color-p u-text-underline">{{ GOCARDLESS.GB.SUPPORT.EMAIL }}</a> with the subject "Data subject access request".
         </p>
         <p class="para">
           In accordance with the Data Protection Act 1998, you have the right to correct, restrict our use of or ask us to delete your personal information. Use the details on the "Contact Us" to ask any questions or request the correction, restriction or deletion of your personal information.

--- a/app/templates/plain.html
+++ b/app/templates/plain.html
@@ -7,10 +7,10 @@
     <title>{% block title %}{% endblock %} - GoCardless</title>
     {% block meta_tags %}{% endblock %}
     <meta name="viewport" content="width=device-width">
-    <meta name="og:image" content="https://gocardless.com/images/logos/gocardless-square.png">
-    <meta name="og:image:secure_url" content="https://gocardless.com/images/logos/gocardless-square.png">
+    <meta name="og:image" content="{{ LOGO }}">
+    <meta name="og:image:secure_url" content="{{ LOGO }}">
     <meta name="google-site-verification" content="Y80kah87ghJhwiDqw-5ap234p9wCcGt6kMRxvnamtHU">
-    <link href="https://plus.google.com/+Gocardless" rel="publisher">
+    <link href="{{ SOCIAL_LINKS.google }}" rel="publisher">
     {%- macro hreflang_tag(language_code, path) -%}
       <link rel="alternate" href="https://gocardless.com{{path}}" hreflang="{{language_code}}" />
       {% if language_code == "en" -%}

--- a/app/templates/plain.html
+++ b/app/templates/plain.html
@@ -10,7 +10,7 @@
     <meta name="og:image" content="{{ LOGO }}">
     <meta name="og:image:secure_url" content="{{ LOGO }}">
     <meta name="google-site-verification" content="Y80kah87ghJhwiDqw-5ap234p9wCcGt6kMRxvnamtHU">
-    <link href="{{ SOCIAL_LINKS.google }}" rel="publisher">
+    <link href="{{ SOCIAL_LINKS.GOOGLE }}" rel="publisher">
     {%- macro hreflang_tag(language_code, path) -%}
       <link rel="alternate" href="https://gocardless.com{{path}}" hreflang="{{language_code}}" />
       {% if language_code == "en" -%}

--- a/conf/metadata.js
+++ b/conf/metadata.js
@@ -14,10 +14,91 @@ var metadata = {
   TRADING_ADDRESS: '338-346 Goswell Road<br>London, EC1V 7LQ',
   SUPPORT_CONTACT_NUMBER: '020 7183 8674',
   SUPPORT_EMAIL: 'help@gocardless.com',
-  GITHUB_LINK: 'http://github.com/gocardless',
-  TWITTER_LINK: 'https://twitter.com/gocardless',
   CTA_BASIC: 'Start taking payments',
-  CTA_PRO: 'Contact sales'
+  CTA_PRO: 'Contact sales',
+
+  LOGO: 'https://gocardless.com/images/logos/gocardless-square.png',
+  SOCIAL_LINKS: {
+    facebook: 'https://www.facebook.com/GoCardless',
+    twitter: 'https://twitter.com/gocardless',
+    google: 'https://plus.google.com/+Gocardless',
+    linkedin: 'https://www.linkedin.com/company/gocardless',
+    github: 'http://github.com/gocardless'
+  },
+  CONTACT_POINTS: {
+    // Country Code (e.g. GB, FR, BE)
+    //   To comply with schema.org requirements, the country code should use ISO-3166-2
+    //   See http://en.wikipedia.org/wiki/ISO_3166-2 for a list of valid country codes
+    // Contact type (e.g. customer service, sales)
+    //   See https://developers.google.com/structured-data/customize/contact-points
+    'GB': {
+      'customer service': {
+        'phone_full': '+44 20 7183 8674',
+        'phone_local': '020 7183 8674',
+        'email': 'help@gocardless.com'
+      },
+      'sales': {
+        'phone_full': '+44 20 7183 8674',
+        'phone_local': '020 7183 8674',
+        'email': 'help@gocardless.com'
+      }
+    },
+    'FR': {
+      'sales': {
+        'phone_full': '+33 9 75 18 42 95',
+        'phone_local': '09 75 18 42 95',
+        'email': 'france@gocardless.com'
+      }
+    },
+    'BE': {
+      'sales': {
+        'phone_full': '+32 78 48 09 94',
+        'phone_local': '078 48 09 94',
+        'email': 'belgium@gocardless.com'
+      }
+    }
+  }
 };
+
+// Documentation from Google:
+//   https://developers.google.com/structured-data/customize/overview
+// Google's tool for validating the output:
+//   https://developers.google.com/structured-data/testing-tool/
+// Original Schema:
+//   http://schema.org/Organization
+function buildSchemaDotOrgOrganization(metadata) {
+  var organization = {
+    "@context": "http://schema.org",
+    "@type": "Organization",
+    "url": "https://gocardless.com/",
+    "logo": metadata.LOGO,
+    "sameAs" : [],
+    "contactPoint" : [],
+  }
+  
+  for (var network in metadata.SOCIAL_LINKS) {
+    organization.sameAs.push(metadata.SOCIAL_LINKS[network]);
+  }
+  
+  for (var country_code in metadata.CONTACT_POINTS) {
+    for (var contact_type in metadata.CONTACT_POINTS[country_code]) {
+      var contactInfo = metadata.CONTACT_POINTS[country_code][contact_type];
+      if (contactInfo.hasOwnProperty('full')) {
+        organization.contactPoint.push(
+          {
+            "@type" : "ContactPoint",
+            "telephone" : contactInfo.full,
+            "contactType" : contact_type,
+            "areaServed" : country_code
+          }
+        );
+      }
+    }
+  }
+  
+  return organization;
+}
+
+metadata.SCHEMA_ORGANIZATION = JSON.stringify(buildSchemaDotOrgOrganization(metadata));
 
 module.exports = metadata;

--- a/conf/metadata.js
+++ b/conf/metadata.js
@@ -87,12 +87,12 @@ var metadata = {
 //   http://schema.org/Organization
 function buildSchemaDotOrgOrganization(metadata) {
   var organization = {
-    "@context": "http://schema.org",
-    "@type": "Organization",
-    "url": "https://gocardless.com/",
-    "logo": metadata.LOGO,
-    "sameAs" : [],
-    "contactPoint" : [],
+    '@context': 'http://schema.org',
+    '@type': 'Organization',
+    'url': 'https://gocardless.com/',
+    'logo': metadata.LOGO,
+    'sameAs' : [],
+    'contactPoint' : [],
   }
   
   // Add social network links to sameAs
@@ -102,28 +102,28 @@ function buildSchemaDotOrgOrganization(metadata) {
   
   // Add contact details for office in each country
   // See https://support.google.com/webmasters/answer/4620709?hl=en for supported contactType
-  for (var country_code in metadata.GOCARDLESS) {
+  for (var countryCode in metadata.GOCARDLESS) {
     // Sales number (contactType = sales)
-    if (metadata.GOCARDLESS[country_code].SALES) {
+    if ('SALES' in metadata.GOCARDLESS[countryCode]) {
       organization.contactPoint.push(
         {
-          "@type" : "ContactPoint",
-          "telephone" : metadata.GOCARDLESS[country_code].SALES.PHONE_FULL,
-          "email" : metadata.GOCARDLESS[country_code].SALES.EMAIL,
-          "contactType" : "sales",
-          "areaServed" : country_code
+          '@type' : 'ContactPoint',
+          'telephone' : metadata.GOCARDLESS[countryCode].SALES.PHONE_FULL,
+          'email' : metadata.GOCARDLESS[countryCode].SALES.EMAIL,
+          'contactType' : 'sales',
+          'areaServed' : countryCode
         }
       );
     }
     // Customer support number (contactType = customer support)
-    if (metadata.GOCARDLESS[country_code].SUPPORT) {
+    if ('SUPPORT' in metadata.GOCARDLESS[countryCode]) {
       organization.contactPoint.push(
         {
-          "@type" : "ContactPoint",
-          "telephone" : metadata.GOCARDLESS[country_code].SUPPORT.PHONE_FULL,
-          "email" : metadata.GOCARDLESS[country_code].SUPPORT.EMAIL,
-          "contactType" : "customer support",
-          "areaServed" : country_code
+          '@type' : 'ContactPoint',
+          'telephone' : metadata.GOCARDLESS[countryCode].SUPPORT.PHONE_FULL,
+          'email' : metadata.GOCARDLESS[countryCode].SUPPORT.EMAIL,
+          'contactType' : 'customer support',
+          'areaServed' : countryCode
         }
       );
     }

--- a/conf/metadata.js
+++ b/conf/metadata.js
@@ -11,52 +11,71 @@ var mixpanelToken = isProduction() ? mixpanelProduction : mixpanelTest;
 var metadata = {
   ENV_PRODUCTION: isProduction(),
   MIXPANEL_TOKEN: mixpanelToken,
-  TRADING_ADDRESS: '338-346 Goswell Road<br>London, EC1V 7LQ',
-  SUPPORT_CONTACT_NUMBER: '020 7183 8674',
-  SUPPORT_EMAIL: 'help@gocardless.com',
   CTA_BASIC: 'Start taking payments',
   CTA_PRO: 'Contact sales',
-
   LOGO: 'https://gocardless.com/images/logos/gocardless-square.png',
-  SOCIAL_LINKS: {
-    facebook: 'https://www.facebook.com/GoCardless',
-    twitter: 'https://twitter.com/gocardless',
-    google: 'https://plus.google.com/+Gocardless',
-    linkedin: 'https://www.linkedin.com/company/gocardless',
-    github: 'http://github.com/gocardless'
-  },
-  CONTACT_POINTS: {
-    // Country Code (e.g. GB, FR, BE)
-    //   To comply with schema.org requirements, the country code should use ISO-3166-2
-    //   See http://en.wikipedia.org/wiki/ISO_3166-2 for a list of valid country codes
-    // Contact type (e.g. customer service, sales)
-    //   See https://developers.google.com/structured-data/customize/contact-points
-    'GB': {
-      'customer service': {
-        'phone_full': '+44 20 7183 8674',
-        'phone_local': '020 7183 8674',
-        'email': 'help@gocardless.com'
+  
+  // Details of international offices & contact numbers
+  // The country code (e.g. GB, FR, BE) should use ISO-3166-2
+  // See http://en.wikipedia.org/wiki/ISO_3166-2 for a list of valid country codes
+  GOCARDLESS: {
+    GB: {
+      HOMEPAGE: 'https://gocardless.com/',
+      POSTAL_ADDRESS: {
+        STREET_ADDRESS: '338-346 Goswell Road',
+        ADDRESS_LOCALITY: 'London',
+        POSTAL_CODE: 'EC1V 7LQ',
+        ADDRESS_COUNTRY: '',
+        ADDRESS_COUNTRY_ISO: 'GB'
       },
-      'sales': {
-        'phone_full': '+44 20 7183 8674',
-        'phone_local': '020 7183 8674',
-        'email': 'help@gocardless.com'
+      SALES: {
+        PHONE_FULL: '+44 20 7183 8674',
+        PHONE_LOCAL: '020 7183 8674',
+        EMAIL: 'help@gocardless.com'
+      },
+      SUPPORT: {
+        PHONE_FULL: '+44 20 7183 8674',
+        PHONE_LOCAL: '020 7183 8674',
+        EMAIL: 'help@gocardless.com'
       }
     },
-    'FR': {
-      'sales': {
-        'phone_full': '+33 9 75 18 42 95',
-        'phone_local': '09 75 18 42 95',
-        'email': 'france@gocardless.com'
+    FR: {
+      HOMEPAGE: 'https://gocardless.com/fr',
+      POSTAL_ADDRESS: {
+        STREET_ADDRESS: '338-346 Goswell Road',
+        ADDRESS_LOCALITY: 'Londres',
+        POSTAL_CODE: 'EC1V 7LQ',
+        ADDRESS_COUNTRY: '',
+        ADDRESS_COUNTRY_ISO: 'GB'
+      },
+      SALES: {
+        PHONE_FULL: '+33 9 75 18 42 95',
+        PHONE_LOCAL: '09 75 18 42 95',
+        EMAIL: 'france@gocardless.com'
       }
     },
-    'BE': {
-      'sales': {
-        'phone_full': '+32 78 48 09 94',
-        'phone_local': '078 48 09 94',
-        'email': 'belgium@gocardless.com'
+    BE: {
+      HOMEPAGE: 'https://gocardless.com/fr',
+      POSTAL_ADDRESS: {
+        STREET_ADDRESS: '338-346 Goswell Road',
+        ADDRESS_LOCALITY: 'Londres',
+        POSTAL_CODE: 'EC1V 7LQ',
+        ADDRESS_COUNTRY: '',
+        ADDRESS_COUNTRY_ISO: 'GB'
+      },
+      SALES: {
+        PHONE_FULL: '+32 78 48 09 94',
+        PHONE_LOCAL: '078 48 09 94',
+        EMAIL: 'belgium@gocardless.com'
       }
     }
+  },
+  SOCIAL_LINKS: {
+    FACEBOOK: 'https://www.facebook.com/GoCardless',
+    TWITTER: 'https://twitter.com/gocardless',
+    GOOGLE: 'https://plus.google.com/+Gocardless',
+    LINKEDIN: 'https://www.linkedin.com/company/gocardless',
+    GITHUB: 'http://github.com/gocardless'
   }
 };
 
@@ -76,23 +95,37 @@ function buildSchemaDotOrgOrganization(metadata) {
     "contactPoint" : [],
   }
   
+  // Add social network links to sameAs
   for (var network in metadata.SOCIAL_LINKS) {
     organization.sameAs.push(metadata.SOCIAL_LINKS[network]);
   }
   
-  for (var country_code in metadata.CONTACT_POINTS) {
-    for (var contact_type in metadata.CONTACT_POINTS[country_code]) {
-      var contactInfo = metadata.CONTACT_POINTS[country_code][contact_type];
-      if (contactInfo.hasOwnProperty('full')) {
-        organization.contactPoint.push(
-          {
-            "@type" : "ContactPoint",
-            "telephone" : contactInfo.full,
-            "contactType" : contact_type,
-            "areaServed" : country_code
-          }
-        );
-      }
+  // Add contact details for office in each country
+  // See https://support.google.com/webmasters/answer/4620709?hl=en for supported contactType
+  for (var country_code in metadata.GOCARDLESS) {
+    // Sales number (contactType = sales)
+    if (metadata.GOCARDLESS[country_code].SALES) {
+      organization.contactPoint.push(
+        {
+          "@type" : "ContactPoint",
+          "telephone" : metadata.GOCARDLESS[country_code].SALES.PHONE_FULL,
+          "email" : metadata.GOCARDLESS[country_code].SALES.EMAIL,
+          "contactType" : "sales",
+          "areaServed" : country_code
+        }
+      );
+    }
+    // Customer support number (contactType = customer support)
+    if (metadata.GOCARDLESS[country_code].SUPPORT) {
+      organization.contactPoint.push(
+        {
+          "@type" : "ContactPoint",
+          "telephone" : metadata.GOCARDLESS[country_code].SUPPORT.PHONE_FULL,
+          "email" : metadata.GOCARDLESS[country_code].SUPPORT.EMAIL,
+          "contactType" : "customer support",
+          "areaServed" : country_code
+        }
+      );
     }
   }
   


### PR DESCRIPTION
At present, someone searching for GoCardless in [France](https://www.google.fr/search?hl=fr&gl=fr&pws=0&q=gocardless) or in [Belgium](https://www.google.be/search?hl=fr&gl=be&pws=0&q=gocardless) is given this result from the Google Knowledge Graph:
![gocardless france knowledge graph result](https://cloud.githubusercontent.com/assets/6426688/6217460/026f2660-b60c-11e4-87af-cd69adac6d59.png)

This result is non-satisfactory for multiple reasons:
* It has our UK phone number & UK opening hours (merchants in France & Belgium should see their local numbers).
* It gives a map/navigation result (not exactly the most useful result as our business isn't locally-based). Ideally, we probably want a company Knowledge Graph result e.g. like when you search for [Google](https://www.google.co.uk/search?q=google) or for [Microsoft](https://www.google.co.uk/search?q=microsoft):

![desired knowledge graph result](https://cloud.githubusercontent.com/assets/6426688/6227566/7c3bf828-b699-11e4-8a5b-c5fabf1d57f3.png)

The main search result in France also shows our UK phone number under the first result:

![gocardless france search result phone number](https://cloud.githubusercontent.com/assets/6426688/6247252/16d00dcc-b76a-11e4-901a-9b5b371682f0.png)

**What this pull request does**

This pull request implements [structured data](https://developers.google.com/structured-data/customize/overview) using [schema.org/Organization](http://schema.org/Organization). It tries to improve the Knowledge Graph result by providing a logo, geo-targeting our contact details and providing a list of social media accounts. 

A minified version of the following JSON is now output on the Contact Sales page:

```json
<script type="application/ld+json">
{
  "@context":"http://schema.org",
  "@type":"Organization",
  "url":"https://gocardless.com/",
  "logo":"https://gocardless.com/images/logos/gocardless-square.png",
  "sameAs":[
    "https://www.facebook.com/GoCardless",
    "https://twitter.com/gocardless",
    "https://plus.google.com/+Gocardless",
    "https://www.linkedin.com/company/gocardless",
    "http://github.com/gocardless"
  ],
  "contactPoint":[
    {
      "@type":"ContactPoint",
      "telephone":"+44 20 7183 8674",
      "email":"help@gocardless.com",
      "contactType":"sales",
      "areaServed":"GB"
    },
    {
      "@type":"ContactPoint",
      "telephone":"+44 20 7183 8674",
      "email":"help@gocardless.com",
      "contactType":"customer support",
      "areaServed":"GB"
    },
    {
      "@type":"ContactPoint",
      "telephone":"+33 9 75 18 42 95",
      "email":"france@gocardless.com",
      "contactType":"sales",
      "areaServed":"FR"
    },
    {
      "@type":"ContactPoint",
      "telephone":"+32 78 48 09 94",
      "email":"belgium@gocardless.com",
      "contactType":"sales",
      "areaServed":"BE"
    }
  ]
}
</script>
```

See the specs for [logo](https://developers.google.com/structured-data/customize/logos), [ContactPoint (adding a contact number)](https://developers.google.com/structured-data/customize/contact-points) and [sameAs (adding social media links)](https://developers.google.com/structured-data/customize/social-profiles) for the Knowledge Graph. You can validate the output using [Google's Structured Data Testing Tool](https://developers.google.com/structured-data/testing-tool/).

To further emphasise the different markets we serve & the relevant splash pages for each, our address in the footer now also has schema.org markup:

```html 
<p class="u-text-heading u-text-xxs u-color-invert u-margin-Bm" itemscope itemtype="http://schema.org/Organization">
  <span itemprop="name">GoCardless Ltd.</span>
  <meta itemprop="url" content="https://gocardless.com/fr" />
  <span itemprop="address" itemscope itemtype="http://schema.org/PostalAddress">
	<span itemprop="streetAddress">338-346 Goswell Road</span>,
	<span itemprop="addressLocality">Londres</span>,
	<span itemprop="postalCode">EC1V 7LQ</span>.
	<span itemprop="addressCountry" content="GB"></span>
  </span>
  <br>
  FR: <span itemprop="telephone" content="+33 9 75 18 42 95">+33 9 75 18 42 95</span>,
  <a href="mailto:france@gocardless.com" class="u-link-clean u-link-invert" itemprop="email">france@gocardless.com</a>
  <br>
  BE: <span itemprop="telephone" content="+32 78 48 09 94">+32 78 48 09 94</span>,
  <a href="mailto:belgium@gocardless.com" class="u-link-clean u-link-invert" itemprop="email">belgium@gocardless.com</a>
</p>
```

A new variable is defined in `metadata.js` holding our contact details in each country. Existing code has also been refactored to remove old variables e.g. `{{ TWITTER_LINK }}`, `{{ SUPPORT_EMAIL }}`, `{{ TRADING_ADDRESS }}`.