### PR TITLE
Proof of concept for inlining default message

### DIFF
--- a/app/components/inline-message/inline-message.js
+++ b/app/components/inline-message/inline-message.js
@@ -1,0 +1,62 @@
+import React from 'react';
+import { PropTypes } from '../../helpers/prop-types/prop-types';
+import isPlainObject from 'lodash/lang/isPlainObject';
+
+function getMessageFromTranslations(pointer, messages) {
+  return pointer.split('.').reduce(function(obj, pathPart) {
+    return isPlainObject(obj) && obj[pathPart];
+  }, messages);
+}
+
+function isSubsetOfLocale(string, locale) {
+  return locale.startsWith(string);
+}
+
+function checkForDuplicateMessage(localeA, localeB, pointer, messages) {
+  if (localeA !== localeB) { return; }
+
+  const messageExists = !!getMessageFromTranslations(pointer, messages);
+
+  if (messageExists) {
+    throw new Error(`Duplicate translation found for ${pointer}`);
+  }
+}
+
+function getMessage({ currentLocale, locale, givenContent, pointer, messages }) {
+  checkForDuplicateMessage(currentLocale, locale, pointer, messages);
+
+  const foundMessage = getMessageFromTranslations(pointer, messages);
+
+  if (foundMessage) {
+    return foundMessage;
+  }
+
+  if (isSubsetOfLocale(locale, currentLocale)) {
+    return givenContent;
+  }
+
+  throw new ReferenceError(`Could not find Intl pointer: ${pointer}`);
+}
+
+export default class InlineMessage extends React.Component {
+  displayName = 'InlineMessage'
+
+  static propTypes = {
+    children: PropTypes.string.isRequired,
+    locale: PropTypes.string.isRequired,
+    pointer: PropTypes.string.isRequired,
+  }
+
+  static contextTypes = {
+    messages: PropTypes.object.isRequired,
+    currentLocale: PropTypes.locale,
+  }
+
+  render() {
+    const { currentLocale, messages } = this.context;
+    const { locale, children, pointer } = this.props;
+    const message = getMessage({ currentLocale, locale, givenContent: children, pointer, messages });
+
+    return <span>{message}</span>;
+  }
+}

--- a/app/components/inline-message/inline-message.spec.js
+++ b/app/components/inline-message/inline-message.spec.js
@@ -1,0 +1,127 @@
+import InlineMessage from './inline-message';
+import React from 'react';
+import ReactTestUtils from 'react/lib/ReactTestUtils';
+import { PropTypes } from '../../helpers/prop-types/prop-types';
+
+function inlineMessageWithContext(context) {
+  return class extends React.Component {
+    static childContextTypes = {
+      messages: PropTypes.object.isRequired,
+      currentLocale: PropTypes.locale,
+    }
+
+    getChildContext() {
+      return context;
+    }
+
+    render() {
+      return <InlineMessage {...this.props} />;
+    }
+  };
+}
+
+function renderText(component) {
+  const result = ReactTestUtils.renderIntoDocument(component);
+  const element = ReactTestUtils.findRenderedDOMComponentWithTag(result, 'span');
+
+  return element.getDOMNode().textContent;
+}
+
+describe('InlineMessage Component', () => {
+  describe('when the context has the same locale as the given message', () => {
+    describe('when a more specific translation exists', () => {
+      it('uses the translation message', () => {
+        const StubbedInlineMessage = inlineMessageWithContext({
+          currentLocale: 'en-GB',
+          messages: {
+            foo: { bar: 'baz' },
+          },
+        });
+
+        const component = (
+          <StubbedInlineMessage locale='en' pointer='foo.bar'>
+            Inline message
+          </StubbedInlineMessage>
+        );
+
+        expect(renderText(component)).toEqual('baz');
+      });
+    });
+
+    describe('when the inline message is for the most specific locale', () => {
+      it('uses the inline message', () => {
+        const StubbedInlineMessage = inlineMessageWithContext({
+          currentLocale: 'en-GB',
+          messages: {},
+        });
+
+        const component = (
+          <StubbedInlineMessage locale='en-GB' pointer='foo.bar'>
+            Inline message
+          </StubbedInlineMessage>
+        );
+
+        expect(renderText(component)).toEqual('Inline message');
+      });
+    });
+
+    describe('but there also exists a translation for the same locale', () => {
+      it('throws an error', () => {
+        const StubbedInlineMessage = inlineMessageWithContext({
+          currentLocale: 'en-GB',
+          messages: {
+            foo: { bar: 'baz' },
+          },
+        });
+
+        expect(() => {
+          ReactTestUtils.renderIntoDocument(
+            <StubbedInlineMessage locale='en-GB' pointer='foo.bar'>
+              Inline message
+            </StubbedInlineMessage>
+          );
+        }).toThrow(new Error('Duplicate translation found for foo.bar'));
+      });
+    });
+  });
+
+  describe('when the context locale differs to the inline message locale', () => {
+    describe('and we have a translation for that locale', () => {
+      it('uses the translation message', () => {
+        const StubbedInlineMessage = inlineMessageWithContext({
+          currentLocale: 'fr-FR',
+          messages: {
+            foo: { bar: 'baz' },
+          },
+        });
+
+        const component = (
+          <StubbedInlineMessage locale='en-GB' pointer='foo.bar'>
+            Inline message
+          </StubbedInlineMessage>
+        );
+
+        expect(renderText(component)).toEqual('baz');
+      });
+    });
+
+    describe('and there is no translation for the current locale', () => {
+      it('throws an error', () => {
+        const StubbedInlineMessage = inlineMessageWithContext({
+          currentLocale: 'fr-FR',
+          messages: {
+            foo: { bar: 'baz' },
+          },
+        });
+
+        expect(() => {
+          ReactTestUtils.renderIntoDocument(
+            <StubbedInlineMessage locale='en-GB' pointer='doesnt.exist'>
+              Inline message
+            </StubbedInlineMessage>
+          );
+        }).toThrow(new ReferenceError('Could not find Intl pointer: doesnt.exist'));
+      });
+    });
+  });
+});

--- a/app/components/intl/intl.js
+++ b/app/components/intl/intl.js
@@ -2,20 +2,20 @@ import isString from 'lodash/lang/isString';
 import isPlainObject from 'lodash/lang/isPlainObject';
 import isEmpty from 'lodash/lang/isEmpty';
 
-export function getMessage(messages, path) {
-  if (!isString(path)) { throw new TypeError(`Path must be a string`); }
+export function getMessage(messages, pointer) {
+  if (!isString(pointer)) { throw new TypeError(`Pointer must be a string`); }
   if (!isPlainObject(messages) || isEmpty(messages)) {
     throw new TypeError(`Messages must an object`);
   }
 
   let message;
   try {
-    message = path.split('.').reduce(function(obj, pathPart) {
+    message = pointer.split('.').reduce(function(obj, pathPart) {
       return obj[pathPart];
     }, messages);
   } finally {
     if (message === undefined) {
-      throw new ReferenceError(`Could not find Intl message: ${path}`);
+      throw new ReferenceError(`Could not find Intl pointer: ${pointer}`);
     }
   }
 

--- a/app/messages/en.js
+++ b/app/messages/en.js
@@ -27,7 +27,6 @@ export default {
     learn_more: 'Learn about our pricing',
   },
   hero: {
-    header: 'Recurring payments made simple',
     desc: 'GoCardless makes collecting by Direct Debit easy for everyone from individuals to multi-national corporations',
   },
   contact_types: ['customer support', 'sales'],

--- a/app/pages/home/home.js
+++ b/app/pages/home/home.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import Page from '../../components/page/page';
 import Message from '../../components/message/message';
+import InlineMessage from '../../components/inline-message/inline-message';
 import HomeEn from './home.en';
 import HomeFr from './home.fr';
 import Translation from '../../components/translation/translation';
@@ -16,7 +17,7 @@ export default class Home extends React.Component {
             <div className='page-hero__inner'>
               <div className='page-hero__text'>
                 <h1 className='u-text-heading u-color-invert u-text-center u-text-xl u-text-light'>
-                  <Message pointer='hero.header' />
+                  <InlineMessage pointer='hero.header' locale="en">Recurring payments made simple</InlineMessage>
                 </h1>
                 <div className={'u-text-heading u-text-center u-color-invert ' +
                                 'u-text-m u-text-light u-margin-Txxs u-text-no-smoothing page-hero__text__desc'}>


### PR DESCRIPTION
I don't want to merge this, its here only for discussion.

This explores writing `Message` components that are potentially translated into several languages with a 'default' language inline. This is different to what we had before as there would be no inline copy, all copy would live in a translation file.

The benefit of this is that you can see what the actual page looks like with copy in it as you are reading/writing a React page. Previously you would have to jump between the component and the translation file to get an idea of how the page would look.

@harrison what do you think?