### PR TITLE
Add trailing slashes to fr homepage URL

### DIFF
--- a/app/includes/_site_footer.html
+++ b/app/includes/_site_footer.html
@@ -102,7 +102,7 @@
                 </span>
               </li>
               <li class="u-text-semi">
-                <a href="{{other_languages.fr if other_languages.fr else '/fr'}}" class="u-padding-Vxs u-padding-Hm u-block u-link-complex">
+                <a href="{{other_languages.fr if other_languages.fr else '/fr/'}}" class="u-padding-Vxs u-padding-Hm u-block u-link-complex">
                   <img src="/images/icons/fr-flag-icon@2x.png" class="flag-icon--popover u-margin-Rs" alt="">
                   <span class="u-link-complex-target">France</span>
                 </a>

--- a/app/includes/fr/_site_header.html
+++ b/app/includes/fr/_site_header.html
@@ -1,5 +1,5 @@
 <div class="u-pull-start">
-  <a href="/fr" id="track-nav-home" class="header-logo u-relative u-block u-padding-Vl">
+  <a href="/fr/" id="track-nav-home" class="header-logo u-relative u-block u-padding-Vl">
     <img ng-gc-svg-injector class="site-logo__image u-fill-primary" data-src="/images/logos/site-logo.svg">
   </a>
 </div>

--- a/app/includes/fr/_site_header_invert.html
+++ b/app/includes/fr/_site_header_invert.html
@@ -1,5 +1,5 @@
 <div class="u-pull-start">
-  <a href="/fr" id="track-nav-home" class="header-logo u-relative u-block u-padding-Vl">
+  <a href="/fr/" id="track-nav-home" class="header-logo u-relative u-block u-padding-Vl">
     <img ng-gc-svg-injector class="site-logo__image u-fill-invert" data-src="/images/logos/site-logo.svg">
   </a>
 </div>

--- a/app/pages/fr/index.html
+++ b/app/pages/fr/index.html
@@ -1,4 +1,5 @@
 ---
+is_homepage: true
 language: fr
 other_languages:
   en: /

--- a/app/pages/index.html
+++ b/app/pages/index.html
@@ -1,7 +1,8 @@
 ---
+is_homepage: true
 language: en
 other_languages:
-  fr: /fr
+  fr: /fr/
 ---
 
 {% extends "plain.html" %}

--- a/conf/metadata.js
+++ b/conf/metadata.js
@@ -40,7 +40,7 @@ var metadata = {
       }
     },
     FR: {
-      HOMEPAGE: 'https://gocardless.com/fr',
+      HOMEPAGE: 'https://gocardless.com/fr/',
       POSTAL_ADDRESS: {
         STREET_ADDRESS: '338-346 Goswell Road',
         ADDRESS_LOCALITY: 'Londres',
@@ -55,7 +55,7 @@ var metadata = {
       }
     },
     BE: {
-      HOMEPAGE: 'https://gocardless.com/fr',
+      HOMEPAGE: 'https://gocardless.com/fr/',
       POSTAL_ADDRESS: {
         STREET_ADDRESS: '338-346 Goswell Road',
         ADDRESS_LOCALITY: 'Londres',

--- a/scripts/nunjucks.js
+++ b/scripts/nunjucks.js
@@ -31,9 +31,16 @@ function stream(inFile, outFile, outRoot, compile) {
   }, function(file, enc, cb) {
     var _this = this;
     var parsed = frontMatter(file.toString());
-
-    // Strip output folder and trailing /index.html to get the path on website
-    var destinationUrl = outFile.replace(outRoot, '').replace('/index.html', '');
+    
+    if (parsed.attributes.is_homepage) {
+      // Strip output folder and index.html to get the path on the website (leave trailing slash)
+      // e.g. /, /fr/, /de/, etc.
+      var destinationUrl = outFile.replace(outRoot, '').replace('index.html', '');
+    } else {
+      // Strip output folder and trailing /index.html to get the path on website
+      // e.g. /about, /pricing, etc.
+      var destinationUrl = outFile.replace(outRoot, '').replace('/index.html', '');
+    }
     parsed.attributes.path = destinationUrl;
 
     compile(new Buffer(parsed.body), parsed.attributes)

--- a/scripts/nunjucks.js
+++ b/scripts/nunjucks.js
@@ -32,14 +32,11 @@ function stream(inFile, outFile, outRoot, compile) {
     var _this = this;
     var parsed = frontMatter(file.toString());
     
-    if (parsed.attributes.is_homepage) {
-      // Strip output folder and index.html to get the path on the website (leave trailing slash)
-      // e.g. /, /fr/, /de/, etc.
-      var destinationUrl = outFile.replace(outRoot, '').replace('index.html', '');
-    } else {
-      // Strip output folder and trailing /index.html to get the path on website
-      // e.g. /about, /pricing, etc.
-      var destinationUrl = outFile.replace(outRoot, '').replace('/index.html', '');
+    // Strip output folder and trailing /index.html to get the path on website
+    var destinationUrl = outFile.replace(outRoot, '').replace('/index.html', '');
+    // Add a trailing slash for language homepages (e.g. /, /fr/, /de/, etc.)
+    if (parsed.attributes.is_homepage) { 
+      destinationUrl = destinationUrl + '/';
     }
     parsed.attributes.path = destinationUrl;
 


### PR DESCRIPTION
Change URL of French homepage from gocardless.com/fr to gocardless.com/fr/

Rationale:
* Makes the website URL structure more clear
* Google Webmaster Tools only allows you to target folders (/fr isn't a part of the /fr/ directory).
* Allows us to track the /fr/ directory with MixPanel