### PR TITLE
Static site generation optimisation

### DIFF
--- a/app/static-build/builder.js
+++ b/app/static-build/builder.js
@@ -1,4 +1,3 @@
-import request from 'superagent';
 import fs from 'fs';
 import { mkdirP as mkdirPCallback } from 'mkdirp';
 import url from 'url';
@@ -7,24 +6,6 @@ import denodeify from 'denodeify';
 
 const mkdirP = denodeify(mkdirPCallback);
 const writeFile = denodeify(fs.writeFile);
-
-export function fetchPage(host, pagePath) {
-  return new Promise(function(resolve, reject) {
-    const pageUrl = host + pagePath;
-
-    request.get(pageUrl).accept('text/html').end(function(err, res) {
-      if (err) {
-        return reject(err);
-      }
-
-      if (res.ok) {
-        resolve([pageUrl, res.text]);
-      } else {
-        reject([pageUrl, res.text]);
-      }
-    });
-  });
-}
 
 export function writePage(baseDir, [pageUrl, content]) {
   const pathname = url.parse(pageUrl).pathname;

--- a/app/static-build/builder.spec.js
+++ b/app/static-build/builder.spec.js
@@ -1,39 +1,13 @@
-import nock from 'nock';
 import fs from 'fs';
 import rimraf from 'rimraf';
 import mkdirPCallback from 'mkdirp';
-import { fetchPage, writePage } from './builder';
+import { writePage } from './builder';
 import denodeify from 'denodeify';
 
 const readdir = denodeify(fs.readdir);
 const readFile = denodeify(fs.readFile);
 const rmdir = denodeify(rimraf);
 const mkdirP = denodeify(mkdirPCallback);
-
-describe('fetchPage', () => {
-  const host = 'http://localhost:1234';
-
-  beforeEach(() => {
-    nock(host)
-    .get('/')
-    .reply(200, '<html>home</html>')
-    .get('/about')
-    .reply(200, '<html>about</html>');
-  });
-
-  afterEach(nock.cleanAll.bind(nock));
-
-  it('resolves [url, body] tuple', (done) => {
-    const path = '/about';
-
-    fetchPage(host, path)
-      .then(function([url, body]) {
-        expect(url).toEqual(`${host}/about`);
-        expect(body).toEqual('<html>about</html>');
-      })
-      .then(done, done.fail);
-  });
-});
 
 describe('writePage', () => {
   beforeEach((done) => {

--- a/script/build-prod
+++ b/script/build-prod
@@ -1,34 +1,17 @@
 #!/bin/sh
 
-PORT='4413'
-
-# check if something is already on our port
-echo exit | nc localhost $PORT
-if [ $? -eq 0 ]; then
-  echo "something is already running on $PORT"
-  exit 1
-fi
-
 set -e errexit
 ulimit -n 10240
 
 rm -rf dist
 ANIMATIONS_DISABLED=$ANIMATIONS_DISABLED node_modules/.bin/webpack --stats --progress --config ./webpack/prod.config.js
 
-PORT=$PORT node ./index.js &
-SERVER_PID=$!
-
 # from this point on if something goes wrong we don't want to immediately exit
 # because we have to make sure we tidy up the server properly and kill the process
 set +e errexit
 
-# wait for the server to start up
-while ! echo exit | nc localhost $PORT; do sleep 1; done
-
-./script/dump-html "http://localhost:$PORT" 'dist'
+./script/dump-html 'dist'
 DUMP_EXIT=$?
-
-kill $SERVER_PID
 
 set -e errexit
 

--- a/script/dump-html
+++ b/script/dump-html
@@ -1,23 +1,24 @@
 #!/usr/bin/env babel-node
 
-import { fetchPage, writePage } from '../app/static-build/builder';
+import { writePage } from '../app/static-build/builder';
 import availableLocales from '../config/available-locales';
 import { getAllPaths } from '../app/router/route-helpers';
+import { render } from '../server/render';
 
-const [bin, script, serverUrl, outDir] = process.argv;
+const [bin, script, outDir] = process.argv;
 
-if (!serverUrl || !outDir) {
-  console.error(`Usage: ${bin} ${script} host directory`);
+if (!outDir) {
+  console.error(`Usage: ${bin} ${script} directory`);
   process.exit(1);
 }
 
 const processPage = function(pagePath) {
-  return fetchPage(serverUrl, pagePath)
+  return render(pagePath)
     .then(writePage.bind(null, outDir))
     .catch(console.error.bind(console));
 };
 
 Promise.all(getAllPaths(availableLocales).map(processPage)).then(function(filenames) {
   console.log('Completed static html dump:');
-  console.log(filenames.sort().map((filename) => `  ${filename}`).join('\n'));
+  console.log(filenames.sort().map((filename) => ` ${filename}`).join('\n'));
 }).catch(console.error.bind(console));

--- a/server/render.js
+++ b/server/render.js
@@ -28,70 +28,91 @@ function normalizeUrl(urlStr) {
   return url.format(parsedUrl);
 }
 
-export function render(req, res, next) {
+export function render(requestUrl) {
+  return new Promise(function(resolve, reject) {
+    const reqUrl = normalizeUrl(requestUrl);
+    const reqPath = url.parse(reqUrl).path;
+    const reqLocale = pathToLocale(reqPath, availableLocales);
+    const routes = getRoutes(reqLocale.normalized, availableLocales);
+    const messages = cloneDeep(localeMessages[reqLocale.normalized]);
+
+    const availableCountryNames = availableLocales.reduce(function(memo, locale) {
+      memo[locale] = getMessage(localeMessages[locale], 'country');
+      return memo;
+    }, {});
+
+    function appProps(props) {
+      return assign({
+        currentLocale: reqLocale.normalized,
+        language: reqLocale.language,
+        messages: messages,
+        formats: formats,
+        config: config,
+        availableLocales: availableLocales,
+        availableCountryNames: availableCountryNames,
+      }, props);
+    }
+
+    const router = Router.create({
+      onAbort: function(abortReason) {
+        reject(abortReason);
+      },
+      onError: function(err) {
+        reject(err);
+      },
+      routes: routes,
+      location: reqUrl,
+    });
+
+    router.run(function(Handler, state) {
+      const routeName = result(findLast(state.routes.slice(), 'name'), 'name');
+      const routeLocales = Object.keys(getLocalesForRouteName(routeName, availableLocales) || {});
+      const stateProps = {
+        routeName: routeName || 'not_found',
+        pathname: state.pathname,
+        routeLocales: routeLocales,
+      };
+
+      const markup = React.renderToString(<Handler {...appProps(stateProps)} />);
+      const webpackUrls = getWebpackPaths();
+
+      // The application component is rendered to static markup
+      // and sent as response.
+      const html = React.renderToStaticMarkup(
+        <HtmlDocument
+          markup={markup}
+          script={webpackUrls.script}
+          css={webpackUrls.css}
+          router={router}
+          dataRender={appProps(stateProps)}
+          {...appProps(stateProps)} />
+      );
+      const doctype = '<!DOCTYPE html>';
+      resolve([requestUrl, doctype + html]);
+    });
+  });
+}
+
+/**
+ * Middle ware used to serve HTML content rendered based on the react-router path.
+ * Content is rendered in form of the index.html page created as a react component.
+ * @param  {Object}   req  Express request object.
+ * @param  {Object}   res  Express response object.
+ * @param  {Function} next Callback passing control to the next handler.
+ */
+export function renderFromRequest(req, res, next) {
+  // Checking if request is for HTML content.
   const isHtml = req.headers.accept && req.accepts('html');
 
   // Skip not found assets
+  // If not request for HTML content, pass control to the next handler.
   if (!isHtml) { return next(); }
 
-  const reqUrl = normalizeUrl(req.url);
-  const reqPath = url.parse(reqUrl).path;
-  const reqLocale = pathToLocale(reqPath, availableLocales);
-  const routes = getRoutes(reqLocale.normalized, availableLocales);
-  const messages = cloneDeep(localeMessages[reqLocale.normalized]);
-
-  const availableCountryNames = availableLocales.reduce(function(memo, locale) {
-    memo[locale] = getMessage(localeMessages[locale], 'country');
-    return memo;
-  }, {});
-
-  function appProps(props) {
-    return assign({
-      currentLocale: reqLocale.normalized,
-      language: reqLocale.language,
-      messages: messages,
-      formats: formats,
-      config: config,
-      availableLocales: availableLocales,
-      availableCountryNames: availableCountryNames,
-    }, props);
-  }
-
-  const router = Router.create({
-    onAbort: function(abortReason) {
-      next(abortReason);
-    },
-    onError: function(err) {
-      next(err);
-    },
-    routes: routes,
-    location: reqUrl,
-  });
-
-  router.run(function(Handler, state) {
-    const routeName = result(findLast(state.routes.slice(), 'name'), 'name');
-    const routeLocales = Object.keys(getLocalesForRouteName(routeName, availableLocales) || {});
-    const stateProps = {
-      routeName: routeName || 'not_found',
-      pathname: state.pathname,
-      routeLocales: routeLocales,
-    };
-
-    const markup = React.renderToString(<Handler {...appProps(stateProps)} />);
-    const webpackUrls = getWebpackPaths();
-
-    // The application component is rendered to static markup
-    // and sent as response.
-    const html = React.renderToStaticMarkup(
-      <HtmlDocument
-        markup={markup}
-        script={webpackUrls.script}
-        css={webpackUrls.css}
-        router={router}
-        dataRender={appProps(stateProps)}
-        {...appProps(stateProps)} />
-    );
-    const doctype = '<!DOCTYPE html>';
-    res.send(doctype + html);
+  render(req.url)
+  .then(([, htmlOutput]) => {
+    res.send(htmlOutput);
+  })
+  .catch(errorReason => {
+    next(errorReason);
   });
 }

--- a/server/server.js
+++ b/server/server.js
@@ -9,7 +9,7 @@ import devEnv from '../config/dev-environment';
 
 import favicon from 'serve-favicon';
 
-import { render } from './render';
+import { renderFromRequest } from './render';
 import availableLocales from '../config/available-locales';
 
 function normalisePort(val) {
@@ -30,7 +30,7 @@ app.use(favicon(path.join(__dirname, '..', 'public', 'favicon.ico')));
 app.use(express.static(path.join(__dirname, '..', 'public')));
 app.use(express.static(path.join(__dirname, '..', 'app')));
 
-app.use(render);
+app.use(renderFromRequest);
 
 app.use(compression());
 app.set('port', normalisePort(process.env.PORT || devEnv.backendPort));


### PR DESCRIPTION
While preparing to exclude your this static page generation i thought of this small optimisation, and I thought you guys might be interested in it.

I am sending this PR mainly for the purposes of the peer review to see if I didn't miss any reasons why you used express in your static page generation process,
and to see if it could indeed be skipped, like I did here.

Thanks in advance for any feedback.

Static page rendering optimisation
- Bypassing express server in static site generation,
- dump-html now uses the same render function, as the express middleware,
- removed fetchPage method, as it was now not required,
- simplified build-prod script to only run production web pack build, and html-dump, no express sever in the middle.
