### PR TITLE
Rename context.locales => context.currentLocale

### DIFF
--- a/app/client/bootstrap.js
+++ b/app/client/bootstrap.js
@@ -16,7 +16,7 @@ if (process.env.BROWSER) {
 
 function renderApp() {
   const appState = window.app;
-  const routes = getRoutes(appState.locales, appState.availableLocales);
+  const routes = getRoutes(appState.currentLocale, appState.availableLocales);
   const router = Router.create({
     routes: routes,
     location: Router.HistoryLocation,

--- a/app/components/app/app.js
+++ b/app/components/app/app.js
@@ -33,7 +33,7 @@ class App extends React.Component {
   displayName = 'App'
 
   static propTypes = {
-    locales: PropTypes.locale,
+    currentLocale: PropTypes.locale,
     messages: PropTypes.object.isRequired,
     formats: PropTypes.object.isRequired,
     routeName: PropTypes.string.isRequired,
@@ -49,7 +49,7 @@ class App extends React.Component {
   }
 
   static childContextTypes = {
-    locales: PropTypes.locale,
+    currentLocale: PropTypes.locale,
     messages: PropTypes.object.isRequired,
     formats: PropTypes.object.isRequired,
     routeName: PropTypes.string.isRequired,
@@ -81,11 +81,11 @@ class App extends React.Component {
   }
 
   getChildContext() {
-    const { locales, messages, formats, routeName, availableLocales,
+    const { currentLocale, messages, formats, routeName, availableLocales,
             availableCountryNames, routeLocales, config, pathname } = this.props;
 
     return {
-      locales: locales,
+      currentLocale: currentLocale,
       messages: messages,
       formats: formats,
       routeName: routeName,

--- a/app/components/footer/footer.js
+++ b/app/components/footer/footer.js
@@ -33,16 +33,16 @@ class Footer extends React.Component {
 
   static contextTypes = {
     routeName: PropTypes.string.isRequired,
-    locales: PropTypes.locale,
+    currentLocale: PropTypes.locale,
     config: PropTypes.object.isRequired,
     availableLocales: PropTypes.array.isRequired,
     availableCountryNames: PropTypes.object.isRequired,
   }
 
   render() {
-    const { routeName, locales, config, availableLocales, availableCountryNames } = this.context;
-    const availableLocalePages = buildAvailableLocalePages(locales, routeName, availableLocales, availableCountryNames);
-    const region = localeToRegion(locales);
+    const { routeName, currentLocale, config, availableLocales, availableCountryNames } = this.context;
+    const availableLocalePages = buildAvailableLocalePages(currentLocale, routeName, availableLocales, availableCountryNames);
+    const region = localeToRegion(currentLocale);
 
     return (
       <div className='page-footer u-color-invert u-padding-Tl'>

--- a/app/components/html-document/html-document.js
+++ b/app/components/html-document/html-document.js
@@ -35,7 +35,7 @@ class HtmlDocument extends React.Component {
   displayName = 'HtmlDocument'
 
   static propTypes = {
-    locales: PropTypes.locale,
+    currentLocale: PropTypes.locale,
     messages: PropTypes.object.isRequired,
     formats: PropTypes.object.isRequired,
     routeName: PropTypes.string.isRequired,
@@ -57,7 +57,7 @@ class HtmlDocument extends React.Component {
   }
 
   static childContextTypes = {
-    locales: PropTypes.locale,
+    currentLocale: PropTypes.locale,
     messages: PropTypes.object.isRequired,
     formats: PropTypes.object.isRequired,
     routeName: PropTypes.string.isRequired,
@@ -70,11 +70,11 @@ class HtmlDocument extends React.Component {
   };
 
   getChildContext() {
-    const { locales, messages, formats, routeName, availableLocales,
+    const { currentLocale, messages, formats, routeName, availableLocales,
             availableCountryNames, routeLocales, router, pathname, config } = this.props;
 
     return {
-      locales: locales,
+      currentLocale: currentLocale,
       messages: messages,
       formats: formats,
       routeName: routeName,
@@ -88,13 +88,13 @@ class HtmlDocument extends React.Component {
   }
 
   render() {
-    const { messages, routeName, locales, config, pathname, availableLocales, markup, script, css } = this.props;
+    const { messages, routeName, currentLocale, config, pathname, availableLocales, markup, script, css } = this.props;
     const isHome = routeName === homeRoute;
     const schemaDotOrgOrganisation = buildSchemaDotOrgForOrganization(localeMessages, availableLocales, config);
     const routeLocales = getLocalesForRouteName(routeName, availableLocales);
     const pageHref = config.siteRoot + pathname;
     const title = getSiteTitle({ messages, routeName, config });
-    const language = localeToLanguage(locales);
+    const language = localeToLanguage(currentLocale);
     const description = getMessage(messages, `${routeName}.description`);
 
     return (

--- a/app/components/prospect-form/prospect-form.js
+++ b/app/components/prospect-form/prospect-form.js
@@ -41,7 +41,7 @@ export default class ProspectForm extends React.Component {
   }
 
   static contextTypes = {
-    locales: PropTypes.locale,
+    currentLocale: PropTypes.locale,
     messages: React.PropTypes.object.isRequired,
   }
 
@@ -108,10 +108,10 @@ export default class ProspectForm extends React.Component {
   }
 
   render() {
-    const { messages, locales } = this.context;
+    const { messages, currentLocale } = this.context;
     const { prospectType } = this.props;
     const endpoints = prospectTypes[prospectType].endpoints;
-    const action = locales in endpoints ? endpoints[locales].action : endpoints.default.action;
+    const action = currentLocale in endpoints ? endpoints[currentLocale].action : endpoints.default.action;
     const size = this.state.responseData && this.state.responseData.size || 'default';
 
     return (

--- a/app/components/translation/translation.js
+++ b/app/components/translation/translation.js
@@ -29,7 +29,7 @@ export default class Translation extends React.Component {
   }
 
   static contextTypes = {
-    locales: PropTypes.locale,
+    currentLocale: PropTypes.locale,
     routeLocales: PropTypes.array.isRequired,
     routeName: PropTypes.string.isRequired,
   }
@@ -37,7 +37,7 @@ export default class Translation extends React.Component {
   render() {
     const locales = flatten([this.props.locales]);
     const exclude = flatten([this.props.exclude]);
-    const { locales: currentLocale, routeLocales, routeName } = this.context;
+    const { currentLocale, routeLocales, routeName } = this.context;
     const translationLocales = expandLangLocales(locales, routeLocales);
     validateLocale(translationLocales, routeLocales, routeName);
 

--- a/app/components/translation/translation.spec.js
+++ b/app/components/translation/translation.spec.js
@@ -8,7 +8,7 @@ describe('Translation Component', function() {
     it('renders the content', function() {
       var TranslationStub = stubContext(Translation, {
         props: { locales: 'en-GB' },
-        context: { locales: 'en-GB', routeLocales: ['en-GB'], routeName: 'test' },
+        context: { currentLocale: 'en-GB', routeLocales: ['en-GB'], routeName: 'test' },
       });
 
       var result = ReactTestUtils.renderIntoDocument(
@@ -26,7 +26,7 @@ describe('Translation Component', function() {
     it('renders the content', function() {
       var TranslationStub = stubContext(Translation, {
         props: { locales: 'en' },
-        context: { locales: 'en-GB', routeLocales: ['en-GB'], routeName: 'test' },
+        context: { currentLocale: 'en-GB', routeLocales: ['en-GB'], routeName: 'test' },
       });
 
       var result = ReactTestUtils.renderIntoDocument(
@@ -44,7 +44,7 @@ describe('Translation Component', function() {
     it('returns an empty element', function() {
       var TranslationStub = stubContext(Translation, {
         props: { locales: 'fr' },
-        context: { locales: 'en-GB', routeLocales: ['en-GB', 'fr-BE'], routeName: 'test' },
+        context: { currentLocale: 'en-GB', routeLocales: ['en-GB', 'fr-BE'], routeName: 'test' },
       });
 
       var result = ReactTestUtils.renderIntoDocument(
@@ -62,7 +62,7 @@ describe('Translation Component', function() {
     it('returns an empty element', function() {
       var TranslationStub = stubContext(Translation, {
         props: { locales: 'en-FR' },
-        context: { locales: 'en-GB', routeLocales: ['en-GB', 'en-FR'], routeName: 'test' },
+        context: { currentLocale: 'en-GB', routeLocales: ['en-GB', 'en-FR'], routeName: 'test' },
       });
 
       var result = ReactTestUtils.renderIntoDocument(
@@ -80,7 +80,7 @@ describe('Translation Component', function() {
     it('throws error rendering', function() {
       var TranslationStub = stubContext(Translation, {
         props: { locales: 'en-GB' },
-        context: { locales: 'en-GB', routeLocales: ['fr-FR'], routeName: 'test' },
+        context: { currentLocale: 'en-GB', routeLocales: ['fr-FR'], routeName: 'test' },
       });
 
       expect(function() {
@@ -97,7 +97,7 @@ describe('Translation Component', function() {
     it('returns an empty element', function() {
       var TranslationStub = stubContext(Translation, {
         props: { locales: 'en', exclude: ['en-IE'] },
-        context: { locales: 'en-IE', routeLocales: ['en-IE', 'en-GB'], routeName: 'test' },
+        context: { currentLocale: 'en-IE', routeLocales: ['en-IE', 'en-GB'], routeName: 'test' },
       });
 
       var result = ReactTestUtils.renderIntoDocument(
@@ -115,7 +115,7 @@ describe('Translation Component', function() {
     it('renders the content', function() {
       var TranslationStub = stubContext(Translation, {
         props: { locales: 'en', exclude: ['en-GB'] },
-        context: { locales: 'en-IE', routeLocales: ['en-IE', 'en-GB'], routeName: 'test' },
+        context: { currentLocale: 'en-IE', routeLocales: ['en-IE', 'en-GB'], routeName: 'test' },
       });
 
       var result = ReactTestUtils.renderIntoDocument(

--- a/app/helpers/stub-context.js
+++ b/app/helpers/stub-context.js
@@ -4,7 +4,7 @@ import { PropTypes } from './prop-types/prop-types';
 var stubContext = function(Component, { props, context }) {
   return class extends React.Component {
     static childContextTypes = {
-      locales: PropTypes.locale,
+      currentLocale: PropTypes.locale,
       routeLocales: PropTypes.array.isRequired,
       routeName: PropTypes.string.isRequired,
     }

--- a/app/pages/about/jobs/jobs-page.js
+++ b/app/pages/about/jobs/jobs-page.js
@@ -15,13 +15,13 @@ export default class JobsPage extends React.Component {
   }
 
   static contextTypes = {
-    locales: PropTypes.locale,
+    currentLocale: PropTypes.locale,
     availableLocales: PropTypes.array.isRequired,
   }
 
   render() {
-    const { locales, availableLocales } = this.context;
-    const pages = filterRouteByCategory('jobs', locales, availableLocales);
+    const { currentLocale, availableLocales } = this.context;
+    const pages = filterRouteByCategory('jobs', currentLocale, availableLocales);
 
     const categories = pages.reduce(function(memo, job) {
       const category = rest(job.routeConfig.category.split('.')).join('.');

--- a/app/pages/about/jobs/jobs.js
+++ b/app/pages/about/jobs/jobs.js
@@ -6,13 +6,13 @@ export default class Jobs extends React.Component {
   displayName = 'Jobs'
 
   static contextTypes = {
-    locales: PropTypes.locale,
+    currentLocale: PropTypes.locale,
     availableLocales: PropTypes.array.isRequired,
   }
 
   render() {
-    const { locales, availableLocales } = this.context;
-    const pages = filterRouteByCategory('jobs', locales, availableLocales);
+    const { currentLocale, availableLocales } = this.context;
+    const pages = filterRouteByCategory('jobs', currentLocale, availableLocales);
     // Render the first job by default (we need an overview page this is weird)
     const Handler = pages[0].handler;
 

--- a/app/pages/faq/customers/faq-customers-page.js
+++ b/app/pages/faq/customers/faq-customers-page.js
@@ -16,13 +16,13 @@ export default class FaqCustomersPage extends React.Component {
   };
 
   static contextTypes = {
-    locales: PropTypes.locale,
+    currentLocale: PropTypes.locale,
     availableLocales: PropTypes.array.isRequired,
   }
 
   render() {
-    const { locales, availableLocales } = this.context;
-    const pages = filterRouteByCategory('faq.customers', locales, availableLocales);
+    const { currentLocale, availableLocales } = this.context;
+    const pages = filterRouteByCategory('faq.customers', currentLocale, availableLocales);
 
     const faqNav = pages.map(function(page) {
       return (<li key={page.routeConfig.name}>

--- a/app/pages/faq/merchants/faq-merchants-page.js
+++ b/app/pages/faq/merchants/faq-merchants-page.js
@@ -16,13 +16,13 @@ export default class FaqMerchantsPage extends React.Component {
   };
 
   static contextTypes = {
-    locales: PropTypes.locale,
+    currentLocale: PropTypes.locale,
     availableLocales: PropTypes.array.isRequired,
   }
 
   render() {
-    const { locales, availableLocales } = this.context;
-    const pages = filterRouteByCategory('faq.merchants', locales, availableLocales);
+    const { currentLocale, availableLocales } = this.context;
+    const pages = filterRouteByCategory('faq.merchants', currentLocale, availableLocales);
 
     const faqNav = pages.map(function(page) {
       return (<li key={page.routeConfig.name}>

--- a/app/pages/legal/legal-page.js
+++ b/app/pages/legal/legal-page.js
@@ -13,13 +13,13 @@ export default class LegalPage extends React.Component {
   };
 
   static contextTypes = {
-    locales: PropTypes.locale,
+    currentLocale: PropTypes.locale,
     availableLocales: PropTypes.array.isRequired,
   }
 
   render() {
-    const { locales, availableLocales } = this.context;
-    const pages = filterRouteByCategory('legal', locales, availableLocales);
+    const { currentLocale, availableLocales } = this.context;
+    const pages = filterRouteByCategory('legal', currentLocale, availableLocales);
 
 
     const legalNav = pages.map(function(page) {

--- a/server/render.js
+++ b/server/render.js
@@ -47,7 +47,7 @@ export function render(req, res, next) {
 
   function appProps(props) {
     return assign({
-      locales: reqLocale.normalized,
+      currentLocale: reqLocale.normalized,
       language: reqLocale.language,
       messages: messages,
       formats: formats,


### PR DESCRIPTION
Renames `locales` to `currentLocale`. `locales` is confusing as there is only ever one.

This value is typically passed down through our component's `context`, so is therefore referenced almost everywhere! Tests seem fine and I've clicked around locally and everything seems fine...

@harrison could you please review?