### PR TITLE
emphasises no commitments in subtext for signup button

### DIFF
--- a/app/pages/features/index.html
+++ b/app/pages/features/index.html
@@ -400,7 +400,7 @@
           Sign up in minutes, take payments today
         </h2>
         <a href="/merchants/new" id="track-merchants-new" class="btn">{{ CTA_BASIC }}</a>
-        <p class="u-color-p u-margin-Ts">No set up costs, no monthly fees, no hidden charges</p>
+        <p class="u-color-p u-margin-Ts">No set up costs, no hidden charges, no commitments</p>
       </div>
     </div>
 

--- a/app/pages/index.html
+++ b/app/pages/index.html
@@ -173,7 +173,7 @@ other_languages:
   <div class="site-container u-text-center u-padding-Vxxl">
     <div class="u-padding-Vxl">
       <a href="/merchants/new" id="track-cta-sign-up" class="btn">{{ CTA_BASIC }}</a>
-      <p class="u-color-p u-margin-Ts">No set up costs, no monthly fees, no hidden charges</p>
+      <p class="u-color-p u-margin-Ts">No set up costs, no hidden charges, no commitments</p>
     </div>
   </div>
 

--- a/app/pages/pricing/index.html
+++ b/app/pages/pricing/index.html
@@ -38,7 +38,7 @@ other_languages:
               <b>Perfect for small to medium sized businesses</b>
             </li>
             <li class="pricing-options__list-item">
-              No monthly fee, setup fee or hidden charges
+              No set up fees, hidden fees, or commitments
             </li>
             <li class="pricing-options__list-item">
               Scale pricing available (<a href="#scale-pricing-container" ng-gc-smooth-scroll>?</a>)

--- a/app/pages/security/index.html
+++ b/app/pages/security/index.html
@@ -98,7 +98,7 @@ other_languages:
   <div class="site-container u-text-center u-padding-Vxxl">
     <div class="u-padding-Vxl">
       <a href="/merchants/new" class="btn">{{ CTA_BASIC }}</a>
-      <p class="u-color-p u-margin-Ts">No set up costs, no monthly fees, no hidden charges</p>
+      <p class="u-color-p u-margin-Ts">No set up costs, no hidden charges, no commitments</p>
     </div>
   </div>
 

--- a/app/pages/stories/index.html
+++ b/app/pages/stories/index.html
@@ -189,7 +189,7 @@
         Sign up in minutes, take payments today
       </h2>
       <a href="/merchants/new" class="btn">{{ CTA_BASIC }}</a>
-      <p class="u-color-p u-margin-Ts">No set up costs, no monthly fees, no hidden charges</p>
+      <p class="u-color-p u-margin-Ts">No set up costs, no hidden charges, no commitments</p>
     </div>
   </div>
 


### PR DESCRIPTION
Follows up on the observation from @benmiller169 that several new signups haven't been clear on whether they are entering any long-term commitments by taking a test payment.

@anothertompetty