### PR TITLE
Add rel=canonical to French homepage

### DIFF
--- a/app/pages/fr/index.html
+++ b/app/pages/fr/index.html
@@ -8,7 +8,10 @@ other_languages:
 {% extends "plain.html" %}
 
 {% block title %}Le prélèvement high-tech en Europe{% endblock %}
-{% block meta_tags %}<meta name="description" content="Accédez au prélèvement SEPA afin d'améliorer votre rétention clients et réduire vos coûts, sans les complications associées aux opérateurs historiques.">{% endblock %}
+{% block meta_tags %}
+<link rel="canonical" href="https://gocardless.com/fr/">
+<meta name="description" content="Accédez au prélèvement SEPA afin d'améliorer votre rétention clients et réduire vos coûts, sans les complications associées aux opérateurs historiques.">
+{% endblock %}
 
 {% block body %}
 


### PR DESCRIPTION
Adding a rel="canonical" tag so Google will index https://gocardless.com/fr/ instead of https://gocardless.com/fr.

This is a temporary solution to see whether it works (will revisit after 1-2 weeks)