### PR TITLE
Fix learn more

### DIFF
--- a/app/pages/features/features.en.js
+++ b/app/pages/features/features.en.js
@@ -331,9 +331,9 @@ export default class FeaturesEn extends React.Component {
                       <td />
                       <td />
                       <td className='u-padding-As u-size-1of3'>
-                        <a href='/pro' id='track-comparison-table-pro' className='u-color-primary'>
+                        <Link to='/pro' id='track-comparison-table-pro' className='u-color-primary'>
                           Learn more about GoCardless Pro
-                        </a>
+                        </Link>
                       </td>
                     </tr>
                   </tfoot>

--- a/app/pages/features/features.en.js
+++ b/app/pages/features/features.en.js
@@ -325,11 +325,12 @@ export default class FeaturesEn extends React.Component {
             <div className='u-text-center u-padding-Vxxl u-background-light-gray'>
               <div className='site-container u-padding-Vxl'>
                 <ProductComparison />
-                <table className='u-size-full'><tfoot>
+                <table className='u-size-full'>
+                  <tfoot>
                     <tr className='comparison-table__row'>
                       <td />
                       <td />
-                      <td className='u-padding-As'>
+                      <td className='u-padding-As u-size-1of3'>
                         <a href='/pro' id='track-comparison-table-pro' className='u-color-primary'>
                           Learn more about GoCardless Pro
                         </a>

--- a/app/pages/features/features.fr.js
+++ b/app/pages/features/features.fr.js
@@ -251,7 +251,7 @@ export default class FeaturesFr extends React.Component {
                     <tr className='comparison-table__row'>
                       <td />
                       <td />
-                      <td className='u-padding-As'>
+                      <td className='u-padding-As u-size-1of3'>
                         <a href='/pro' id='track-comparison-table-pro' className='u-color-primary'>
                           Apprenez-en plus sur GoCardless Pro
                         </a>

--- a/app/pages/features/features.fr.js
+++ b/app/pages/features/features.fr.js
@@ -252,9 +252,9 @@ export default class FeaturesFr extends React.Component {
                       <td />
                       <td />
                       <td className='u-padding-As u-size-1of3'>
-                        <a href='/pro' id='track-comparison-table-pro' className='u-color-primary'>
+                        <Link to="pro" id='track-comparison-table-pro' className='u-color-primary'>
                           Apprenez-en plus sur GoCardless Pro
-                        </a>
+                        </Link>
                       </td>
                     </tr>
                   </tfoot>

--- a/app/pages/pro/pro.en.js
+++ b/app/pages/pro/pro.en.js
@@ -263,10 +263,11 @@ export default class ProEn extends React.Component {
               <div className='u-text-center u-padding-Vxxl u-background-light-gray'>
                 <div className='site-container u-padding-Vxl'>
                   <ProductComparison />
-                  <table className='u-size-full'><tfoot>
+                  <table className='u-size-full'>
+                    <tfoot>
                       <tr className='comparison-table__row'>
                         <td />
-                        <td className='u-padding-As'>
+                        <td className='u-size-1of3 u-padding-As'>
                           <Link to='features' id='track-comparison-table-features'
                           className='u-color-primary'>
                             Learn more about GoCardless

--- a/app/pages/pro/pro.fr.js
+++ b/app/pages/pro/pro.fr.js
@@ -200,7 +200,7 @@ export default class ProFr extends React.Component {
               <table className='u-size-full'><tfoot>
                   <tr className='comparison-table__row'>
                     <td />
-                    <td className='u-padding-As'>
+                    <td className='u-size-1of3 u-padding-As'>
                       <Link to='features' id='track-comparison-table-features'
                       className='u-color-primary'>
                         Apprenez-en plus sur GoCardless


### PR DESCRIPTION
Fixes #153

In addition to fixing the alignment, also fixes a place we were using an `a` link, rather than a `Link` component, meaning you would always end up on the English Pro page.

Before:
![screen shot 2015-05-21 at 17 29 00](https://cloud.githubusercontent.com/assets/597448/7753677/e5abd790-ffde-11e4-97e7-d107b3b5ee1d.png)

After:
![screen shot 2015-05-21 at 16 57 07](https://cloud.githubusercontent.com/assets/597448/7753679/e9e72d00-ffde-11e4-8934-1db3597afef1.png)

@harrison could you review?