### PR TITLE
Output dataLayer variable for Google Tag Manager & Google Analytics

### DIFF
--- a/app/client/bootstrap.js
+++ b/app/client/bootstrap.js
@@ -8,6 +8,7 @@ import Router from 'react-router';
 import { getRoutes, getLocalesForRouteName } from '../router/route-helpers';
 import { pushDataLayer } from '../helpers/gtm-tracker/gtm-tracker';
 import { isHostBlacklisted } from '../../config/blacklisted-origins';
+import { localeToLanguage, localeToRegion } from '../helpers/locale-helper/locale-helper';
 
 if (process.env.BROWSER) {
   require('../css/main.scss');
@@ -47,6 +48,9 @@ function renderApp() {
     React.render(<Handler {...stateProps} />, mountNode, () => {
       console.log('App has been mounted. Logging pageview.');
       pushDataLayer({
+        pageType: 'splash-pages',
+        pageLanguage: localeToLanguage(appState.currentLocale),
+        pageRegion: localeToRegion(appState.currentLocale),
         event: 'pageview',
         title: document.title,
         virtualUrl: state.pathname,

--- a/app/components/html-document/html-document.js
+++ b/app/components/html-document/html-document.js
@@ -141,9 +141,11 @@ class HtmlDocument extends React.Component {
           }
 
           { config.googleTagManagerId &&
-              <div dangerouslySetInnerHTML={{__html: GTM.replace('{TAG_ID}', config.googleTagManagerId)
+              <div dangerouslySetInnerHTML={{
+                __html: GTM.replace('{TAG_ID}', config.googleTagManagerId)
                 .replace('{PAGE_LANGUAGE}', language)
-                .replace('{PAGE_REGION}', region) }} />
+                .replace('{PAGE_REGION}', region),
+              }} />
           }
         </body>
       </html>

--- a/app/components/html-document/html-document.js
+++ b/app/components/html-document/html-document.js
@@ -8,7 +8,7 @@ import websiteSchema from '../layout-static/website-schema';
 import getSiteTitle from '../get-site-title/get-site-title';
 import { getMessage } from '../intl/intl';
 import localeMessages from '../../../config/messages';
-import { defaultLocale, localeToLanguage } from '../../helpers/locale-helper/locale-helper';
+import { defaultLocale, localeToLanguage, localeToRegion } from '../../helpers/locale-helper/locale-helper';
 import { homeRoute } from '../../router/routes';
 import { getLocalesForRouteName } from '../../router/route-helpers';
 import { buildSchemaDotOrgForOrganization } from '../../helpers/schema-dot-org/schema-dot-org';
@@ -92,6 +92,7 @@ class HtmlDocument extends React.Component {
     const pageHref = config.siteRoot + pathname;
     const title = getSiteTitle({ messages, routeName, config });
     const language = localeToLanguage(currentLocale);
+    const region = localeToRegion(currentLocale);
     const description = getMessage(messages, `${routeName}.description`);
 
     return (
@@ -140,7 +141,9 @@ class HtmlDocument extends React.Component {
           }
 
           { config.googleTagManagerId &&
-              <div dangerouslySetInnerHTML={{__html: GTM.replace('{TAG_ID}', config.googleTagManagerId) }} />
+              <div dangerouslySetInnerHTML={{__html: GTM.replace('{TAG_ID}', config.googleTagManagerId)
+                .replace('{PAGE_LANGUAGE}', language)
+                .replace('{PAGE_REGION}', region) }} />
           }
         </body>
       </html>

--- a/app/components/layout-static/google-tag-manager.js
+++ b/app/components/layout-static/google-tag-manager.js
@@ -1,5 +1,9 @@
 const GTM = `<script>
-  dataLayer = [];
+  dataLayer = [{
+    pageType: 'splash-pages',
+    pageLanguage: '{PAGE_LANGUAGE}',
+    pageRegion: '{PAGE_REGION}',
+  }];
 </script>
 <script src="//www.googletagmanager.com/gtm.js?id={TAG_ID}" async></script>
 <script>

--- a/config/development.js
+++ b/config/development.js
@@ -1,3 +1,4 @@
 export default {
+  googleTagManagerId: 'GTM-PRFKNC',
   siteRoot: 'http://localhost:4402',
 };


### PR DESCRIPTION
At present, our GTM & GA setups are rather complex and difficult to maintain (we use all kinds of regexps, custom javascripts, etc to determine country, type of content, etc). We also use complex regexps to filter information into different GA profiles (no longer a scalable solution).

Along with https://github.com/gocardless/guides/pull/227 and https://github.com/gocardless/blog/pull/239, this PR outputs a dataLayer variable with useful stuff for GTM & GA. It should be merged concurrently with version 69 of the tag manager container which contains a refactoring to make use of the new variables.