### PR TITLE
Removing line in German country lead ad

### DIFF
--- a/app/pages/about/jobs/positions/country-lead-de-at.js
+++ b/app/pages/about/jobs/positions/country-lead-de-at.js
@@ -51,9 +51,6 @@ export default class CountryLeadGermanyAustria extends React.Component {
           Launching GoCardless in a new territory will require a depth and breadth of
           skills akin to starting a new company. It's an exciting challenge, and you'll
           benefit from the support and experience of our existing country leads.
-          One of your first tasks will be to start building your team, hiring someone
-          whose strengths complement your own to assist you as you forge a path
-          for success in Germany &amp; Austria.
         </p>
         <h4 className='u-text-s u-margin-Bxs u-margin-Tm'>
           The ideal candidate


### PR DESCRIPTION
@jackfranklin please can you check this?

@moyni removed this line: " One of your first tasks will be to start building your team, hiring someone whose strengths complement your own to assist you as you forge a path for success in Germany & Austria." Spoke to Jutta and we mention building a team in the previous para, so thought looked better to delete rather than explaining that we have one country lead already. Sound ok?