### PR TITLE
Show local phone number in footer

### DIFF
--- a/app/components/footer/footer.js
+++ b/app/components/footer/footer.js
@@ -163,7 +163,9 @@ class Footer extends React.Component {
                     <Message pointer='postal_address.address_country' />
                   </SchemaItemProp>.
                 </SchemaItemProp><br />
-                <SchemaItemProp itemProp='telephone' pointer='phone_full' />,&nbsp;
+                <SchemaItemProp itemProp='telephone' pointer='phone_full'>
+                  <Message pointer='phone_local' />
+                </SchemaItemProp>,&nbsp;
                 <Href to='email' className='u-link-invert' itemProp='email' />
               </p>
               <p className='u-text-heading u-text-xxs u-color-invert u-margin-Bm'>

--- a/app/messages/en-EU.js
+++ b/app/messages/en-EU.js
@@ -2,6 +2,7 @@
 
 export default {
   country: 'Europe',
+  phone_local: '020 7183 8674',
   hero: {
     header: 'Accept recurring payments across Europe',
     desc: 'GoCardless allows you to collect Direct Debit payments from the UK and the Eurozone in a single integration.',

--- a/app/messages/en-EU.js
+++ b/app/messages/en-EU.js
@@ -2,7 +2,6 @@
 
 export default {
   country: 'Europe',
-  phone_local: '020 7183 8674',
   hero: {
     header: 'Accept recurring payments across Europe',
     desc: 'GoCardless allows you to collect Direct Debit payments from the UK and the Eurozone in a single integration.',

--- a/app/messages/en-GB.js
+++ b/app/messages/en-GB.js
@@ -2,6 +2,7 @@
 
 export default {
   country: 'United Kingdom',
+  phone_local: '020 7183 8674',
   documentation_link: 'https://developer.gocardless.com/',
   footer: {
     description: 'GoCardless is a Bacs approved bureau and is regulated by the Financial Conduct Authority as an Authorised Payment Institution.',

--- a/app/messages/en.js
+++ b/app/messages/en.js
@@ -38,7 +38,7 @@ export default {
     address_country_iso: 'GB',
   },
   phone_full: '+44 20 7183 8674',
-  phone_local: '020 7183 8674',
+  phone_local: '+44 20 7183 8674',
   email: 'help@gocardless.com',
   documentation_link: 'https://developer.gocardless.com/pro',
   prospect_form: {

--- a/app/pages/contact-sales/contact-sales.js
+++ b/app/pages/contact-sales/contact-sales.js
@@ -2,6 +2,7 @@ import React from 'react';
 import Page from '../../components/page/page';
 import ProspectForm from '../../components/prospect-form/prospect-form';
 import Message from '../../components/message/message';
+import Translation from '../../components/translation/translation';
 
 export default class ContactSales extends React.Component {
   displayName = 'ContactSales'
@@ -25,8 +26,11 @@ export default class ContactSales extends React.Component {
             <ProspectForm prospectType='sales' />
             <hr />
             <p className='u-text-center u-color-meta u-margin-Bs'>
-              <b><Message pointer='contact_sales.talk_to_us' /></b><br/>
-              <Message pointer='contact_sales.call_us' /> <Message pointer='phone_full' />
+              <b><Message pointer='contact_sales.talk_to_us' /></b><br />
+              <Message pointer='contact_sales.call_us' /> <Message pointer='phone_local' />
+              <Translation locales='en-GB'>
+                <br />(<Message pointer='phone_full' /> from outside the UK)
+              </Translation>
             </p>
             <hr />
             <p className='u-text-center u-color-meta u-margin-Bs'>

--- a/app/pages/faq/faq-sidebar.js
+++ b/app/pages/faq/faq-sidebar.js
@@ -16,7 +16,7 @@ export default class FaqSidebar extends React.Component {
           <hr className='u-size-11of12' />
           <p className='para u-padding-Txs'>
             <Message pointer='faq.sidebar' />&nbsp;
-            <Message pointer='phone_full' />
+            <Message pointer='phone_local' />
           </p>
         </div>
       </div>

--- a/app/pages/features/features.en.js
+++ b/app/pages/features/features.en.js
@@ -371,7 +371,7 @@ export default class FeaturesEn extends React.Component {
                     <PhoneIcon className='svg-icon__image u-fill-dark-gray' />
                   </figure>
                   <h2 className='u-text-heading u-color-heading u-text-l u-text-light u-margin-Tm'>
-                    <Message pointer="phone_full" />
+                    <Message pointer="phone_local" />
                   </h2>
                   <div className='u-center'>
                     <p className='u-text-s u-color-p u-margin-Ts'>

--- a/app/pages/pricing/pricing.de.js
+++ b/app/pages/pricing/pricing.de.js
@@ -91,7 +91,7 @@ export default class PricingDe extends React.Component {
         <div className='site-container u-text-center u-padding-Tm u-padding-Bxxl'>
           <div className='u-padding-Vxl'>
             <h2 className='u-text-heading u-text-l u-color-heading u-text-light'>Haben Sie Fragen?</h2>
-            <p className='u-color-p u-margin-Ts'>Sprechen Sie mit einem unserer Zahlungsexperten: <Message pointer='phone_full' /></p>
+            <p className='u-color-p u-margin-Ts'>Sprechen Sie mit einem unserer Zahlungsexperten: <Message pointer='phone_local' /></p>
             <Link to='contact_sales' query={{ s: 'pricing' }} className='btn btn--hollow u-margin-Tm'>Kontakt</Link>
           </div>
         </div>

--- a/app/pages/pricing/pricing.en-GB.js
+++ b/app/pages/pricing/pricing.en-GB.js
@@ -139,8 +139,8 @@ export default class PricingEnGb extends React.Component {
         <div className='site-container u-text-center u-padding-Tm u-padding-Bxxl'>
           <div className='u-padding-Vxl'>
             <h2 className='u-text-heading u-text-l u-color-heading u-text-light'>Got any questions?</h2>
-            <p className='u-color-p u-margin-Ts'>Speak with one of our payments experts on <Message pointer='phone_full' /></p>
-            <Translation locales={['en']} exclude="en-GB">
+            <p className='u-color-p u-margin-Ts'>Speak with one of our payments experts on <Message pointer='phone_local' /></p>
+            <Translation locales={['en']} exclude={['en-GB']}>
               <Link to='contact_sales' query={{ s: 'pricing' }} className='btn btn--hollow u-margin-Tm'>Contact sales</Link>
             </Translation>
             <Translation locales='en-GB'>

--- a/app/pages/pricing/pricing.en.js
+++ b/app/pages/pricing/pricing.en.js
@@ -91,7 +91,7 @@ export default class PricingEn extends React.Component {
         <div className='site-container u-text-center u-padding-Tm u-padding-Bxxl'>
           <div className='u-padding-Vxl'>
             <h2 className='u-text-heading u-text-l u-color-heading u-text-light'>Got any questions?</h2>
-            <p className='u-color-p u-margin-Ts'>Speak with one of our payments experts on <Message pointer='phone_full' /></p>
+            <p className='u-color-p u-margin-Ts'>Speak with one of our payments experts on <Message pointer='phone_local' /></p>
             <Link to='contact_sales' query={{ s: 'pricing' }} className='btn btn--hollow u-margin-Tm'>Contact sales</Link>
           </div>
         </div>

--- a/app/pages/pricing/pricing.fr.js
+++ b/app/pages/pricing/pricing.fr.js
@@ -136,7 +136,7 @@ export default class PricingFr extends React.Component {
               </figure>
               <div className='u-center'>
                 <p className='u-color-p u-margin-Ts'>
-                  Nous sommes disponible afin de répondre à vos questions au <Message pointer='phone_full' />
+                  Nous sommes disponible afin de répondre à vos questions au <Message pointer='phone_local' />
                 </p>
                 <Link to='contact_sales' className='btn btn--hollow u-margin-Tm'>
                   Contactez-nous

--- a/app/pages/pro/pro.de.js
+++ b/app/pages/pro/pro.de.js
@@ -195,7 +195,7 @@ export default class ProDe extends React.Component {
                     <PhoneIcon className='svg-icon__image u-fill-dark-gray' />
                   </figure>
                   <h2 className='u-text-heading u-color-heading u-text-l u-text-light u-margin-Tm'>
-                    <Message pointer='phone_full' />
+                    <Message pointer='phone_local' />
                   </h2>
                   <div className='u-center'>
                     <p className='u-text-s u-color-p u-margin-Ts'>
@@ -289,7 +289,7 @@ export default class ProDe extends React.Component {
                 <hr className='u-margin-Vxxl' />
                 <p className='u-color-p'>
                   <strong>Sie möchten mit jemandem sprechen?</strong><br />
-                  Rufen Sie unsere Experten an unter <Message pointer='phone_full' />.git <br />
+                  Rufen Sie unsere Experten an unter <Message pointer='phone_local' />.<br />
                   Wir sind zwischen 10.00 und 19.00 Uhr für Sie da, Montag bis Freitag.
                 </p>
               </div>

--- a/app/pages/pro/pro.en.js
+++ b/app/pages/pro/pro.en.js
@@ -219,7 +219,7 @@ export default class ProEn extends React.Component {
                     <PhoneIcon className='svg-icon__image u-fill-dark-gray' />
                   </figure>
                   <h2 className='u-text-heading u-color-heading u-text-l u-text-light u-margin-Tm'>
-                    <Message pointer='phone_full' />
+                    <Message pointer='phone_local' />
                   </h2>
                   <div className='u-center'>
                     <p className='u-text-s u-color-p u-margin-Ts'>
@@ -337,7 +337,7 @@ export default class ProEn extends React.Component {
                 <hr className='u-margin-Vxxl' />
                 <p className='u-color-p'>
                   <strong>Want to talk to someone first?</strong><br />
-                  Call our payments experts on <Message pointer='phone_full' /><br />
+                  Call our payments experts on <Message pointer='phone_local' /><br />
                   We're available 9am - 6pm Monday to Friday
                 </p>
               </div>

--- a/app/pages/security/security.en.js
+++ b/app/pages/security/security.en.js
@@ -66,7 +66,7 @@ export default class SecurityEn extends React.Component {
           <div className='site-container u-text-center u-padding-Tm u-padding-Bxxl'>
             <div className='u-padding-Vxl'>
               <h2 className='u-text-heading u-text-l u-color-heading u-text-light'>Got any questions?</h2>
-              <p className='u-color-p u-margin-Ts'>Speak with one of our experts on <Message pointer='phone_full' /></p>
+              <p className='u-color-p u-margin-Ts'>Speak with one of our experts on <Message pointer='phone_local' /></p>
               <Link to='contact_sales' query={{ s: 'security' }} className='btn btn--hollow u-margin-Tm'>Contact sales</Link>
             </div>
           </div>


### PR DESCRIPTION
Removes the international dialling prefix and shows a local number in the footer when available.

Germany footer is vastly improved:
![screen shot 2015-05-29 at 12 26 36](https://cloud.githubusercontent.com/assets/6426688/7881744/0d1021c2-05fe-11e5-81cd-4c2ff30da130.png)

France:
![screen shot 2015-05-29 at 12 26 52](https://cloud.githubusercontent.com/assets/6426688/7881743/0d0f8438-05fe-11e5-8068-4ac765340ab6.png)

Europe/Ireland splash pages still shows number with international dialling prefix, they need to call us in the UK at present.
![screen shot 2015-05-29 at 12 27 06](https://cloud.githubusercontent.com/assets/6426688/7881745/0d156312-05fe-11e5-950c-43b059fd9f87.png)
