### PR TITLE
Remove noindex, follow from contact sales pages

### DIFF
--- a/app/pages/contact-sales/index.html
+++ b/app/pages/contact-sales/index.html
@@ -7,10 +7,7 @@ other_languages:
 {% extends "plain.html" %}
 
 {% block title %}Get a quote{% endblock %}
-{% block meta_tags %}
-  <meta name="description" content="Find out how much you can save using GoCardless to collect Direct Debit payments online. Enter your details and we'll e-mail you a quote within 24 hours.">
-  <meta name="robots" content="noindex,follow">
-{% endblock %}
+{% block meta_tags %}<meta name="description" content="Find out how much you can save using GoCardless to collect Direct Debit payments online. Enter your details and we'll e-mail you a quote within 24 hours.">{% endblock %}
 
 {% block body %}
 

--- a/app/pages/fr/contactez-nous/index.html
+++ b/app/pages/fr/contactez-nous/index.html
@@ -7,10 +7,7 @@ other_languages:
 {% extends "plain.html" %}
 
 {% block title %}Contactez-nous{% endblock %}
-{% block meta_tags %}
-  <meta name="description" content="Apprenez-en plus sur comment GoCardless peut vous aider à collecter vos prélèvements automatiques. Nous vous contacterons sous 24 heures.">
-  <meta name="robots" content="noindex,follow">
-{% endblock %}
+{% block meta_tags %}<meta name="description" content="Apprenez-en plus sur comment GoCardless peut vous aider à collecter vos prélèvements automatiques. Nous vous contacterons sous 24 heures.">{% endblock %}
 
 {% block body %}
 


### PR DESCRIPTION
We should remove `<meta name="robots" content="noindex,follow">` from the Contact Sales page (was previously copied over from an old lead capture page when we made the new page).

* The page is important especially for GC Pro & International
* We're now using the page for schema.org organization markup https://github.com/gocardless/splash-pages/pull/419