### PR TITLE
Use span rather than div for link exists to avoid CSS problems

### DIFF
--- a/app/components/link-exists/link-exists.js
+++ b/app/components/link-exists/link-exists.js
@@ -24,8 +24,10 @@ class LinkExists extends React.Component {
       hasLink = false;
     }
 
+    if (!hasLink) { return null; }
+
     return (
-      <div>{ hasLink && this.props.children }</div>
+      <span>{ this.props.children }</span>
     );
   }
 }


### PR DESCRIPTION
@harrison is this the right approach? Swapping the wrapping element to be one that isn't block by default makes sense to me...

Good spot from @jesssummerfield  !

Before
![screen shot 2015-05-28 at 17 46 13](https://cloud.githubusercontent.com/assets/193238/7866020/8a74f9c0-0564-11e5-9c6b-86133e6b17e3.png)

After
![screen shot 2015-05-28 at 18 08 08](https://cloud.githubusercontent.com/assets/193238/7866022/8ecc8fec-0564-11e5-8fa1-c8e3fced70d7.png)

