### PR TITLE
Backport the popover CSS fix from guides

### DIFF
--- a/app/css/components/popover.scss
+++ b/app/css/components/popover.scss
@@ -74,7 +74,7 @@
   content: "";
 }
 
-.u-link-invert .popover-link:after {
+.popover-link--invert:after {
   border-top-color: white;
 }
 

--- a/app/includes/_site_footer.html
+++ b/app/includes/_site_footer.html
@@ -87,7 +87,7 @@
       <span class="u-relative">
         <popover-container>
           <a popover-toggle href="" class="u-text-semi u-link-invert">
-            <span class="popover-link">
+            <span class="popover-link popover-link--invert">
               United Kingdom
             </span>
           </a>

--- a/app/includes/_site_header_invert.html
+++ b/app/includes/_site_header_invert.html
@@ -10,7 +10,7 @@
     <div class="nav__item u-relative">
       <popover-container>
         <a popover-toggle href="" id="track-nav-products" class="u-padding-Vl u-block u-link-clean u-link-invert">
-          <div class="nav__item-link popover-link">
+          <div class="nav__item-link popover-link popover-link--invert">
             Our products
           </div>
         </a>
@@ -36,7 +36,7 @@
     <div class="nav__item u-relative">
       <popover-container>
         <a popover-toggle href="" id="track-nav-more" class="u-padding-Vl u-block u-link-clean u-link-invert">
-          <div class="nav__item-link popover-link">
+          <div class="nav__item-link popover-link popover-link--invert">
             More
           </div>
         </a>

--- a/app/includes/fr/_site_footer.html
+++ b/app/includes/fr/_site_footer.html
@@ -63,7 +63,7 @@
       <span class="u-relative">
         <popover-container>
           <a popover-toggle href="" class="u-text-semi u-link-invert">
-            <span class="popover-link">
+            <span class="popover-link popover-link--invert">
               France
             </span>
           </a>

--- a/app/includes/fr/_site_header_invert.html
+++ b/app/includes/fr/_site_header_invert.html
@@ -24,7 +24,7 @@
     <div class="nav__item u-relative">
       <popover-container>
         <a popover-toggle href="" id="track-nav-more" class="u-padding-Vl u-block u-link-clean u-link-invert">
-          <div class="nav__item-link popover-link">
+          <div class="nav__item-link popover-link popover-link--invert">
             Plus
           </div>
         </a>


### PR DESCRIPTION
Port changes from https://github.com/gocardless/guides/commit/e7928ecfcfd4deb1adcba890c667bc349037bd11 back into splash-pages