### PR TITLE
Output an XML Sitemap From Splash Pages - v2

### DIFF
--- a/app/static-build/sitemap.js
+++ b/app/static-build/sitemap.js
@@ -1,0 +1,150 @@
+import url from 'url';
+const cheerio = require('cheerio');
+const crypto = require('crypto');
+
+/**
+ * Creates a new sitemapUrlSet object.
+ * e.g. var sitemap = new sitemapUrlSet('http://example.com')
+ *
+ * @class
+ * @param {string} domain - Domain to which the sitemap refers e.g. https://example.com
+ */
+export class sitemapUrlSet {
+  constructor(domain) {
+    this.urlSet = {};
+    this.domain = domain;
+  }
+
+  /**
+   * Loads in an existing XML Sitemap and returns a sitemapUrlSet object.
+   * e.g. var currentSitemap = new sitemapUrlSet('http://example.com').fromXml(xmlFileContents)
+   *
+   * @param {string} xml - Sitemap in XML format
+   * @returns {sitemapUrlSet} A sitemapUrlSet object representing the sitemap.
+   */
+  fromXml(xml) {
+    var sitemapUrlSet = this;
+    var $ = cheerio.load(xml);
+    var sitemapUrls = $('url');
+    sitemapUrls.each(function(i, element) {
+      var location = $(this).find('loc').text();
+      if (location) {
+        var pathName = url.parse(location).pathname;
+        var hash = $(this).find('content\\:hash').text();
+        var lastMod = Date.parse($(this).find('lastmod').text());
+        sitemapUrlSet.urlSet[pathName] = {
+          'hash': hash,
+          'lastMod': lastMod,
+        };
+      }
+    });
+    return sitemapUrlSet;
+  }
+
+  /**
+   * Returns an XML representation of the current sitemapUrlSet object.
+   *
+   * @returns {string} A XML format representation of the sitemapUrlSet object.
+   */
+  toXml() {
+    var xml = "<?xml version='1.0' encoding='UTF-8'?>\n"
+            + "<urlset xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'\n"
+            + "  xsi:schemaLocation='http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd'\n"
+            + "  xmlns='http://www.sitemaps.org/schemas/sitemap/0.9'\n"
+            + "  xmlns:xhtml='http://www.w3.org/1999/xhtml'\n"
+            + "  xmlns:content='https://github.com/gocardless/splash-pages#xml-sitemap-hash'>\n";
+    for (url in this.urlSet) {
+      var lastMod = new Date(this.urlSet[url]['lastMod']);
+      var lastMod_w3 = lastMod.toISOString().substring(0,10); // Date should be in W3C Datetime (YYYY-MM-DD) format
+      xml += `  <url>\n`
+          +  `    <loc>${this.domain}${url}</loc>\n`
+          +  `    <content:hash>${this.urlSet[url]['hash']}</content:hash>\n`
+          +  `    <lastmod>${lastMod_w3}</lastmod>\n`
+          +  `  </url>\n`;
+    }
+    xml += '</urlset>'
+    return xml;
+  }
+
+  /**
+   * Add a URL to the sitemap.
+   * e.g. sitemap.addUrl('http://www.example.com/about/', 'About Page Contents')
+   *
+   * @param {string} pageUrl - URL of the page to add to the sitemap
+   * @param {string} content - HTML contents of the page
+   */
+  addUrl(pageUrl, content) {
+    const pathName = url.parse(pageUrl).pathname;
+    const pageHash = getHashOfContent(content);
+    this.urlSet[pathName] = {
+      'hash': pageHash,
+      'lastMod': Date.now(),
+    }
+  }
+
+  /**
+   * Extracts a URL from the sitemap.
+   * e.g. var aboutPage = sitemap.getUrl('http://www.example.com/about/')
+   *
+   * @param {string} pageUrl - URL of the page to add to the sitemap
+   * @return {{Object|boolean}} Returns URL info if exists in the sitemap; otherwise returns false 
+   */
+  getUrl(pageUrl) {
+    const pathName = url.parse(pageUrl).pathname;
+    if (pathName in this.urlSet) {
+      return this.urlSet[pathName];
+    }
+    return false;
+  }
+
+  /**
+   * Removes a URL from the sitemap.
+   * e.g. sitemap.removeUrl('http://www.example.com/about/')
+   *
+   * @param {string} pageUrl - URL of the page to remove from the sitemap
+   * @return {boolean} Returns true if page was removed from sitemap; otherwise returns false
+   */
+  removeUrl(pageUrl) {
+    const pathName = url.parse(pageUrl).pathname;
+    if (pathName in this.urlSet) {
+      delete this.urlSet[pathName];
+      return true
+    }
+    return false;
+  }
+
+  /**
+   * Imports the timestamps from an old sitemap when the content is unchanged.
+   * e.g. newSitemap.importTimestampsFromOldSitemap(oldSitemap)
+   *
+   * @param {sitemapUrlSet} oldSitemap - A sitemapUrlSet object for the old sitemap
+   * @returns {sitemapUrlSet} A sitemapUrlSet object with imported timestamps from the old sitemap.
+   */
+  importTimestampsFromOldSitemap(oldSitemap) {
+    for (url in this.urlSet) {
+      if (url in oldSitemap.urlSet) {
+        var oldUrl = oldSitemap.urlSet[url];
+        var newUrl = this.urlSet[url];
+        if (oldUrl['hash'] === newUrl['hash']) {
+          newUrl['lastMod'] = Math.min(newUrl['lastMod'], oldUrl['lastMod']);
+        }
+      }
+    }
+    return this;
+  }
+}
+
+/**
+ * Returns a md5 hash representation of the content.
+ * Will remove script tags and other HTML before generating the hash.
+ *
+ * @param {string} content - HTML content of the page.
+ * @returns {string} md5 hash representation of the content of the page
+ */
+function getHashOfContent(content) {
+  content = content.replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '');
+  var $ = cheerio.load(content);
+  var bodyText = $('body').text();
+  var cryptoHash = crypto.createHash('md5').update(bodyText).digest('hex');
+  return cryptoHash;
+}

--- a/app/static-build/sitemap.js
+++ b/app/static-build/sitemap.js
@@ -15,14 +15,14 @@ export function downloadOldSitemap(host, sitemapUrl) {
     request.get(sitemapUrl).buffer().end(function(err, res) {
       if (err) {
         console.log(`Error downloading old sitemap from ${sitemapUrl}: ${err}. Continuing anyway (all pages may have lastMod of today).`);
-        return resolve(new SitemapUrlSet(host));
+        return resolve(new Sitemap(host));
       }
       if (res.ok) {
         console.log(`Downloaded old sitemap from ${sitemapUrl}.`);
-        resolve(new SitemapUrlSet(host).fromXml(res.text));
+        resolve(new Sitemap(host).fromXml(res.text));
       } else {
         console.log(`Error downloading old sitemap from ${sitemapUrl}: !res.ok. Continuing anyway (all pages may have lastMod of today).`);
-        resolve(new SitemapUrlSet(host));
+        resolve(new Sitemap(host));
       }
     });
   });
@@ -45,24 +45,24 @@ function getHashOfContent(content) {
 }
 
 /**
- * Creates a new SitemapUrlSet object.
- * e.g. let sitemap = new SitemapUrlSet('http://example.com')
+ * Creates a new Sitemap object.
+ * e.g. const sitemap = new Sitemap('http://example.com')
  *
  * @class
  * @param {string} domain - Domain to which the sitemap refers e.g. https://example.com
  */
-export class SitemapUrlSet {
+export class Sitemap {
   constructor(domain) {
     this.urlSet = {};
     this.domain = domain;
   }
 
   /**
-   * Loads in an existing XML Sitemap and returns a SitemapUrlSet object.
-   * e.g. let currentSitemap = new SitemapUrlSet('http://example.com').fromXml(xmlFileContents)
+   * Loads in an existing XML Sitemap and returns a Sitemap object.
+   * e.g. let currentSitemap = new Sitemap('http://example.com').fromXml(xmlFileContents)
    *
    * @param {string} xml - Sitemap in XML format
-   * @returns {SitemapUrlSet} A SitemapUrlSet object representing the sitemap.
+   * @returns {Sitemap} A Sitemap object representing the sitemap.
    */
   fromXml(xml) {
     const $ = cheerio.load(xml);
@@ -84,9 +84,9 @@ export class SitemapUrlSet {
   }
 
   /**
-   * Returns an XML representation of the current SitemapUrlSet object.
+   * Returns an XML representation of the current Sitemap object.
    *
-   * @returns {string} A XML format representation of the SitemapUrlSet object.
+   * @returns {string} A XML format representation of the Sitemap object.
    */
   toXml() {
     /*eslint-disable max-len*/
@@ -162,8 +162,8 @@ export class SitemapUrlSet {
    * Imports the timestamps from an old sitemap when the content is unchanged.
    * e.g. newSitemap.importTimestampsFromOldSitemap(oldSitemap)
    *
-   * @param {SitemapUrlSet} oldSitemap - A SitemapUrlSet object for the old sitemap
-   * @returns {SitemapUrlSet} A SitemapUrlSet object with imported timestamps from the old sitemap.
+   * @param {Sitemap} oldSitemap - A Sitemap object for the old sitemap
+   * @returns {Sitemap} A Sitemap object with imported timestamps from the old sitemap.
    */
   importTimestampsFromOldSitemap(oldSitemap) {
     for (url in this.urlSet) {

--- a/app/static-build/sitemap.js
+++ b/app/static-build/sitemap.js
@@ -11,15 +11,15 @@ const crypto = require('crypto');
  */
 function getHashOfContent(content) {
   content = content.replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '');
-  var $ = cheerio.load(content);
-  var bodyText = $('body').text();
-  var cryptoHash = crypto.createHash('md5').update(bodyText).digest('hex');
+  const $ = cheerio.load(content);
+  const bodyText = $('body').text();
+  const cryptoHash = crypto.createHash('md5').update(bodyText).digest('hex');
   return cryptoHash;
 }
 
 /**
  * Creates a new SitemapUrlSet object.
- * e.g. var sitemap = new SitemapUrlSet('http://example.com')
+ * e.g. let sitemap = new SitemapUrlSet('http://example.com')
  *
  * @class
  * @param {string} domain - Domain to which the sitemap refers e.g. https://example.com
@@ -32,21 +32,21 @@ export class SitemapUrlSet {
 
   /**
    * Loads in an existing XML Sitemap and returns a SitemapUrlSet object.
-   * e.g. var currentSitemap = new SitemapUrlSet('http://example.com').fromXml(xmlFileContents)
+   * e.g. let currentSitemap = new SitemapUrlSet('http://example.com').fromXml(xmlFileContents)
    *
    * @param {string} xml - Sitemap in XML format
    * @returns {SitemapUrlSet} A SitemapUrlSet object representing the sitemap.
    */
   fromXml(xml) {
-    var $ = cheerio.load(xml);
-    var sitemapUrls = $('url');
+    const $ = cheerio.load(xml);
+    const sitemapUrls = $('url');
     sitemapUrls.each((i, element) => {
       let currentUrlElement = $(element);
-      var location = currentUrlElement.find('loc').text();
+      let location = currentUrlElement.find('loc').text();
       if (location) {
-        var pathName = url.parse(location).pathname;
-        var hash = currentUrlElement.find('content\\:hash').text();
-        var lastMod = Date.parse(currentUrlElement.find('lastmod').text());
+        let pathName = url.parse(location).pathname;
+        let hash = currentUrlElement.find('content\\:hash').text();
+        let lastMod = Date.parse(currentUrlElement.find('lastmod').text());
         this.urlSet[pathName] = {
           hash: hash,
           lastMod: lastMod,
@@ -63,7 +63,7 @@ export class SitemapUrlSet {
    */
   toXml() {
     /*eslint-disable max-len*/
-    var xml = '<?xml version="1.0" encoding="UTF-8"?>\n' +
+    let xml = '<?xml version="1.0" encoding="UTF-8"?>\n' +
               '<urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"\n' +
               '  xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd"\n' +
               '  xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"\n' +
@@ -71,9 +71,9 @@ export class SitemapUrlSet {
               '  xmlns:content="https://github.com/gocardless/splash-pages#xml-sitemap-hash">\n';
     /*eslint-enable max-len*/
     for (let pageUrl in this.urlSet) {
-      var lastMod = new Date(this.urlSet[pageUrl].lastMod);
+      let lastMod = new Date(this.urlSet[pageUrl].lastMod);
       // Date should be in W3C Datetime (YYYY-MM-DD) format
-      var lastModW3 = lastMod.toISOString().substring(0,10);
+      let lastModW3 = lastMod.toISOString().substring(0,10);
       xml += `  <url>\n` +
              `    <loc>${this.domain}${pageUrl}</loc>\n` +
              `    <content:hash>${this.urlSet[pageUrl].hash}</content:hash>\n` +
@@ -102,7 +102,7 @@ export class SitemapUrlSet {
 
   /**
    * Extracts a URL from the sitemap.
-   * e.g. var aboutPage = sitemap.getUrl('http://www.example.com/about/')
+   * e.g. const aboutPage = sitemap.getUrl('http://www.example.com/about/')
    *
    * @param {string} pageUrl - URL of the page to add to the sitemap
    * @return {{Object|boolean}} Returns URL info if exists in the sitemap; otherwise returns false
@@ -141,8 +141,8 @@ export class SitemapUrlSet {
   importTimestampsFromOldSitemap(oldSitemap) {
     for (url in this.urlSet) {
       if (url in oldSitemap.urlSet) {
-        var oldUrl = oldSitemap.urlSet[url];
-        var newUrl = this.urlSet[url];
+        let oldUrl = oldSitemap.urlSet[url];
+        let newUrl = this.urlSet[url];
         if (oldUrl.hash === newUrl.hash) {
           newUrl.lastMod = Math.min(newUrl.lastMod, oldUrl.lastMod);
         }

--- a/app/static-build/sitemap.js
+++ b/app/static-build/sitemap.js
@@ -10,8 +10,9 @@ const crypto = require('crypto');
  * @returns {string} md5 hash representation of the content of the page
  */
 function getHashOfContent(content) {
-  content = content.replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '');
   const $ = cheerio.load(content);
+  $('script').remove();
+  $('style').remove();
   const bodyText = $('body').text();
   const cryptoHash = crypto.createHash('md5').update(bodyText).digest('hex');
   return cryptoHash;

--- a/app/static-build/sitemap.js
+++ b/app/static-build/sitemap.js
@@ -3,6 +3,21 @@ const cheerio = require('cheerio');
 const crypto = require('crypto');
 
 /**
+ * Returns a md5 hash representation of the content.
+ * Will remove script tags and other HTML before generating the hash.
+ *
+ * @param {string} content - HTML content of the page.
+ * @returns {string} md5 hash representation of the content of the page
+ */
+function getHashOfContent(content) {
+  content = content.replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '');
+  var $ = cheerio.load(content);
+  var bodyText = $('body').text();
+  var cryptoHash = crypto.createHash('md5').update(bodyText).digest('hex');
+  return cryptoHash;
+}
+
+/**
  * Creates a new sitemapUrlSet object.
  * e.g. var sitemap = new sitemapUrlSet('http://example.com')
  *
@@ -23,22 +38,22 @@ export class sitemapUrlSet {
    * @returns {sitemapUrlSet} A sitemapUrlSet object representing the sitemap.
    */
   fromXml(xml) {
-    var sitemapUrlSet = this;
+    var thisSitemap = this;
     var $ = cheerio.load(xml);
     var sitemapUrls = $('url');
-    sitemapUrls.each(function(i, element) {
+    sitemapUrls.each(function() {
       var location = $(this).find('loc').text();
       if (location) {
         var pathName = url.parse(location).pathname;
         var hash = $(this).find('content\\:hash').text();
         var lastMod = Date.parse($(this).find('lastmod').text());
-        sitemapUrlSet.urlSet[pathName] = {
-          'hash': hash,
-          'lastMod': lastMod,
+        thisSitemap.urlSet[pathName] = {
+          hash: hash,
+          lastMod: lastMod,
         };
       }
     });
-    return sitemapUrlSet;
+    return thisSitemap;
   }
 
   /**
@@ -47,22 +62,25 @@ export class sitemapUrlSet {
    * @returns {string} A XML format representation of the sitemapUrlSet object.
    */
   toXml() {
-    var xml = "<?xml version='1.0' encoding='UTF-8'?>\n"
-            + "<urlset xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'\n"
-            + "  xsi:schemaLocation='http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd'\n"
-            + "  xmlns='http://www.sitemaps.org/schemas/sitemap/0.9'\n"
-            + "  xmlns:xhtml='http://www.w3.org/1999/xhtml'\n"
-            + "  xmlns:content='https://github.com/gocardless/splash-pages#xml-sitemap-hash'>\n";
+    /*eslint-disable max-len*/
+    var xml = '<?xml version="1.0" encoding="UTF-8"?>\n' +
+              '<urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"\n' +
+              '  xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd"\n' +
+              '  xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"\n' +
+              '  xmlns:xhtml="http://www.w3.org/1999/xhtml"\n' +
+              '  xmlns:content="https://github.com/gocardless/splash-pages#xml-sitemap-hash">\n';
+    /*eslint-enable max-len*/
     for (url in this.urlSet) {
-      var lastMod = new Date(this.urlSet[url]['lastMod']);
-      var lastMod_w3 = lastMod.toISOString().substring(0,10); // Date should be in W3C Datetime (YYYY-MM-DD) format
-      xml += `  <url>\n`
-          +  `    <loc>${this.domain}${url}</loc>\n`
-          +  `    <content:hash>${this.urlSet[url]['hash']}</content:hash>\n`
-          +  `    <lastmod>${lastMod_w3}</lastmod>\n`
-          +  `  </url>\n`;
+      var lastMod = new Date(this.urlSet[url].lastMod);
+      // Date should be in W3C Datetime (YYYY-MM-DD) format
+      var lastModW3 = lastMod.toISOString().substring(0,10);
+      xml += `  <url>\n` +
+             `    <loc>${this.domain}${url}</loc>\n` +
+             `    <content:hash>${this.urlSet[url].hash}</content:hash>\n` +
+             `    <lastmod>${lastModW3}</lastmod>\n` +
+             `  </url>\n`;
     }
-    xml += '</urlset>'
+    xml += '</urlset>';
     return xml;
   }
 
@@ -77,9 +95,9 @@ export class sitemapUrlSet {
     const pathName = url.parse(pageUrl).pathname;
     const pageHash = getHashOfContent(content);
     this.urlSet[pathName] = {
-      'hash': pageHash,
-      'lastMod': Date.now(),
-    }
+      hash: pageHash,
+      lastMod: Date.now(),
+    };
   }
 
   /**
@@ -87,7 +105,7 @@ export class sitemapUrlSet {
    * e.g. var aboutPage = sitemap.getUrl('http://www.example.com/about/')
    *
    * @param {string} pageUrl - URL of the page to add to the sitemap
-   * @return {{Object|boolean}} Returns URL info if exists in the sitemap; otherwise returns false 
+   * @return {{Object|boolean}} Returns URL info if exists in the sitemap; otherwise returns false
    */
   getUrl(pageUrl) {
     const pathName = url.parse(pageUrl).pathname;
@@ -108,7 +126,7 @@ export class sitemapUrlSet {
     const pathName = url.parse(pageUrl).pathname;
     if (pathName in this.urlSet) {
       delete this.urlSet[pathName];
-      return true
+      return true;
     }
     return false;
   }
@@ -125,26 +143,11 @@ export class sitemapUrlSet {
       if (url in oldSitemap.urlSet) {
         var oldUrl = oldSitemap.urlSet[url];
         var newUrl = this.urlSet[url];
-        if (oldUrl['hash'] === newUrl['hash']) {
-          newUrl['lastMod'] = Math.min(newUrl['lastMod'], oldUrl['lastMod']);
+        if (oldUrl.hash === newUrl.hash) {
+          newUrl.lastMod = Math.min(newUrl.lastMod, oldUrl.lastMod);
         }
       }
     }
     return this;
   }
-}
-
-/**
- * Returns a md5 hash representation of the content.
- * Will remove script tags and other HTML before generating the hash.
- *
- * @param {string} content - HTML content of the page.
- * @returns {string} md5 hash representation of the content of the page
- */
-function getHashOfContent(content) {
-  content = content.replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '');
-  var $ = cheerio.load(content);
-  var bodyText = $('body').text();
-  var cryptoHash = crypto.createHash('md5').update(bodyText).digest('hex');
-  return cryptoHash;
 }

--- a/app/static-build/sitemap.js
+++ b/app/static-build/sitemap.js
@@ -38,22 +38,22 @@ export class SitemapUrlSet {
    * @returns {SitemapUrlSet} A SitemapUrlSet object representing the sitemap.
    */
   fromXml(xml) {
-    var thisSitemap = this;
     var $ = cheerio.load(xml);
     var sitemapUrls = $('url');
-    sitemapUrls.each(function() {
-      var location = $(this).find('loc').text();
+    sitemapUrls.each((i, element) => {
+      let currentUrlElement = $(element);
+      var location = currentUrlElement.find('loc').text();
       if (location) {
         var pathName = url.parse(location).pathname;
-        var hash = $(this).find('content\\:hash').text();
-        var lastMod = Date.parse($(this).find('lastmod').text());
-        thisSitemap.urlSet[pathName] = {
+        var hash = currentUrlElement.find('content\\:hash').text();
+        var lastMod = Date.parse(currentUrlElement.find('lastmod').text());
+        this.urlSet[pathName] = {
           hash: hash,
           lastMod: lastMod,
         };
       }
     });
-    return thisSitemap;
+    return this;
   }
 
   /**

--- a/app/static-build/sitemap.js
+++ b/app/static-build/sitemap.js
@@ -166,15 +166,14 @@ export class Sitemap {
    * @returns {Sitemap} A Sitemap object with imported timestamps from the old sitemap.
    */
   importTimestampsFromOldSitemap(oldSitemap) {
-    for (url in this.urlSet) {
-      if (url in oldSitemap.urlSet) {
-        let oldUrl = oldSitemap.urlSet[url];
-        let newUrl = this.urlSet[url];
-        if (oldUrl.hash === newUrl.hash) {
-          newUrl.lastMod = Math.min(newUrl.lastMod, oldUrl.lastMod);
-        }
-      }
-    }
+    Object.keys(this.urlSet)
+      .filter((pathName) => oldSitemap.urlSet[pathName])
+      .filter((pathName) => oldSitemap.urlSet[pathName].hash === this.urlSet[pathName].hash)
+      .forEach((pathName) => {
+        const oldUrl = oldSitemap.urlSet[pathName];
+        const newUrl = this.urlSet[pathName];
+        newUrl.lastMod = Math.min(newUrl.lastMod, oldUrl.lastMod);
+      });
     return this;
   }
 }

--- a/app/static-build/sitemap.js
+++ b/app/static-build/sitemap.js
@@ -1,6 +1,32 @@
 import url from 'url';
+import request from 'superagent';
 const cheerio = require('cheerio');
 const crypto = require('crypto');
+
+/**
+ * Downloads an old version of the sitemap using Superagent.
+ * e.g. downloadOldSitemap('https://gocardless.com', 'https://gocardless.com/sitemap.xml').then((oldSitemap) => { console.log(oldSitemap) })
+ *
+ * @param {string} host - Domain name to which the sitemap refers
+ * @param {string} sitemapUrl - URL at which the sitemap can be found
+ */
+export function downloadOldSitemap(host, sitemapUrl) {
+  return new Promise(function(resolve) {
+    request.get(sitemapUrl).buffer().end(function(err, res) {
+      if (err) {
+        console.log(`Error downloading old sitemap from ${sitemapUrl}: ${err}. Continuing anyway (all pages may have lastMod of today).`);
+        return resolve(new SitemapUrlSet(host));
+      }
+      if (res.ok) {
+        console.log(`Downloaded old sitemap from ${sitemapUrl}.`);
+        resolve(new SitemapUrlSet(host).fromXml(res.text));
+      } else {
+        console.log(`Error downloading old sitemap from ${sitemapUrl}: !res.ok. Continuing anyway (all pages may have lastMod of today).`);
+        resolve(new SitemapUrlSet(host));
+      }
+    });
+  });
+}
 
 /**
  * Returns a md5 hash representation of the content.

--- a/app/static-build/sitemap.js
+++ b/app/static-build/sitemap.js
@@ -18,24 +18,24 @@ function getHashOfContent(content) {
 }
 
 /**
- * Creates a new sitemapUrlSet object.
- * e.g. var sitemap = new sitemapUrlSet('http://example.com')
+ * Creates a new SitemapUrlSet object.
+ * e.g. var sitemap = new SitemapUrlSet('http://example.com')
  *
  * @class
  * @param {string} domain - Domain to which the sitemap refers e.g. https://example.com
  */
-export class sitemapUrlSet {
+export class SitemapUrlSet {
   constructor(domain) {
     this.urlSet = {};
     this.domain = domain;
   }
 
   /**
-   * Loads in an existing XML Sitemap and returns a sitemapUrlSet object.
-   * e.g. var currentSitemap = new sitemapUrlSet('http://example.com').fromXml(xmlFileContents)
+   * Loads in an existing XML Sitemap and returns a SitemapUrlSet object.
+   * e.g. var currentSitemap = new SitemapUrlSet('http://example.com').fromXml(xmlFileContents)
    *
    * @param {string} xml - Sitemap in XML format
-   * @returns {sitemapUrlSet} A sitemapUrlSet object representing the sitemap.
+   * @returns {SitemapUrlSet} A SitemapUrlSet object representing the sitemap.
    */
   fromXml(xml) {
     var thisSitemap = this;
@@ -57,9 +57,9 @@ export class sitemapUrlSet {
   }
 
   /**
-   * Returns an XML representation of the current sitemapUrlSet object.
+   * Returns an XML representation of the current SitemapUrlSet object.
    *
-   * @returns {string} A XML format representation of the sitemapUrlSet object.
+   * @returns {string} A XML format representation of the SitemapUrlSet object.
    */
   toXml() {
     /*eslint-disable max-len*/
@@ -70,13 +70,13 @@ export class sitemapUrlSet {
               '  xmlns:xhtml="http://www.w3.org/1999/xhtml"\n' +
               '  xmlns:content="https://github.com/gocardless/splash-pages#xml-sitemap-hash">\n';
     /*eslint-enable max-len*/
-    for (url in this.urlSet) {
-      var lastMod = new Date(this.urlSet[url].lastMod);
+    for (let pageUrl in this.urlSet) {
+      var lastMod = new Date(this.urlSet[pageUrl].lastMod);
       // Date should be in W3C Datetime (YYYY-MM-DD) format
       var lastModW3 = lastMod.toISOString().substring(0,10);
       xml += `  <url>\n` +
-             `    <loc>${this.domain}${url}</loc>\n` +
-             `    <content:hash>${this.urlSet[url].hash}</content:hash>\n` +
+             `    <loc>${this.domain}${pageUrl}</loc>\n` +
+             `    <content:hash>${this.urlSet[pageUrl].hash}</content:hash>\n` +
              `    <lastmod>${lastModW3}</lastmod>\n` +
              `  </url>\n`;
     }
@@ -135,8 +135,8 @@ export class sitemapUrlSet {
    * Imports the timestamps from an old sitemap when the content is unchanged.
    * e.g. newSitemap.importTimestampsFromOldSitemap(oldSitemap)
    *
-   * @param {sitemapUrlSet} oldSitemap - A sitemapUrlSet object for the old sitemap
-   * @returns {sitemapUrlSet} A sitemapUrlSet object with imported timestamps from the old sitemap.
+   * @param {SitemapUrlSet} oldSitemap - A SitemapUrlSet object for the old sitemap
+   * @returns {SitemapUrlSet} A SitemapUrlSet object with imported timestamps from the old sitemap.
    */
   importTimestampsFromOldSitemap(oldSitemap) {
     for (url in this.urlSet) {

--- a/app/static-build/sitemap.spec.js
+++ b/app/static-build/sitemap.spec.js
@@ -1,4 +1,4 @@
-import { SitemapUrlSet } from './sitemap';
+import { Sitemap } from './sitemap';
 
 const sitemapXmlHeader = '<?xml version="1.0" encoding="UTF-8"?>\n' +
   '<urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"\n' +
@@ -59,34 +59,34 @@ const updatedSitemapAfterChangeJs = {
   },
 };
 
-describe('SitemapUrlSet component', () => {
+describe('Sitemap component', () => {
   describe('constructor', () => {
-    it('returns a SitemapUrlSet with no entries', () => {
-      var blankSitemap = new SitemapUrlSet('http://example.com');
+    it('returns a Sitemap with no entries', () => {
+      var blankSitemap = new Sitemap('http://example.com');
       expect(blankSitemap.urlSet).toEqual(exampleSitemapWithNoPagesJs);
     });
   });
 
   describe('fromXml', () => {
-    it('returns a SitemapUrlSet with the right entries', () => {
-      var sitemapWithNoPages = new SitemapUrlSet('http://example.com').fromXml(exampleSitemapWithNoPagesXml);
+    it('returns a Sitemap with the right entries', () => {
+      var sitemapWithNoPages = new Sitemap('http://example.com').fromXml(exampleSitemapWithNoPagesXml);
       expect(sitemapWithNoPages.urlSet).toEqual(exampleSitemapWithNoPagesJs);
-      var sitemapWithOnePage = new SitemapUrlSet('http://example.com').fromXml(exampleSitemapWithOnePageXml);
+      var sitemapWithOnePage = new Sitemap('http://example.com').fromXml(exampleSitemapWithOnePageXml);
       expect(sitemapWithOnePage.urlSet).toEqual(exampleSitemapWithOnePageJs);
-      var sitemapWithTwoPages = new SitemapUrlSet('http://example.com').fromXml(exampleSitemapWithTwoPagesXml);
+      var sitemapWithTwoPages = new Sitemap('http://example.com').fromXml(exampleSitemapWithTwoPagesXml);
       expect(sitemapWithTwoPages.urlSet).toEqual(exampleSitemapWithTwoPagesJs);
     });
   });
 
   describe('toXml', () => {
-    it('returns the appropiate XML for the SitemapUrlSet', () => {
-      var sitemapWithNoPages = new SitemapUrlSet('http://example.com');
+    it('returns the appropiate XML for the Sitemap', () => {
+      var sitemapWithNoPages = new Sitemap('http://example.com');
       sitemapWithNoPages.urlSet = exampleSitemapWithNoPagesJs;
       expect(sitemapWithNoPages.toXml()).toEqual(exampleSitemapWithNoPagesXml);
-      var sitemapWithOnePage = new SitemapUrlSet('http://example.com');
+      var sitemapWithOnePage = new Sitemap('http://example.com');
       sitemapWithOnePage.urlSet = exampleSitemapWithOnePageJs;
       expect(sitemapWithOnePage.toXml()).toEqual(exampleSitemapWithOnePageXml);
-      var sitemapWithTwoPages = new SitemapUrlSet('http://example.com');
+      var sitemapWithTwoPages = new Sitemap('http://example.com');
       sitemapWithTwoPages.urlSet = exampleSitemapWithTwoPagesJs;
       expect(sitemapWithTwoPages.toXml()).toEqual(exampleSitemapWithTwoPagesXml);
     });
@@ -95,7 +95,7 @@ describe('SitemapUrlSet component', () => {
   describe('addUrl', () => {
     it('adds the URL correctly to the sitemap', () => {
       jasmine.clock().mockDate(new Date(2015, 0, 1));
-      var sitemap = new SitemapUrlSet('http://example.com');
+      var sitemap = new Sitemap('http://example.com');
       sitemap.addUrl('http://example.com/about/', '<html><body>About Page Contents</body></html>');
       expect(sitemap.urlSet).toEqual(exampleSitemapWithOnePageJs);
       jasmine.clock().mockDate(new Date(2015, 1, 1));
@@ -105,8 +105,8 @@ describe('SitemapUrlSet component', () => {
   });
 
   describe('getUrl', () => {
-    it('returns the URL correctly from SitemapUrlSet', () => {
-      var sitemap = new SitemapUrlSet('http://example.com');
+    it('returns the URL correctly from Sitemap', () => {
+      var sitemap = new Sitemap('http://example.com');
       sitemap.urlSet = exampleSitemapWithOnePageJs;
       expect(sitemap.getUrl('http://example.com/about/')).toEqual(exampleSitemapWithOnePageJs['/about/']);
     });
@@ -114,7 +114,7 @@ describe('SitemapUrlSet component', () => {
 
   describe('removeUrl', () => {
     it('removes the URL correctly from the sitemap', () => {
-      var sitemap = new SitemapUrlSet('http://example.com');
+      var sitemap = new Sitemap('http://example.com');
       sitemap.urlSet = exampleSitemapWithTwoPagesJs;
       sitemap.removeUrl('http://example.com/pricing/');
       expect(sitemap.urlSet).toEqual(exampleSitemapWithOnePageJs);
@@ -126,8 +126,8 @@ describe('SitemapUrlSet component', () => {
   describe('importTimestampsFromOldSitemap', () => {
     it('updates the last modified time only for documents which have actually changed', () => {
       jasmine.clock().mockDate(new Date(2015, 2, 1));
-      var oldSitemap = new SitemapUrlSet('http://example.com').fromXml(exampleSitemapWithTwoPagesXml);
-      var newSitemap = new SitemapUrlSet('http://example.com');
+      var oldSitemap = new Sitemap('http://example.com').fromXml(exampleSitemapWithTwoPagesXml);
+      var newSitemap = new Sitemap('http://example.com');
       newSitemap.addUrl('http://example.com/about/', '<html><body>Updated Version of About Page Contents</body></html>');
       newSitemap.addUrl('http://example.com/pricing/', '<html><body>Pricing Page Contents</body></html>');
       newSitemap.importTimestampsFromOldSitemap(oldSitemap);

--- a/app/static-build/sitemap.spec.js
+++ b/app/static-build/sitemap.spec.js
@@ -1,0 +1,137 @@
+import { SitemapUrlSet } from './sitemap';
+
+const sitemapXmlHeader = '<?xml version="1.0" encoding="UTF-8"?>\n' +
+  '<urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"\n' +
+  '  xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd"\n' +
+  '  xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"\n' +
+  '  xmlns:xhtml="http://www.w3.org/1999/xhtml"\n' +
+  '  xmlns:content="https://github.com/gocardless/splash-pages#xml-sitemap-hash">\n';
+const sitemapXmlFooter = '</urlset>';
+
+// Example Sitemaps
+const exampleSitemapWithNoPagesXml = sitemapXmlHeader + sitemapXmlFooter;
+const exampleSitemapWithNoPagesJs = {};
+const exampleSitemapWithOnePageXml = sitemapXmlHeader +
+                                     '  <url>\n' +
+                                     '    <loc>http://example.com/about/</loc>\n' +
+                                     '    <content:hash>069bfb8015349d73655fa878018498de</content:hash>\n' +
+                                     '    <lastmod>2015-01-01</lastmod>\n' +
+                                     '  </url>\n' +
+                                     sitemapXmlFooter;
+const exampleSitemapWithOnePageJs = {
+  '/about/': {
+    hash: '069bfb8015349d73655fa878018498de',
+    lastMod: new Date(2015, 0, 1).getTime(),
+  },
+};
+const exampleSitemapWithTwoPagesXml = sitemapXmlHeader +
+                                      '  <url>\n' +
+                                      '    <loc>http://example.com/about/</loc>\n' +
+                                      '    <content:hash>069bfb8015349d73655fa878018498de</content:hash>\n' +
+                                      '    <lastmod>2015-01-01</lastmod>\n' +
+                                      '  </url>\n' +
+                                      '  <url>\n' +
+                                      '    <loc>http://example.com/pricing/</loc>\n' +
+                                      '    <content:hash>f303f4bfc20f771c2180cfa44327f13f</content:hash>\n' +
+                                      '    <lastmod>2015-02-01</lastmod>\n' +
+                                      '  </url>\n' +
+                                      sitemapXmlFooter;
+const exampleSitemapWithTwoPagesJs = {
+  '/about/': {
+    hash: '069bfb8015349d73655fa878018498de',
+    lastMod: new Date(2015, 0, 1).getTime(),
+  },
+  '/pricing/': {
+    hash: 'f303f4bfc20f771c2180cfa44327f13f',
+    lastMod: new Date(2015, 1, 1).getTime(),
+  },
+};
+const updatedSitemapAfterChangeJs = {
+  '/about/': {
+    // About page gets updated with new content so also gets an updated timestamp
+    hash: 'ae10751344a1af9b28835466fe43c55b',
+    lastMod: new Date(2015, 2, 1).getTime(),
+  },
+  '/pricing/': {
+    // Pricing change remains unchanged so keeps the same timestamp
+    hash: 'f303f4bfc20f771c2180cfa44327f13f',
+    lastMod: new Date(2015, 1, 1).getTime(),
+  },
+};
+
+describe('SitemapUrlSet component', () => {
+  describe('constructor', () => {
+    it('returns a SitemapUrlSet with no entries', () => {
+      var blankSitemap = new SitemapUrlSet('http://example.com');
+      expect(blankSitemap.urlSet).toEqual(exampleSitemapWithNoPagesJs);
+    });
+  });
+
+  describe('fromXml', () => {
+    it('returns a SitemapUrlSet with the right entries', () => {
+      var sitemapWithNoPages = new SitemapUrlSet('http://example.com').fromXml(exampleSitemapWithNoPagesXml);
+      expect(sitemapWithNoPages.urlSet).toEqual(exampleSitemapWithNoPagesJs);
+      var sitemapWithOnePage = new SitemapUrlSet('http://example.com').fromXml(exampleSitemapWithOnePageXml);
+      expect(sitemapWithOnePage.urlSet).toEqual(exampleSitemapWithOnePageJs);
+      var sitemapWithTwoPages = new SitemapUrlSet('http://example.com').fromXml(exampleSitemapWithTwoPagesXml);
+      expect(sitemapWithTwoPages.urlSet).toEqual(exampleSitemapWithTwoPagesJs);
+    });
+  });
+
+  describe('toXml', () => {
+    it('returns the appropiate XML for the SitemapUrlSet', () => {
+      var sitemapWithNoPages = new SitemapUrlSet('http://example.com');
+      sitemapWithNoPages.urlSet = exampleSitemapWithNoPagesJs;
+      expect(sitemapWithNoPages.toXml()).toEqual(exampleSitemapWithNoPagesXml);
+      var sitemapWithOnePage = new SitemapUrlSet('http://example.com');
+      sitemapWithOnePage.urlSet = exampleSitemapWithOnePageJs;
+      expect(sitemapWithOnePage.toXml()).toEqual(exampleSitemapWithOnePageXml);
+      var sitemapWithTwoPages = new SitemapUrlSet('http://example.com');
+      sitemapWithTwoPages.urlSet = exampleSitemapWithTwoPagesJs;
+      expect(sitemapWithTwoPages.toXml()).toEqual(exampleSitemapWithTwoPagesXml);
+    });
+  });
+
+  describe('addUrl', () => {
+    it('adds the URL correctly to the sitemap', () => {
+      jasmine.clock().mockDate(new Date(2015, 0, 1));
+      var sitemap = new SitemapUrlSet('http://example.com');
+      sitemap.addUrl('http://example.com/about/', '<html><body>About Page Contents</body></html>');
+      expect(sitemap.urlSet).toEqual(exampleSitemapWithOnePageJs);
+      jasmine.clock().mockDate(new Date(2015, 1, 1));
+      sitemap.addUrl('http://example.com/pricing/', '<html><body>Pricing Page Contents</body></html>');
+      expect(sitemap.urlSet).toEqual(exampleSitemapWithTwoPagesJs);
+    });
+  });
+
+  describe('getUrl', () => {
+    it('returns the URL correctly from SitemapUrlSet', () => {
+      var sitemap = new SitemapUrlSet('http://example.com');
+      sitemap.urlSet = exampleSitemapWithOnePageJs;
+      expect(sitemap.getUrl('http://example.com/about/')).toEqual(exampleSitemapWithOnePageJs['/about/']);
+    });
+  });
+
+  describe('removeUrl', () => {
+    it('removes the URL correctly from the sitemap', () => {
+      var sitemap = new SitemapUrlSet('http://example.com');
+      sitemap.urlSet = exampleSitemapWithTwoPagesJs;
+      sitemap.removeUrl('http://example.com/pricing/');
+      expect(sitemap.urlSet).toEqual(exampleSitemapWithOnePageJs);
+      sitemap.removeUrl('http://example.com/about/');
+      expect(sitemap.urlSet).toEqual(exampleSitemapWithNoPagesJs);
+    });
+  });
+
+  describe('importTimestampsFromOldSitemap', () => {
+    it('updates the last modified time only for documents which have actually changed', () => {
+      jasmine.clock().mockDate(new Date(2015, 2, 1));
+      var oldSitemap = new SitemapUrlSet('http://example.com').fromXml(exampleSitemapWithTwoPagesXml);
+      var newSitemap = new SitemapUrlSet('http://example.com');
+      newSitemap.addUrl('http://example.com/about/', '<html><body>Updated Version of About Page Contents</body></html>');
+      newSitemap.addUrl('http://example.com/pricing/', '<html><body>Pricing Page Contents</body></html>');
+      newSitemap.importTimestampsFromOldSitemap(oldSitemap);
+      expect(newSitemap.urlSet).toEqual(updatedSitemapAfterChangeJs);
+    });
+  });
+});

--- a/circle.yml
+++ b/circle.yml
@@ -8,7 +8,7 @@ deployment:
   staging:
     branch: dev
     commands:
-      - npm run build-production
+      - npm run build-staging
       - npm run deploy-live-staging
 
 machine:

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2319,64 +2319,64 @@
       "dependencies": {
         "browser-request": {
           "version": "0.3.3",
-          "from": "https://registry.npmjs.org/browser-request/-/browser-request-0.3.3.tgz",
+          "from": "browser-request@>=0.3.1 <0.4.0",
           "resolved": "https://registry.npmjs.org/browser-request/-/browser-request-0.3.3.tgz"
         },
         "contextify": {
           "version": "0.1.14",
-          "from": "https://registry.npmjs.org/contextify/-/contextify-0.1.14.tgz",
+          "from": "contextify@>=0.1.9 <0.2.0",
           "resolved": "https://registry.npmjs.org/contextify/-/contextify-0.1.14.tgz",
           "dependencies": {
             "bindings": {
               "version": "1.2.1",
-              "from": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz",
+              "from": "bindings@*",
               "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz"
             },
             "nan": {
               "version": "1.8.4",
-              "from": "https://registry.npmjs.org/nan/-/nan-1.8.4.tgz",
+              "from": "nan@>=1.8.4 <1.9.0",
               "resolved": "https://registry.npmjs.org/nan/-/nan-1.8.4.tgz"
             }
           }
         },
         "cssom": {
           "version": "0.3.0",
-          "from": "https://registry.npmjs.org/cssom/-/cssom-0.3.0.tgz",
+          "from": "cssom@>=0.3.0 <0.4.0",
           "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.0.tgz"
         },
         "cssstyle": {
-          "version": "0.2.26",
-          "from": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.26.tgz",
-          "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.26.tgz"
+          "version": "0.2.29",
+          "from": "cssstyle@>=0.2.21 <0.3.0",
+          "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.29.tgz"
         },
         "htmlparser2": {
-          "version": "3.8.2",
-          "from": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.2.tgz",
-          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.2.tgz",
+          "version": "3.8.3",
+          "from": "htmlparser2@>=3.7.3 <4.0.0",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
           "dependencies": {
             "domhandler": {
               "version": "2.3.0",
-              "from": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
+              "from": "domhandler@>=2.3.0 <2.4.0",
               "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz"
             },
             "domutils": {
               "version": "1.5.1",
-              "from": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+              "from": "domutils@>=1.5.0 <1.6.0",
               "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
               "dependencies": {
                 "dom-serializer": {
                   "version": "0.1.0",
-                  "from": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+                  "from": "dom-serializer@>=0.0.0 <1.0.0",
                   "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
                   "dependencies": {
                     "domelementtype": {
                       "version": "1.1.3",
-                      "from": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+                      "from": "domelementtype@>=1.1.1 <1.2.0",
                       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
                     },
                     "entities": {
                       "version": "1.1.1",
-                      "from": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
+                      "from": "entities@>=1.1.1 <1.2.0",
                       "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
                     }
                   }
@@ -2385,335 +2385,345 @@
             },
             "domelementtype": {
               "version": "1.3.0",
-              "from": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
+              "from": "domelementtype@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
             },
             "readable-stream": {
               "version": "1.1.13",
-              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+              "from": "readable-stream@>=1.1.0 <1.2.0",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                  "from": "isarray@0.0.1",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                  "from": "string_decoder@>=0.10.0 <0.11.0",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "from": "inherits@>=2.0.1 <2.1.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             },
             "entities": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
+              "from": "entities@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz"
             }
           }
         },
         "nwmatcher": {
-          "version": "1.3.4",
-          "from": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.3.4.tgz",
-          "resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.3.4.tgz"
+          "version": "1.3.6",
+          "from": "nwmatcher@>=1.3.4 <2.0.0",
+          "resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.3.6.tgz"
         },
         "parse5": {
-          "version": "1.4.2",
-          "from": "https://registry.npmjs.org/parse5/-/parse5-1.4.2.tgz",
-          "resolved": "https://registry.npmjs.org/parse5/-/parse5-1.4.2.tgz"
+          "version": "1.5.0",
+          "from": "parse5@>=1.3.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/parse5/-/parse5-1.5.0.tgz"
         },
         "request": {
-          "version": "2.55.0",
-          "from": "https://registry.npmjs.org/request/-/request-2.55.0.tgz",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.55.0.tgz",
+          "version": "2.60.0",
+          "from": "request@>=2.44.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.60.0.tgz",
           "dependencies": {
             "bl": {
-              "version": "0.9.4",
-              "from": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
-              "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
+              "version": "1.0.0",
+              "from": "bl@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz",
               "dependencies": {
                 "readable-stream": {
-                  "version": "1.0.33",
-                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                  "version": "2.0.2",
+                  "from": "readable-stream@>=2.0.0 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                    },
-                    "isarray": {
-                      "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "from": "inherits@>=2.0.1 <2.1.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "process-nextick-args": {
+                      "version": "1.0.2",
+                      "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "util-deprecate": {
+                      "version": "1.0.1",
+                      "from": "util-deprecate@>=1.0.1 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
                     }
                   }
                 }
               }
             },
             "caseless": {
-              "version": "0.9.0",
-              "from": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz",
-              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz"
+              "version": "0.11.0",
+              "from": "caseless@>=0.11.0 <0.12.0",
+              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
+            },
+            "extend": {
+              "version": "3.0.0",
+              "from": "extend@>=3.0.0 <3.1.0",
+              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
             },
             "forever-agent": {
               "version": "0.6.1",
-              "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+              "from": "forever-agent@>=0.6.0 <0.7.0",
               "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
             },
             "form-data": {
-              "version": "0.2.0",
-              "from": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
-              "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
+              "version": "1.0.0-rc2",
+              "from": "form-data@>=1.0.0-rc1 <1.1.0",
+              "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc2.tgz",
               "dependencies": {
                 "async": {
-                  "version": "0.9.2",
-                  "from": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
-                  "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
+                  "version": "1.4.0",
+                  "from": "async@>=1.2.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/async/-/async-1.4.0.tgz"
                 }
               }
             },
             "json-stringify-safe": {
               "version": "5.0.1",
-              "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+              "from": "json-stringify-safe@>=5.0.0 <5.1.0",
               "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
             },
             "mime-types": {
-              "version": "2.0.12",
-              "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.12.tgz",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.12.tgz",
+              "version": "2.1.3",
+              "from": "mime-types@>=2.1.2 <2.2.0",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.3.tgz",
               "dependencies": {
                 "mime-db": {
-                  "version": "1.10.0",
-                  "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.10.0.tgz",
-                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.10.0.tgz"
+                  "version": "1.15.0",
+                  "from": "mime-db@>=1.15.0 <1.16.0",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.15.0.tgz"
                 }
               }
             },
             "node-uuid": {
               "version": "1.4.3",
-              "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz",
+              "from": "node-uuid@>=1.4.0 <1.5.0",
               "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
             },
             "qs": {
-              "version": "2.4.2",
-              "from": "https://registry.npmjs.org/qs/-/qs-2.4.2.tgz",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-2.4.2.tgz"
+              "version": "4.0.0",
+              "from": "qs@>=4.0.0 <4.1.0",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz"
             },
             "tunnel-agent": {
-              "version": "0.4.0",
-              "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz",
-              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
+              "version": "0.4.1",
+              "from": "tunnel-agent@>=0.4.0 <0.5.0",
+              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
             },
             "tough-cookie": {
-              "version": "1.1.0",
-              "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-1.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-1.1.0.tgz"
+              "version": "2.0.0",
+              "from": "tough-cookie@>=0.12.0",
+              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.0.0.tgz"
             },
             "http-signature": {
-              "version": "0.10.1",
-              "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
-              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+              "version": "0.11.0",
+              "from": "http-signature@>=0.11.0 <0.12.0",
+              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
               "dependencies": {
                 "assert-plus": {
                   "version": "0.1.5",
-                  "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+                  "from": "assert-plus@>=0.1.5 <0.2.0",
                   "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
                 },
                 "asn1": {
                   "version": "0.1.11",
-                  "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
+                  "from": "asn1@0.1.11",
                   "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
                 },
                 "ctype": {
                   "version": "0.5.3",
-                  "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
+                  "from": "ctype@0.5.3",
                   "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
                 }
               }
             },
             "oauth-sign": {
-              "version": "0.6.0",
-              "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz",
-              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz"
+              "version": "0.8.0",
+              "from": "oauth-sign@>=0.8.0 <0.9.0",
+              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz"
             },
             "hawk": {
-              "version": "2.3.1",
-              "from": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
-              "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
+              "version": "3.1.0",
+              "from": "hawk@>=3.1.0 <3.2.0",
+              "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.0.tgz",
               "dependencies": {
                 "hoek": {
-                  "version": "2.13.0",
-                  "from": "https://registry.npmjs.org/hoek/-/hoek-2.13.0.tgz",
-                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.13.0.tgz"
+                  "version": "2.14.0",
+                  "from": "hoek@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.14.0.tgz"
                 },
                 "boom": {
-                  "version": "2.7.1",
-                  "from": "https://registry.npmjs.org/boom/-/boom-2.7.1.tgz",
-                  "resolved": "https://registry.npmjs.org/boom/-/boom-2.7.1.tgz"
+                  "version": "2.8.0",
+                  "from": "boom@>=2.8.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/boom/-/boom-2.8.0.tgz"
                 },
                 "cryptiles": {
                   "version": "2.0.4",
-                  "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz",
+                  "from": "cryptiles@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz"
                 },
                 "sntp": {
                   "version": "1.0.9",
-                  "from": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+                  "from": "sntp@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
                 }
               }
             },
             "aws-sign2": {
               "version": "0.5.0",
-              "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
+              "from": "aws-sign2@>=0.5.0 <0.6.0",
               "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
             },
             "stringstream": {
               "version": "0.0.4",
-              "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz",
+              "from": "stringstream@>=0.0.4 <0.1.0",
               "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
             },
             "combined-stream": {
-              "version": "0.0.7",
-              "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
-              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+              "version": "1.0.5",
+              "from": "combined-stream@>=1.0.1 <1.1.0",
+              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
               "dependencies": {
                 "delayed-stream": {
-                  "version": "0.0.5",
-                  "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
-                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                  "version": "1.0.0",
+                  "from": "delayed-stream@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
                 }
               }
             },
             "isstream": {
               "version": "0.1.2",
-              "from": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+              "from": "isstream@>=0.1.1 <0.2.0",
               "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
             },
             "har-validator": {
-              "version": "1.7.0",
-              "from": "https://registry.npmjs.org/har-validator/-/har-validator-1.7.0.tgz",
-              "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-1.7.0.tgz",
+              "version": "1.8.0",
+              "from": "har-validator@>=1.6.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-1.8.0.tgz",
               "dependencies": {
                 "bluebird": {
-                  "version": "2.9.25",
-                  "from": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.25.tgz",
-                  "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.25.tgz"
+                  "version": "2.9.34",
+                  "from": "bluebird@>=2.9.30 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.34.tgz"
                 },
                 "chalk": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
+                  "version": "1.1.0",
+                  "from": "chalk@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.0.tgz",
                   "dependencies": {
                     "ansi-styles": {
-                      "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
+                      "version": "2.1.0",
+                      "from": "ansi-styles@>=2.1.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
                     },
                     "escape-string-regexp": {
                       "version": "1.0.3",
-                      "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
+                      "from": "escape-string-regexp@>=1.0.2 <2.0.0",
                       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
                     },
                     "has-ansi": {
-                      "version": "1.0.3",
-                      "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
-                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
+                      "version": "2.0.0",
+                      "from": "has-ansi@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                       "dependencies": {
                         "ansi-regex": {
-                          "version": "1.1.1",
-                          "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
-                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
-                        },
-                        "get-stdin": {
-                          "version": "4.0.1",
-                          "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                          "version": "2.0.0",
+                          "from": "ansi-regex@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                         }
                       }
                     },
                     "strip-ansi": {
-                      "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+                      "version": "3.0.0",
+                      "from": "strip-ansi@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                       "dependencies": {
                         "ansi-regex": {
-                          "version": "1.1.1",
-                          "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
-                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                          "version": "2.0.0",
+                          "from": "ansi-regex@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                         }
                       }
                     },
                     "supports-color": {
-                      "version": "1.3.1",
-                      "from": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz",
-                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
+                      "version": "2.0.0",
+                      "from": "supports-color@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                     }
                   }
                 },
                 "commander": {
                   "version": "2.8.1",
-                  "from": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+                  "from": "commander@>=2.8.1 <3.0.0",
                   "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
                   "dependencies": {
                     "graceful-readlink": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+                      "from": "graceful-readlink@>=1.0.0",
                       "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
                     }
                   }
                 },
                 "is-my-json-valid": {
-                  "version": "2.12.0",
-                  "from": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.0.tgz",
-                  "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.0.tgz",
+                  "version": "2.12.1",
+                  "from": "is-my-json-valid@>=2.12.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.1.tgz",
                   "dependencies": {
                     "generate-function": {
                       "version": "2.0.0",
-                      "from": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+                      "from": "generate-function@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
                     },
                     "generate-object-property": {
                       "version": "1.2.0",
-                      "from": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+                      "from": "generate-object-property@>=1.1.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
                       "dependencies": {
                         "is-property": {
                           "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+                          "from": "is-property@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
                         }
                       }
                     },
                     "jsonpointer": {
                       "version": "1.1.0",
-                      "from": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-1.1.0.tgz",
+                      "from": "jsonpointer@>=1.1.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-1.1.0.tgz"
                     },
                     "xtend": {
                       "version": "4.0.0",
-                      "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
+                      "from": "xtend@>=4.0.0 <5.0.0",
                       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
                     }
                   }
@@ -2724,97 +2734,97 @@
         },
         "xml-name-validator": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-1.0.0.tgz",
+          "from": "xml-name-validator@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-1.0.0.tgz"
         },
         "xmlhttprequest": {
           "version": "1.7.0",
-          "from": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.7.0.tgz",
+          "from": "xmlhttprequest@>=1.6.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.7.0.tgz"
         },
         "acorn-globals": {
-          "version": "1.0.4",
-          "from": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-1.0.4.tgz",
-          "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-1.0.4.tgz",
+          "version": "1.0.5",
+          "from": "acorn-globals@>=1.0.2 <2.0.0",
+          "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-1.0.5.tgz",
           "dependencies": {
             "acorn": {
-              "version": "1.1.0",
-              "from": "https://registry.npmjs.org/acorn/-/acorn-1.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.1.0.tgz"
+              "version": "2.1.0",
+              "from": "acorn@>=2.1.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.1.0.tgz"
             }
           }
         },
         "acorn": {
           "version": "0.11.0",
-          "from": "https://registry.npmjs.org/acorn/-/acorn-0.11.0.tgz",
+          "from": "acorn@0.11.0",
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-0.11.0.tgz"
         },
         "escodegen": {
           "version": "1.6.1",
-          "from": "https://registry.npmjs.org/escodegen/-/escodegen-1.6.1.tgz",
+          "from": "escodegen@>=1.6.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.6.1.tgz",
           "dependencies": {
             "estraverse": {
               "version": "1.9.3",
-              "from": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
+              "from": "estraverse@>=1.9.1 <2.0.0",
               "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz"
             },
             "esutils": {
               "version": "1.1.6",
-              "from": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz",
+              "from": "esutils@>=1.1.6 <2.0.0",
               "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz"
             },
             "esprima": {
               "version": "1.2.5",
-              "from": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz",
+              "from": "esprima@>=1.2.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz"
             },
             "optionator": {
               "version": "0.5.0",
-              "from": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
+              "from": "optionator@>=0.5.0 <0.6.0",
               "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
               "dependencies": {
                 "prelude-ls": {
                   "version": "1.1.2",
-                  "from": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+                  "from": "prelude-ls@>=1.1.1 <1.2.0",
                   "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
                 },
                 "deep-is": {
                   "version": "0.1.3",
-                  "from": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+                  "from": "deep-is@>=0.1.2 <0.2.0",
                   "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
                 },
                 "wordwrap": {
                   "version": "0.0.3",
-                  "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+                  "from": "wordwrap@>=0.0.2 <0.1.0",
                   "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
                 },
                 "type-check": {
                   "version": "0.3.1",
-                  "from": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz",
+                  "from": "type-check@>=0.3.1 <0.4.0",
                   "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz"
                 },
                 "levn": {
                   "version": "0.2.5",
-                  "from": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz",
+                  "from": "levn@>=0.2.5 <0.3.0",
                   "resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz"
                 },
                 "fast-levenshtein": {
                   "version": "1.0.6",
-                  "from": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.6.tgz",
+                  "from": "fast-levenshtein@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.6.tgz"
                 }
               }
             },
             "source-map": {
               "version": "0.1.43",
-              "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+              "from": "source-map@>=0.1.40 <0.2.0",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
               "dependencies": {
                 "amdefine": {
-                  "version": "0.1.0",
-                  "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
-                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                  "version": "1.0.0",
+                  "from": "amdefine@>=0.0.4",
+                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
                 }
               }
             }
@@ -3141,100 +3151,100 @@
       "dependencies": {
         "async-foreach": {
           "version": "0.1.3",
-          "from": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz",
+          "from": "async-foreach@>=0.1.3 <0.2.0",
           "resolved": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz"
         },
         "chalk": {
-          "version": "1.0.0",
-          "from": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
+          "version": "1.1.0",
+          "from": "chalk@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.0.tgz",
           "dependencies": {
             "ansi-styles": {
-              "version": "2.0.1",
-              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
+              "version": "2.1.0",
+              "from": "ansi-styles@>=2.1.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.3",
-              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
             },
             "has-ansi": {
-              "version": "1.0.3",
-              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
-              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
+              "version": "2.0.0",
+              "from": "has-ansi@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
               "dependencies": {
                 "ansi-regex": {
-                  "version": "1.1.1",
-                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                  "version": "2.0.0",
+                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "strip-ansi": {
-              "version": "2.0.1",
-              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+              "version": "3.0.0",
+              "from": "strip-ansi@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
               "dependencies": {
                 "ansi-regex": {
-                  "version": "1.1.1",
-                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                  "version": "2.0.0",
+                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "supports-color": {
-              "version": "1.3.1",
-              "from": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
+              "version": "2.0.0",
+              "from": "supports-color@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
             }
           }
         },
         "gaze": {
           "version": "0.5.1",
-          "from": "https://registry.npmjs.org/gaze/-/gaze-0.5.1.tgz",
+          "from": "gaze@>=0.5.1 <0.6.0",
           "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.1.tgz",
           "dependencies": {
             "globule": {
               "version": "0.1.0",
-              "from": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
+              "from": "globule@>=0.1.0 <0.2.0",
               "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
               "dependencies": {
                 "lodash": {
                   "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
+                  "from": "lodash@>=1.0.1 <1.1.0",
                   "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz"
                 },
                 "glob": {
                   "version": "3.1.21",
-                  "from": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+                  "from": "glob@>=3.1.21 <3.2.0",
                   "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
                   "dependencies": {
                     "graceful-fs": {
                       "version": "1.2.3",
-                      "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
+                      "from": "graceful-fs@>=1.2.0 <1.3.0",
                       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
                     },
                     "inherits": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz",
+                      "from": "inherits@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
                     }
                   }
                 },
                 "minimatch": {
                   "version": "0.2.14",
-                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                  "from": "minimatch@>=0.2.11 <0.3.0",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                   "dependencies": {
                     "lru-cache": {
-                      "version": "2.6.4",
-                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz",
-                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
+                      "version": "2.6.5",
+                      "from": "lru-cache@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+                      "from": "sigmund@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                     }
                   }
@@ -3245,49 +3255,49 @@
         },
         "get-stdin": {
           "version": "4.0.1",
-          "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+          "from": "get-stdin@>=4.0.1 <5.0.0",
           "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
         },
         "meow": {
-          "version": "3.1.0",
-          "from": "https://registry.npmjs.org/meow/-/meow-3.1.0.tgz",
-          "resolved": "https://registry.npmjs.org/meow/-/meow-3.1.0.tgz",
+          "version": "3.3.0",
+          "from": "meow@>=3.1.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/meow/-/meow-3.3.0.tgz",
           "dependencies": {
             "camelcase-keys": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+              "from": "camelcase-keys@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
               "dependencies": {
                 "camelcase": {
                   "version": "1.1.0",
-                  "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.1.0.tgz",
+                  "from": "camelcase@>=1.0.1 <2.0.0",
                   "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.1.0.tgz"
                 },
                 "map-obj": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+                  "from": "map-obj@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
                 }
               }
             },
             "indent-string": {
-              "version": "1.2.1",
-              "from": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.1.tgz",
-              "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.1.tgz",
+              "version": "1.2.2",
+              "from": "indent-string@>=1.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
               "dependencies": {
                 "repeating": {
-                  "version": "1.1.2",
-                  "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.2.tgz",
-                  "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.2.tgz",
+                  "version": "1.1.3",
+                  "from": "repeating@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                   "dependencies": {
                     "is-finite": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                      "from": "is-finite@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                       "dependencies": {
                         "number-is-nan": {
                           "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                          "from": "number-is-nan@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                         }
                       }
@@ -3297,132 +3307,144 @@
               }
             },
             "object-assign": {
-              "version": "2.0.0",
-              "from": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz"
+              "version": "3.0.0",
+              "from": "object-assign@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
             }
           }
         },
         "nan": {
           "version": "1.8.4",
-          "from": "https://registry.npmjs.org/nan/-/nan-1.8.4.tgz",
+          "from": "nan@>=1.8.4 <2.0.0",
           "resolved": "https://registry.npmjs.org/nan/-/nan-1.8.4.tgz"
         },
         "npmconf": {
           "version": "2.1.2",
-          "from": "https://registry.npmjs.org/npmconf/-/npmconf-2.1.2.tgz",
+          "from": "npmconf@>=2.1.1 <3.0.0",
           "resolved": "https://registry.npmjs.org/npmconf/-/npmconf-2.1.2.tgz",
           "dependencies": {
             "config-chain": {
-              "version": "1.1.8",
-              "from": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.8.tgz",
-              "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.8.tgz",
+              "version": "1.1.9",
+              "from": "config-chain@>=1.1.8 <1.2.0",
+              "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.9.tgz",
               "dependencies": {
                 "proto-list": {
                   "version": "1.2.4",
-                  "from": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+                  "from": "proto-list@>=1.2.1 <1.3.0",
                   "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz"
                 }
               }
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+              "from": "inherits@>=2.0.0 <2.1.0",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "ini": {
-              "version": "1.3.3",
-              "from": "https://registry.npmjs.org/ini/-/ini-1.3.3.tgz",
-              "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.3.tgz"
+              "version": "1.3.4",
+              "from": "ini@>=1.2.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
             },
             "nopt": {
-              "version": "3.0.2",
-              "from": "https://registry.npmjs.org/nopt/-/nopt-3.0.2.tgz",
-              "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.2.tgz",
+              "version": "3.0.3",
+              "from": "nopt@>=3.0.1 <3.1.0",
+              "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.3.tgz",
               "dependencies": {
                 "abbrev": {
-                  "version": "1.0.6",
-                  "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.6.tgz",
-                  "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.6.tgz"
+                  "version": "1.0.7",
+                  "from": "abbrev@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
                 }
               }
             },
             "once": {
               "version": "1.3.2",
-              "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+              "from": "once@>=1.3.0 <1.4.0",
               "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                  "from": "wrappy@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
             },
             "osenv": {
-              "version": "0.1.1",
-              "from": "https://registry.npmjs.org/osenv/-/osenv-0.1.1.tgz",
-              "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.1.tgz"
+              "version": "0.1.3",
+              "from": "osenv@>=0.1.0 <0.2.0",
+              "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
+              "dependencies": {
+                "os-homedir": {
+                  "version": "1.0.1",
+                  "from": "os-homedir@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
+                },
+                "os-tmpdir": {
+                  "version": "1.0.1",
+                  "from": "os-tmpdir@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
+                }
+              }
             },
             "semver": {
-              "version": "4.3.4",
-              "from": "https://registry.npmjs.org/semver/-/semver-4.3.4.tgz",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.4.tgz"
+              "version": "4.3.6",
+              "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
             },
             "uid-number": {
               "version": "0.0.5",
-              "from": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.5.tgz",
+              "from": "uid-number@0.0.5",
               "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.5.tgz"
             }
           }
         },
         "pangyp": {
-          "version": "2.2.0",
-          "from": "https://registry.npmjs.org/pangyp/-/pangyp-2.2.0.tgz",
-          "resolved": "https://registry.npmjs.org/pangyp/-/pangyp-2.2.0.tgz",
+          "version": "2.2.1",
+          "from": "pangyp@>=2.2.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/pangyp/-/pangyp-2.2.1.tgz",
           "dependencies": {
             "fstream": {
-              "version": "1.0.6",
-              "from": "https://registry.npmjs.org/fstream/-/fstream-1.0.6.tgz",
-              "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.6.tgz",
+              "version": "1.0.7",
+              "from": "fstream@>=1.0.3 <1.1.0",
+              "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.7.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "from": "inherits@>=2.0.0 <2.1.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             },
             "glob": {
               "version": "4.3.5",
-              "from": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
+              "from": "glob@>=4.3.5 <4.4.0",
               "resolved": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
               "dependencies": {
                 "inflight": {
                   "version": "1.0.4",
-                  "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                  "from": "inflight@>=1.0.4 <2.0.0",
                   "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "from": "inherits@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "once": {
                   "version": "1.3.2",
-                  "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                  "from": "once@>=1.3.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
@@ -3430,28 +3452,28 @@
               }
             },
             "graceful-fs": {
-              "version": "3.0.7",
-              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.7.tgz",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.7.tgz"
+              "version": "3.0.8",
+              "from": "graceful-fs@>=3.0.5 <3.1.0",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
             },
             "minimatch": {
-              "version": "2.0.8",
-              "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
+              "version": "2.0.10",
+              "from": "minimatch@>=2.0.1 <2.1.0",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.0",
-                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                  "from": "brace-expansion@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                   "dependencies": {
                     "balanced-match": {
                       "version": "0.2.0",
-                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz",
+                      "from": "balanced-match@>=0.2.0 <0.3.0",
                       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
                     },
                     "concat-map": {
                       "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                      "from": "concat-map@0.0.1",
                       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                     }
                   }
@@ -3459,60 +3481,60 @@
               }
             },
             "nopt": {
-              "version": "3.0.2",
-              "from": "https://registry.npmjs.org/nopt/-/nopt-3.0.2.tgz",
-              "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.2.tgz",
+              "version": "3.0.3",
+              "from": "nopt@>=3.0.1 <3.1.0",
+              "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.3.tgz",
               "dependencies": {
                 "abbrev": {
-                  "version": "1.0.6",
-                  "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.6.tgz",
-                  "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.6.tgz"
+                  "version": "1.0.7",
+                  "from": "abbrev@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
                 }
               }
             },
             "npmlog": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/npmlog/-/npmlog-1.0.0.tgz",
+              "from": "npmlog@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-1.0.0.tgz",
               "dependencies": {
                 "ansi": {
                   "version": "0.3.0",
-                  "from": "https://registry.npmjs.org/ansi/-/ansi-0.3.0.tgz",
+                  "from": "ansi@>=0.3.0 <0.4.0",
                   "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.0.tgz"
                 },
                 "are-we-there-yet": {
                   "version": "1.0.4",
-                  "from": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.4.tgz",
+                  "from": "are-we-there-yet@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.4.tgz",
                   "dependencies": {
                     "delegates": {
                       "version": "0.1.0",
-                      "from": "https://registry.npmjs.org/delegates/-/delegates-0.1.0.tgz",
+                      "from": "delegates@>=0.1.0 <0.2.0",
                       "resolved": "https://registry.npmjs.org/delegates/-/delegates-0.1.0.tgz"
                     },
                     "readable-stream": {
                       "version": "1.1.13",
-                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                      "from": "readable-stream@>=1.1.13 <2.0.0",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                          "from": "core-util-is@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                         },
                         "isarray": {
                           "version": "0.0.1",
-                          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                          "from": "isarray@0.0.1",
                           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                          "from": "string_decoder@>=0.10.0 <0.11.0",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                         },
                         "inherits": {
                           "version": "2.0.1",
-                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                          "from": "inherits@>=2.0.1 <2.1.0",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         }
                       }
@@ -3521,12 +3543,12 @@
                 },
                 "gauge": {
                   "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/gauge/-/gauge-1.0.2.tgz",
+                  "from": "gauge@>=1.0.2 <1.1.0",
                   "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.0.2.tgz",
                   "dependencies": {
                     "has-unicode": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/has-unicode/-/has-unicode-1.0.0.tgz",
+                      "from": "has-unicode@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-1.0.0.tgz"
                     }
                   }
@@ -3534,43 +3556,55 @@
               }
             },
             "osenv": {
-              "version": "0.1.1",
-              "from": "https://registry.npmjs.org/osenv/-/osenv-0.1.1.tgz",
-              "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.1.tgz"
+              "version": "0.1.3",
+              "from": "osenv@>=0.0.0 <1.0.0",
+              "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
+              "dependencies": {
+                "os-homedir": {
+                  "version": "1.0.1",
+                  "from": "os-homedir@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
+                },
+                "os-tmpdir": {
+                  "version": "1.0.1",
+                  "from": "os-tmpdir@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
+                }
+              }
             },
             "request": {
               "version": "2.51.0",
-              "from": "https://registry.npmjs.org/request/-/request-2.51.0.tgz",
+              "from": "request@>=2.51.0 <2.52.0",
               "resolved": "https://registry.npmjs.org/request/-/request-2.51.0.tgz",
               "dependencies": {
                 "bl": {
                   "version": "0.9.4",
-                  "from": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
+                  "from": "bl@>=0.9.0 <0.10.0",
                   "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
                   "dependencies": {
                     "readable-stream": {
                       "version": "1.0.33",
-                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                      "from": "readable-stream@>=1.0.26 <1.1.0",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                          "from": "core-util-is@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                         },
                         "isarray": {
                           "version": "0.0.1",
-                          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                          "from": "isarray@0.0.1",
                           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                          "from": "string_decoder@>=0.10.0 <0.11.0",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                         },
                         "inherits": {
                           "version": "2.0.1",
-                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                          "from": "inherits@>=2.0.1 <2.1.0",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         }
                       }
@@ -3579,33 +3613,33 @@
                 },
                 "caseless": {
                   "version": "0.8.0",
-                  "from": "https://registry.npmjs.org/caseless/-/caseless-0.8.0.tgz",
+                  "from": "caseless@>=0.8.0 <0.9.0",
                   "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.8.0.tgz"
                 },
                 "forever-agent": {
                   "version": "0.5.2",
-                  "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz",
+                  "from": "forever-agent@>=0.5.0 <0.6.0",
                   "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
                 },
                 "form-data": {
                   "version": "0.2.0",
-                  "from": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
+                  "from": "form-data@>=0.2.0 <0.3.0",
                   "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
                   "dependencies": {
                     "async": {
                       "version": "0.9.2",
-                      "from": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+                      "from": "async@>=0.9.0 <0.10.0",
                       "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
                     },
                     "mime-types": {
-                      "version": "2.0.12",
-                      "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.12.tgz",
-                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.12.tgz",
+                      "version": "2.0.14",
+                      "from": "mime-types@>=2.0.3 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
                       "dependencies": {
                         "mime-db": {
-                          "version": "1.10.0",
-                          "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.10.0.tgz",
-                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.10.0.tgz"
+                          "version": "1.12.0",
+                          "from": "mime-db@>=1.12.0 <1.13.0",
+                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
                         }
                       }
                     }
@@ -3613,106 +3647,106 @@
                 },
                 "json-stringify-safe": {
                   "version": "5.0.1",
-                  "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+                  "from": "json-stringify-safe@>=5.0.0 <5.1.0",
                   "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
                 },
                 "mime-types": {
                   "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz",
+                  "from": "mime-types@>=1.0.1 <1.1.0",
                   "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
                 },
                 "node-uuid": {
                   "version": "1.4.3",
-                  "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz",
+                  "from": "node-uuid@>=1.4.0 <1.5.0",
                   "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
                 },
                 "qs": {
                   "version": "2.3.3",
-                  "from": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz",
+                  "from": "qs@>=2.3.1 <2.4.0",
                   "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
                 },
                 "tunnel-agent": {
-                  "version": "0.4.0",
-                  "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz",
-                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
+                  "version": "0.4.1",
+                  "from": "tunnel-agent@>=0.4.0 <0.5.0",
+                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
                 },
                 "tough-cookie": {
-                  "version": "1.1.0",
-                  "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-1.1.0.tgz",
-                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-1.1.0.tgz"
+                  "version": "2.0.0",
+                  "from": "tough-cookie@>=0.12.0",
+                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.0.0.tgz"
                 },
                 "http-signature": {
                   "version": "0.10.1",
-                  "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+                  "from": "http-signature@>=0.10.0 <0.11.0",
                   "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
                   "dependencies": {
                     "assert-plus": {
                       "version": "0.1.5",
-                      "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+                      "from": "assert-plus@>=0.1.5 <0.2.0",
                       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
                     },
                     "asn1": {
                       "version": "0.1.11",
-                      "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
+                      "from": "asn1@0.1.11",
                       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
                     },
                     "ctype": {
                       "version": "0.5.3",
-                      "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
+                      "from": "ctype@0.5.3",
                       "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
                     }
                   }
                 },
                 "oauth-sign": {
                   "version": "0.5.0",
-                  "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.5.0.tgz",
+                  "from": "oauth-sign@>=0.5.0 <0.6.0",
                   "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.5.0.tgz"
                 },
                 "hawk": {
                   "version": "1.1.1",
-                  "from": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
+                  "from": "hawk@1.1.1",
                   "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
                   "dependencies": {
                     "hoek": {
                       "version": "0.9.1",
-                      "from": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz",
+                      "from": "hoek@>=0.9.0 <0.10.0",
                       "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
                     },
                     "boom": {
                       "version": "0.4.2",
-                      "from": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
+                      "from": "boom@>=0.4.0 <0.5.0",
                       "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
                     },
                     "cryptiles": {
                       "version": "0.2.2",
-                      "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz",
+                      "from": "cryptiles@>=0.2.0 <0.3.0",
                       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
                     },
                     "sntp": {
                       "version": "0.2.4",
-                      "from": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz",
+                      "from": "sntp@>=0.2.0 <0.3.0",
                       "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
                     }
                   }
                 },
                 "aws-sign2": {
                   "version": "0.5.0",
-                  "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
+                  "from": "aws-sign2@>=0.5.0 <0.6.0",
                   "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
                 },
                 "stringstream": {
                   "version": "0.0.4",
-                  "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz",
+                  "from": "stringstream@>=0.0.4 <0.1.0",
                   "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
                 },
                 "combined-stream": {
                   "version": "0.0.7",
-                  "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+                  "from": "combined-stream@>=0.0.5 <0.1.0",
                   "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
                   "dependencies": {
                     "delayed-stream": {
                       "version": "0.0.5",
-                      "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
+                      "from": "delayed-stream@0.0.5",
                       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
                     }
                   }
@@ -3721,269 +3755,284 @@
             },
             "rimraf": {
               "version": "2.2.8",
-              "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+              "from": "rimraf@>=2.2.8 <2.3.0",
               "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
             },
             "semver": {
-              "version": "4.2.2",
-              "from": "https://registry.npmjs.org/semver/-/semver-4.2.2.tgz",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-4.2.2.tgz"
+              "version": "4.3.6",
+              "from": "semver@>=4.3.6 <4.4.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
             },
             "tar": {
               "version": "1.0.3",
-              "from": "https://registry.npmjs.org/tar/-/tar-1.0.3.tgz",
+              "from": "tar@>=1.0.3 <1.1.0",
               "resolved": "https://registry.npmjs.org/tar/-/tar-1.0.3.tgz",
               "dependencies": {
                 "block-stream": {
                   "version": "0.0.8",
-                  "from": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.8.tgz",
+                  "from": "block-stream@*",
                   "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.8.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "from": "inherits@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             },
             "which": {
               "version": "1.0.9",
-              "from": "https://registry.npmjs.org/which/-/which-1.0.9.tgz",
+              "from": "which@>=1.0.8 <1.1.0",
               "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz"
             }
           }
         },
         "request": {
-          "version": "2.55.0",
-          "from": "https://registry.npmjs.org/request/-/request-2.55.0.tgz",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.55.0.tgz",
+          "version": "2.60.0",
+          "from": "request@>=2.55.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.60.0.tgz",
           "dependencies": {
             "bl": {
-              "version": "0.9.4",
-              "from": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
-              "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
+              "version": "1.0.0",
+              "from": "bl@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz",
               "dependencies": {
                 "readable-stream": {
-                  "version": "1.0.33",
-                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                  "version": "2.0.2",
+                  "from": "readable-stream@>=2.0.0 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                    },
-                    "isarray": {
-                      "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "from": "inherits@>=2.0.1 <2.1.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "process-nextick-args": {
+                      "version": "1.0.2",
+                      "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "util-deprecate": {
+                      "version": "1.0.1",
+                      "from": "util-deprecate@>=1.0.1 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
                     }
                   }
                 }
               }
             },
             "caseless": {
-              "version": "0.9.0",
-              "from": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz",
-              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz"
+              "version": "0.11.0",
+              "from": "caseless@>=0.11.0 <0.12.0",
+              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
+            },
+            "extend": {
+              "version": "3.0.0",
+              "from": "extend@>=3.0.0 <3.1.0",
+              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
             },
             "forever-agent": {
               "version": "0.6.1",
-              "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+              "from": "forever-agent@>=0.6.0 <0.7.0",
               "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
             },
             "form-data": {
-              "version": "0.2.0",
-              "from": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
-              "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
+              "version": "1.0.0-rc2",
+              "from": "form-data@>=1.0.0-rc1 <1.1.0",
+              "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc2.tgz",
               "dependencies": {
                 "async": {
-                  "version": "0.9.2",
-                  "from": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
-                  "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
+                  "version": "1.4.0",
+                  "from": "async@>=1.2.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/async/-/async-1.4.0.tgz"
                 }
               }
             },
             "json-stringify-safe": {
               "version": "5.0.1",
-              "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+              "from": "json-stringify-safe@>=5.0.0 <5.1.0",
               "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
             },
             "mime-types": {
-              "version": "2.0.12",
-              "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.12.tgz",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.12.tgz",
+              "version": "2.1.3",
+              "from": "mime-types@>=2.1.2 <2.2.0",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.3.tgz",
               "dependencies": {
                 "mime-db": {
-                  "version": "1.10.0",
-                  "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.10.0.tgz",
-                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.10.0.tgz"
+                  "version": "1.15.0",
+                  "from": "mime-db@>=1.15.0 <1.16.0",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.15.0.tgz"
                 }
               }
             },
             "node-uuid": {
               "version": "1.4.3",
-              "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz",
+              "from": "node-uuid@>=1.4.0 <1.5.0",
               "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
             },
             "qs": {
-              "version": "2.4.2",
-              "from": "https://registry.npmjs.org/qs/-/qs-2.4.2.tgz",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-2.4.2.tgz"
+              "version": "4.0.0",
+              "from": "qs@>=4.0.0 <4.1.0",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz"
             },
             "tunnel-agent": {
-              "version": "0.4.0",
-              "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz",
-              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
+              "version": "0.4.1",
+              "from": "tunnel-agent@>=0.4.0 <0.5.0",
+              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
             },
             "tough-cookie": {
-              "version": "1.1.0",
-              "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-1.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-1.1.0.tgz"
+              "version": "2.0.0",
+              "from": "tough-cookie@>=0.12.0",
+              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.0.0.tgz"
             },
             "http-signature": {
-              "version": "0.10.1",
-              "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
-              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+              "version": "0.11.0",
+              "from": "http-signature@>=0.11.0 <0.12.0",
+              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
               "dependencies": {
                 "assert-plus": {
                   "version": "0.1.5",
-                  "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+                  "from": "assert-plus@>=0.1.5 <0.2.0",
                   "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
                 },
                 "asn1": {
                   "version": "0.1.11",
-                  "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
+                  "from": "asn1@0.1.11",
                   "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
                 },
                 "ctype": {
                   "version": "0.5.3",
-                  "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
+                  "from": "ctype@0.5.3",
                   "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
                 }
               }
             },
             "oauth-sign": {
-              "version": "0.6.0",
-              "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz",
-              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz"
+              "version": "0.8.0",
+              "from": "oauth-sign@>=0.8.0 <0.9.0",
+              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz"
             },
             "hawk": {
-              "version": "2.3.1",
-              "from": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
-              "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
+              "version": "3.1.0",
+              "from": "hawk@>=3.1.0 <3.2.0",
+              "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.0.tgz",
               "dependencies": {
                 "hoek": {
-                  "version": "2.13.0",
-                  "from": "https://registry.npmjs.org/hoek/-/hoek-2.13.0.tgz",
-                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.13.0.tgz"
+                  "version": "2.14.0",
+                  "from": "hoek@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.14.0.tgz"
                 },
                 "boom": {
-                  "version": "2.7.1",
-                  "from": "https://registry.npmjs.org/boom/-/boom-2.7.1.tgz",
-                  "resolved": "https://registry.npmjs.org/boom/-/boom-2.7.1.tgz"
+                  "version": "2.8.0",
+                  "from": "boom@>=2.8.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/boom/-/boom-2.8.0.tgz"
                 },
                 "cryptiles": {
                   "version": "2.0.4",
-                  "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz",
+                  "from": "cryptiles@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz"
                 },
                 "sntp": {
                   "version": "1.0.9",
-                  "from": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+                  "from": "sntp@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
                 }
               }
             },
             "aws-sign2": {
               "version": "0.5.0",
-              "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
+              "from": "aws-sign2@>=0.5.0 <0.6.0",
               "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
             },
             "stringstream": {
               "version": "0.0.4",
-              "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz",
+              "from": "stringstream@>=0.0.4 <0.1.0",
               "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
             },
             "combined-stream": {
-              "version": "0.0.7",
-              "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
-              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+              "version": "1.0.5",
+              "from": "combined-stream@>=1.0.1 <1.1.0",
+              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
               "dependencies": {
                 "delayed-stream": {
-                  "version": "0.0.5",
-                  "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
-                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                  "version": "1.0.0",
+                  "from": "delayed-stream@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
                 }
               }
             },
             "isstream": {
               "version": "0.1.2",
-              "from": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+              "from": "isstream@>=0.1.1 <0.2.0",
               "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
             },
             "har-validator": {
-              "version": "1.7.0",
-              "from": "https://registry.npmjs.org/har-validator/-/har-validator-1.7.0.tgz",
-              "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-1.7.0.tgz",
+              "version": "1.8.0",
+              "from": "har-validator@>=1.6.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-1.8.0.tgz",
               "dependencies": {
                 "bluebird": {
-                  "version": "2.9.25",
-                  "from": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.25.tgz",
-                  "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.25.tgz"
+                  "version": "2.9.34",
+                  "from": "bluebird@>=2.9.30 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.34.tgz"
                 },
                 "commander": {
                   "version": "2.8.1",
-                  "from": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+                  "from": "commander@>=2.8.1 <3.0.0",
                   "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
                   "dependencies": {
                     "graceful-readlink": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+                      "from": "graceful-readlink@>=1.0.0",
                       "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
                     }
                   }
                 },
                 "is-my-json-valid": {
-                  "version": "2.12.0",
-                  "from": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.0.tgz",
-                  "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.0.tgz",
+                  "version": "2.12.1",
+                  "from": "is-my-json-valid@>=2.12.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.1.tgz",
                   "dependencies": {
                     "generate-function": {
                       "version": "2.0.0",
-                      "from": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+                      "from": "generate-function@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
                     },
                     "generate-object-property": {
                       "version": "1.2.0",
-                      "from": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+                      "from": "generate-object-property@>=1.1.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
                       "dependencies": {
                         "is-property": {
                           "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+                          "from": "is-property@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
                         }
                       }
                     },
                     "jsonpointer": {
                       "version": "1.1.0",
-                      "from": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-1.1.0.tgz",
+                      "from": "jsonpointer@>=1.1.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-1.1.0.tgz"
                     },
                     "xtend": {
                       "version": "4.0.0",
-                      "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
+                      "from": "xtend@>=4.0.0 <5.0.0",
                       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
                     }
                   }
@@ -3994,47 +4043,47 @@
         },
         "sass-graph": {
           "version": "2.0.0",
-          "from": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.0.0.tgz",
+          "from": "sass-graph@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.0.0.tgz",
           "dependencies": {
             "yargs": {
-              "version": "3.9.1",
-              "from": "https://registry.npmjs.org/yargs/-/yargs-3.9.1.tgz",
-              "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.9.1.tgz",
+              "version": "3.15.0",
+              "from": "yargs@>=3.8.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.15.0.tgz",
               "dependencies": {
                 "camelcase": {
                   "version": "1.1.0",
-                  "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.1.0.tgz",
+                  "from": "camelcase@>=1.0.2 <2.0.0",
                   "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.1.0.tgz"
                 },
                 "cliui": {
                   "version": "2.1.0",
-                  "from": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+                  "from": "cliui@>=2.1.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
                   "dependencies": {
                     "center-align": {
                       "version": "0.1.1",
-                      "from": "https://registry.npmjs.org/center-align/-/center-align-0.1.1.tgz",
+                      "from": "center-align@>=0.1.1 <0.2.0",
                       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.1.tgz",
                       "dependencies": {
                         "align-text": {
-                          "version": "0.1.1",
-                          "from": "https://registry.npmjs.org/align-text/-/align-text-0.1.1.tgz",
-                          "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.1.tgz",
+                          "version": "0.1.3",
+                          "from": "align-text@>=0.1.1 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
                           "dependencies": {
                             "kind-of": {
-                              "version": "1.1.0",
-                              "from": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
-                              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz"
+                              "version": "2.0.0",
+                              "from": "kind-of@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.0.tgz"
                             },
                             "longest": {
                               "version": "1.0.1",
-                              "from": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+                              "from": "longest@>=1.0.1 <2.0.0",
                               "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
                             },
                             "repeat-string": {
                               "version": "1.5.2",
-                              "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz",
+                              "from": "repeat-string@>=1.5.2 <2.0.0",
                               "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
                             }
                           }
@@ -4042,28 +4091,28 @@
                       }
                     },
                     "right-align": {
-                      "version": "0.1.1",
-                      "from": "https://registry.npmjs.org/right-align/-/right-align-0.1.1.tgz",
-                      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.1.tgz",
+                      "version": "0.1.3",
+                      "from": "right-align@>=0.1.1 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
                       "dependencies": {
                         "align-text": {
-                          "version": "0.1.1",
-                          "from": "https://registry.npmjs.org/align-text/-/align-text-0.1.1.tgz",
-                          "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.1.tgz",
+                          "version": "0.1.3",
+                          "from": "align-text@>=0.1.1 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
                           "dependencies": {
                             "kind-of": {
-                              "version": "1.1.0",
-                              "from": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
-                              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz"
+                              "version": "2.0.0",
+                              "from": "kind-of@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.0.tgz"
                             },
                             "longest": {
                               "version": "1.0.1",
-                              "from": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+                              "from": "longest@>=1.0.1 <2.0.0",
                               "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
                             },
                             "repeat-string": {
                               "version": "1.5.2",
-                              "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz",
+                              "from": "repeat-string@>=1.5.2 <2.0.0",
                               "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
                             }
                           }
@@ -4072,20 +4121,20 @@
                     },
                     "wordwrap": {
                       "version": "0.0.2",
-                      "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+                      "from": "wordwrap@0.0.2",
                       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                     }
                   }
                 },
                 "decamelize": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/decamelize/-/decamelize-1.0.0.tgz",
+                  "from": "decamelize@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.0.0.tgz"
                 },
                 "window-size": {
-                  "version": "0.1.0",
-                  "from": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-                  "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
+                  "version": "0.1.2",
+                  "from": "window-size@>=0.1.1 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.2.tgz"
                 }
               }
             }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -50,91 +50,91 @@
     },
     "aws-sdk": {
       "version": "2.1.29",
-      "from": "aws-sdk@2.1.29",
+      "from": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1.29.tgz",
       "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1.29.tgz",
       "dependencies": {
         "sax": {
           "version": "0.5.3",
-          "from": "sax@0.5.3",
+          "from": "https://registry.npmjs.org/sax/-/sax-0.5.3.tgz",
           "resolved": "https://registry.npmjs.org/sax/-/sax-0.5.3.tgz"
         },
         "xml2js": {
           "version": "0.2.8",
-          "from": "xml2js@0.2.8",
+          "from": "https://registry.npmjs.org/xml2js/-/xml2js-0.2.8.tgz",
           "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.2.8.tgz"
         },
         "xmlbuilder": {
           "version": "0.4.2",
-          "from": "xmlbuilder@0.4.2",
+          "from": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-0.4.2.tgz",
           "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-0.4.2.tgz"
         }
       }
     },
     "babel": {
       "version": "5.4.5",
-      "from": "babel@5.4.5",
+      "from": "https://registry.npmjs.org/babel/-/babel-5.4.5.tgz",
       "resolved": "https://registry.npmjs.org/babel/-/babel-5.4.5.tgz",
       "dependencies": {
         "chokidar": {
           "version": "1.0.1",
-          "from": "chokidar@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/chokidar/-/chokidar-1.0.1.tgz",
           "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.0.1.tgz",
           "dependencies": {
             "anymatch": {
               "version": "1.3.0",
-              "from": "anymatch@>=1.1.0 <2.0.0",
+              "from": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
               "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
               "dependencies": {
                 "micromatch": {
                   "version": "2.1.6",
-                  "from": "micromatch@>=2.1.5 <3.0.0",
+                  "from": "https://registry.npmjs.org/micromatch/-/micromatch-2.1.6.tgz",
                   "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.1.6.tgz",
                   "dependencies": {
                     "arr-diff": {
                       "version": "1.0.1",
-                      "from": "arr-diff@>=1.0.1 <2.0.0",
+                      "from": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.0.1.tgz",
                       "dependencies": {
                         "array-slice": {
                           "version": "0.2.3",
-                          "from": "array-slice@>=0.2.2 <0.3.0",
+                          "from": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz",
                           "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz"
                         }
                       }
                     },
                     "braces": {
                       "version": "1.8.0",
-                      "from": "braces@>=1.8.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/braces/-/braces-1.8.0.tgz",
                       "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.0.tgz",
                       "dependencies": {
                         "expand-range": {
                           "version": "1.8.1",
-                          "from": "expand-range@>=1.8.1 <2.0.0",
+                          "from": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.1.tgz",
                           "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.1.tgz",
                           "dependencies": {
                             "fill-range": {
                               "version": "2.2.2",
-                              "from": "fill-range@>=2.1.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.2.tgz",
                               "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.2.tgz",
                               "dependencies": {
                                 "is-number": {
                                   "version": "1.1.2",
-                                  "from": "is-number@>=1.1.2 <2.0.0",
+                                  "from": "https://registry.npmjs.org/is-number/-/is-number-1.1.2.tgz",
                                   "resolved": "https://registry.npmjs.org/is-number/-/is-number-1.1.2.tgz"
                                 },
                                 "isobject": {
                                   "version": "1.0.0",
-                                  "from": "isobject@>=1.0.0 <2.0.0",
+                                  "from": "https://registry.npmjs.org/isobject/-/isobject-1.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/isobject/-/isobject-1.0.0.tgz"
                                 },
                                 "randomatic": {
                                   "version": "1.1.0",
-                                  "from": "randomatic@>=1.1.0 <2.0.0",
+                                  "from": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.0.tgz",
                                   "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.0.tgz"
                                 },
                                 "repeat-string": {
                                   "version": "1.5.2",
-                                  "from": "repeat-string@>=1.5.2 <2.0.0",
+                                  "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz",
                                   "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
                                 }
                               }
@@ -143,109 +143,109 @@
                         },
                         "preserve": {
                           "version": "0.2.0",
-                          "from": "preserve@>=0.2.0 <0.3.0",
+                          "from": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
                           "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
                         },
                         "repeat-element": {
                           "version": "1.1.2",
-                          "from": "repeat-element@>=1.1.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
                           "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
                         }
                       }
                     },
                     "debug": {
                       "version": "2.2.0",
-                      "from": "debug@>=2.1.3 <3.0.0",
+                      "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                       "dependencies": {
                         "ms": {
                           "version": "0.7.1",
-                          "from": "ms@0.7.1",
+                          "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
                           "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                         }
                       }
                     },
                     "expand-brackets": {
                       "version": "0.1.1",
-                      "from": "expand-brackets@>=0.1.1 <0.2.0",
+                      "from": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.1.tgz",
                       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.1.tgz"
                     },
                     "filename-regex": {
                       "version": "2.0.0",
-                      "from": "filename-regex@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz"
                     },
                     "kind-of": {
                       "version": "1.1.0",
-                      "from": "kind-of@>=1.1.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz"
                     },
                     "object.omit": {
                       "version": "0.2.1",
-                      "from": "object.omit@>=0.2.1 <0.3.0",
+                      "from": "https://registry.npmjs.org/object.omit/-/object.omit-0.2.1.tgz",
                       "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-0.2.1.tgz",
                       "dependencies": {
                         "for-own": {
                           "version": "0.1.3",
-                          "from": "for-own@>=0.1.1 <0.2.0",
+                          "from": "https://registry.npmjs.org/for-own/-/for-own-0.1.3.tgz",
                           "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.3.tgz",
                           "dependencies": {
                             "for-in": {
                               "version": "0.1.4",
-                              "from": "for-in@>=0.1.4 <0.2.0",
+                              "from": "https://registry.npmjs.org/for-in/-/for-in-0.1.4.tgz",
                               "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.4.tgz"
                             }
                           }
                         },
                         "isobject": {
                           "version": "0.2.0",
-                          "from": "isobject@>=0.2.0 <0.3.0",
+                          "from": "https://registry.npmjs.org/isobject/-/isobject-0.2.0.tgz",
                           "resolved": "https://registry.npmjs.org/isobject/-/isobject-0.2.0.tgz"
                         }
                       }
                     },
                     "parse-glob": {
                       "version": "3.0.2",
-                      "from": "parse-glob@>=3.0.0 <4.0.0",
+                      "from": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.2.tgz",
                       "dependencies": {
                         "glob-base": {
                           "version": "0.2.0",
-                          "from": "glob-base@>=0.2.0 <0.3.0",
+                          "from": "https://registry.npmjs.org/glob-base/-/glob-base-0.2.0.tgz",
                           "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.2.0.tgz"
                         },
                         "is-dotfile": {
                           "version": "1.0.0",
-                          "from": "is-dotfile@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.0.tgz"
                         },
                         "is-extglob": {
                           "version": "1.0.0",
-                          "from": "is-extglob@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
                         }
                       }
                     },
                     "regex-cache": {
                       "version": "0.4.2",
-                      "from": "regex-cache@>=0.4.0 <0.5.0",
+                      "from": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.2.tgz",
                       "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.2.tgz",
                       "dependencies": {
                         "is-equal-shallow": {
                           "version": "0.1.2",
-                          "from": "is-equal-shallow@>=0.1.1 <0.2.0",
+                          "from": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.2.tgz",
                           "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.2.tgz",
                           "dependencies": {
                             "is-primitive": {
                               "version": "1.0.0",
-                              "from": "is-primitive@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/is-primitive/-/is-primitive-1.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-1.0.0.tgz"
                             }
                           }
                         },
                         "is-primitive": {
                           "version": "2.0.0",
-                          "from": "is-primitive@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
                         }
                       }
@@ -256,86 +256,86 @@
             },
             "arrify": {
               "version": "1.0.0",
-              "from": "arrify@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/arrify/-/arrify-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.0.tgz"
             },
             "async-each": {
               "version": "0.1.6",
-              "from": "async-each@>=0.1.5 <0.2.0",
+              "from": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz",
               "resolved": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz"
             },
             "glob-parent": {
               "version": "1.2.0",
-              "from": "glob-parent@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/glob-parent/-/glob-parent-1.2.0.tgz",
               "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-1.2.0.tgz"
             },
             "is-binary-path": {
               "version": "1.0.0",
-              "from": "is-binary-path@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.0.tgz",
               "dependencies": {
                 "binary-extensions": {
                   "version": "1.3.1",
-                  "from": "binary-extensions@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.3.1.tgz",
                   "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.3.1.tgz"
                 }
               }
             },
             "is-glob": {
               "version": "1.1.3",
-              "from": "is-glob@>=1.1.3 <2.0.0",
+              "from": "https://registry.npmjs.org/is-glob/-/is-glob-1.1.3.tgz",
               "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-1.1.3.tgz"
             },
             "readdirp": {
               "version": "1.3.0",
-              "from": "readdirp@>=1.3.0 <2.0.0",
+              "from": "https://registry.npmjs.org/readdirp/-/readdirp-1.3.0.tgz",
               "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-1.3.0.tgz",
               "dependencies": {
                 "graceful-fs": {
                   "version": "2.0.3",
-                  "from": "graceful-fs@>=2.0.0 <2.1.0",
+                  "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
                   "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
                 },
                 "minimatch": {
                   "version": "0.2.14",
-                  "from": "minimatch@>=0.2.12 <0.3.0",
+                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.6.4",
-                      "from": "lru-cache@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz",
                       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.1",
-                      "from": "sigmund@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                     }
                   }
                 },
                 "readable-stream": {
                   "version": "1.0.33",
-                  "from": "readable-stream@>=1.0.26-2 <1.1.0",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "isarray@0.0.1",
+                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
@@ -344,12 +344,12 @@
             },
             "fsevents": {
               "version": "0.3.6",
-              "from": "fsevents@>=0.3.1 <0.4.0",
+              "from": "https://registry.npmjs.org/fsevents/-/fsevents-0.3.6.tgz",
               "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-0.3.6.tgz",
               "dependencies": {
                 "nan": {
                   "version": "1.8.4",
-                  "from": "nan@>=1.8.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/nan/-/nan-1.8.4.tgz",
                   "resolved": "https://registry.npmjs.org/nan/-/nan-1.8.4.tgz"
                 }
               }
@@ -358,280 +358,280 @@
         },
         "commander": {
           "version": "2.8.1",
-          "from": "commander@>=2.6.0 <3.0.0",
+          "from": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
           "dependencies": {
             "graceful-readlink": {
               "version": "1.0.1",
-              "from": "graceful-readlink@>=1.0.0",
+              "from": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
             }
           }
         },
         "convert-source-map": {
           "version": "1.1.1",
-          "from": "convert-source-map@>=1.1.0 <2.0.0",
+          "from": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.1.tgz",
           "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.1.tgz"
         },
         "fs-readdir-recursive": {
           "version": "0.1.2",
-          "from": "fs-readdir-recursive@>=0.1.0 <0.2.0",
+          "from": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-0.1.2.tgz",
           "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-0.1.2.tgz"
         },
         "output-file-sync": {
           "version": "1.1.0",
-          "from": "output-file-sync@>=1.1.0 <2.0.0",
+          "from": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.0.tgz",
           "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.0.tgz",
           "dependencies": {
             "xtend": {
               "version": "4.0.0",
-              "from": "xtend@>=4.0.0 <5.0.0",
+              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
             }
           }
         },
         "path-is-absolute": {
           "version": "1.0.0",
-          "from": "path-is-absolute@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
         },
         "source-map": {
           "version": "0.4.2",
-          "from": "source-map@>=0.4.0 <0.5.0",
+          "from": "https://registry.npmjs.org/source-map/-/source-map-0.4.2.tgz",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.2.tgz",
           "dependencies": {
             "amdefine": {
               "version": "0.1.0",
-              "from": "amdefine@>=0.0.4",
+              "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
               "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
             }
           }
         },
         "slash": {
           "version": "1.0.0",
-          "from": "slash@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz"
         }
       }
     },
     "babel-core": {
       "version": "5.4.5",
-      "from": "babel-core@5.4.5",
+      "from": "https://registry.npmjs.org/babel-core/-/babel-core-5.4.5.tgz",
       "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-5.4.5.tgz",
       "dependencies": {
         "acorn-jsx": {
           "version": "1.0.1",
-          "from": "acorn-jsx@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-1.0.1.tgz",
           "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-1.0.1.tgz",
           "dependencies": {
             "acorn": {
               "version": "1.1.0",
-              "from": "acorn@>=1.0.3 <2.0.0",
+              "from": "https://registry.npmjs.org/acorn/-/acorn-1.1.0.tgz",
               "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.1.0.tgz"
             }
           }
         },
         "ast-types": {
           "version": "0.7.6",
-          "from": "ast-types@>=0.7.0 <0.8.0",
+          "from": "https://registry.npmjs.org/ast-types/-/ast-types-0.7.6.tgz",
           "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.7.6.tgz"
         },
         "bluebird": {
           "version": "2.9.25",
-          "from": "bluebird@>=2.9.25 <3.0.0",
+          "from": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.25.tgz",
           "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.25.tgz"
         },
         "chalk": {
           "version": "1.0.0",
-          "from": "chalk@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "2.0.1",
-              "from": "ansi-styles@>=2.0.1 <3.0.0",
+              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.3",
-              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
             },
             "has-ansi": {
               "version": "1.0.3",
-              "from": "has-ansi@>=1.0.3 <2.0.0",
+              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "1.1.1",
-                  "from": "ansi-regex@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
                 },
                 "get-stdin": {
                   "version": "4.0.1",
-                  "from": "get-stdin@>=4.0.1 <5.0.0",
+                  "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "2.0.1",
-              "from": "strip-ansi@>=2.0.1 <3.0.0",
+              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "1.1.1",
-                  "from": "ansi-regex@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "1.3.1",
-              "from": "supports-color@>=1.3.0 <2.0.0",
+              "from": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
             }
           }
         },
         "convert-source-map": {
           "version": "1.1.1",
-          "from": "convert-source-map@>=1.1.0 <2.0.0",
+          "from": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.1.tgz",
           "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.1.tgz"
         },
         "core-js": {
           "version": "0.9.11",
-          "from": "core-js@>=0.9.0 <0.10.0",
+          "from": "https://registry.npmjs.org/core-js/-/core-js-0.9.11.tgz",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-0.9.11.tgz"
         },
         "debug": {
           "version": "2.2.0",
-          "from": "debug@>=2.1.1 <3.0.0",
+          "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "dependencies": {
             "ms": {
               "version": "0.7.1",
-              "from": "ms@0.7.1",
+              "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
               "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
             }
           }
         },
         "detect-indent": {
           "version": "3.0.1",
-          "from": "detect-indent@>=3.0.0 <4.0.0",
+          "from": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
           "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
           "dependencies": {
             "get-stdin": {
               "version": "4.0.1",
-              "from": "get-stdin@>=4.0.1 <5.0.0",
+              "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
               "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
             }
           }
         },
         "esquery": {
           "version": "0.4.0",
-          "from": "esquery@>=0.4.0 <0.5.0",
+          "from": "https://registry.npmjs.org/esquery/-/esquery-0.4.0.tgz",
           "resolved": "https://registry.npmjs.org/esquery/-/esquery-0.4.0.tgz"
         },
         "estraverse": {
           "version": "4.1.0",
-          "from": "estraverse@>=4.0.0 <5.0.0",
+          "from": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.0.tgz",
           "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.0.tgz"
         },
         "esutils": {
           "version": "2.0.2",
-          "from": "esutils@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
           "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
         },
         "fs-readdir-recursive": {
           "version": "0.1.2",
-          "from": "fs-readdir-recursive@>=0.1.0 <0.2.0",
+          "from": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-0.1.2.tgz",
           "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-0.1.2.tgz"
         },
         "globals": {
           "version": "6.4.1",
-          "from": "globals@>=6.4.0 <7.0.0",
+          "from": "https://registry.npmjs.org/globals/-/globals-6.4.1.tgz",
           "resolved": "https://registry.npmjs.org/globals/-/globals-6.4.1.tgz"
         },
         "home-or-tmp": {
           "version": "1.0.0",
-          "from": "home-or-tmp@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
           "dependencies": {
             "os-tmpdir": {
               "version": "1.0.1",
-              "from": "os-tmpdir@>=1.0.1 <2.0.0",
+              "from": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
             },
             "user-home": {
               "version": "1.1.1",
-              "from": "user-home@>=1.1.1 <2.0.0",
+              "from": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
               "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
             }
           }
         },
         "is-integer": {
           "version": "1.0.4",
-          "from": "is-integer@>=1.0.4 <2.0.0",
+          "from": "https://registry.npmjs.org/is-integer/-/is-integer-1.0.4.tgz",
           "resolved": "https://registry.npmjs.org/is-integer/-/is-integer-1.0.4.tgz",
           "dependencies": {
             "is-finite": {
               "version": "1.0.1",
-              "from": "is-finite@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
               "dependencies": {
                 "number-is-nan": {
                   "version": "1.0.0",
-                  "from": "number-is-nan@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                 }
               }
             },
             "is-nan": {
               "version": "1.0.1",
-              "from": "is-nan@>=1.0.1 <2.0.0",
+              "from": "https://registry.npmjs.org/is-nan/-/is-nan-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.0.1.tgz"
             }
           }
         },
         "js-tokens": {
           "version": "1.0.0",
-          "from": "js-tokens@1.0.0",
+          "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.0.tgz"
         },
         "leven": {
           "version": "1.0.2",
-          "from": "leven@>=1.0.1 <2.0.0",
+          "from": "https://registry.npmjs.org/leven/-/leven-1.0.2.tgz",
           "resolved": "https://registry.npmjs.org/leven/-/leven-1.0.2.tgz"
         },
         "line-numbers": {
           "version": "0.2.0",
-          "from": "line-numbers@0.2.0",
+          "from": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
           "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
           "dependencies": {
             "left-pad": {
               "version": "0.0.3",
-              "from": "left-pad@0.0.3",
+              "from": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz",
               "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
             }
           }
         },
         "minimatch": {
           "version": "2.0.8",
-          "from": "minimatch@>=2.0.3 <3.0.0",
+          "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
           "dependencies": {
             "brace-expansion": {
               "version": "1.1.0",
-              "from": "brace-expansion@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
               "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
               "dependencies": {
                 "balanced-match": {
                   "version": "0.2.0",
-                  "from": "balanced-match@>=0.2.0 <0.3.0",
+                  "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
                 },
                 "concat-map": {
                   "version": "0.0.1",
-                  "from": "concat-map@0.0.1",
+                  "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                 }
               }
@@ -640,127 +640,127 @@
         },
         "output-file-sync": {
           "version": "1.1.0",
-          "from": "output-file-sync@>=1.1.0 <2.0.0",
+          "from": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.0.tgz",
           "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.0.tgz",
           "dependencies": {
             "xtend": {
               "version": "4.0.0",
-              "from": "xtend@>=4.0.0 <5.0.0",
+              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
             }
           }
         },
         "path-is-absolute": {
           "version": "1.0.0",
-          "from": "path-is-absolute@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
         },
         "private": {
           "version": "0.1.6",
-          "from": "private@>=0.1.6 <0.2.0",
+          "from": "https://registry.npmjs.org/private/-/private-0.1.6.tgz",
           "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz"
         },
         "regenerator": {
           "version": "0.8.26",
-          "from": "regenerator@>=0.8.20 <0.9.0",
+          "from": "https://registry.npmjs.org/regenerator/-/regenerator-0.8.26.tgz",
           "resolved": "https://registry.npmjs.org/regenerator/-/regenerator-0.8.26.tgz",
           "dependencies": {
             "commoner": {
               "version": "0.10.1",
-              "from": "commoner@>=0.10.0 <0.11.0",
+              "from": "https://registry.npmjs.org/commoner/-/commoner-0.10.1.tgz",
               "resolved": "https://registry.npmjs.org/commoner/-/commoner-0.10.1.tgz",
               "dependencies": {
                 "q": {
                   "version": "1.1.2",
-                  "from": "q@>=1.1.2 <1.2.0",
+                  "from": "https://registry.npmjs.org/q/-/q-1.1.2.tgz",
                   "resolved": "https://registry.npmjs.org/q/-/q-1.1.2.tgz"
                 },
                 "recast": {
                   "version": "0.9.18",
-                  "from": "recast@>=0.9.5 <0.10.0",
+                  "from": "https://registry.npmjs.org/recast/-/recast-0.9.18.tgz",
                   "resolved": "https://registry.npmjs.org/recast/-/recast-0.9.18.tgz",
                   "dependencies": {
                     "esprima-fb": {
                       "version": "10001.1.0-dev-harmony-fb",
-                      "from": "esprima-fb@>=10001.1.0-dev-harmony-fb <10001.2.0",
+                      "from": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-10001.1.0-dev-harmony-fb.tgz",
                       "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-10001.1.0-dev-harmony-fb.tgz"
                     },
                     "source-map": {
                       "version": "0.1.43",
-                      "from": "source-map@>=0.1.40 <0.2.0",
+                      "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                       "dependencies": {
                         "amdefine": {
                           "version": "0.1.0",
-                          "from": "amdefine@>=0.0.4",
+                          "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
                           "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                         }
                       }
                     },
                     "ast-types": {
                       "version": "0.6.16",
-                      "from": "ast-types@>=0.6.1 <0.7.0",
+                      "from": "https://registry.npmjs.org/ast-types/-/ast-types-0.6.16.tgz",
                       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.6.16.tgz"
                     }
                   }
                 },
                 "commander": {
                   "version": "2.5.1",
-                  "from": "commander@>=2.5.0 <2.6.0",
+                  "from": "https://registry.npmjs.org/commander/-/commander-2.5.1.tgz",
                   "resolved": "https://registry.npmjs.org/commander/-/commander-2.5.1.tgz"
                 },
                 "graceful-fs": {
                   "version": "3.0.7",
-                  "from": "graceful-fs@>=3.0.4 <3.1.0",
+                  "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.7.tgz",
                   "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.7.tgz"
                 },
                 "glob": {
                   "version": "4.2.2",
-                  "from": "glob@>=4.2.1 <4.3.0",
+                  "from": "https://registry.npmjs.org/glob/-/glob-4.2.2.tgz",
                   "resolved": "https://registry.npmjs.org/glob/-/glob-4.2.2.tgz",
                   "dependencies": {
                     "inflight": {
                       "version": "1.0.4",
-                      "from": "inflight@>=1.0.4 <2.0.0",
+                      "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                         }
                       }
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "minimatch": {
                       "version": "1.0.0",
-                      "from": "minimatch@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
                       "dependencies": {
                         "lru-cache": {
                           "version": "2.6.4",
-                          "from": "lru-cache@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz",
                           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
                         },
                         "sigmund": {
                           "version": "1.0.1",
-                          "from": "sigmund@>=1.0.0 <1.1.0",
+                          "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                         }
                       }
                     },
                     "once": {
                       "version": "1.3.2",
-                      "from": "once@>=1.3.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                       "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                         }
                       }
@@ -769,98 +769,98 @@
                 },
                 "install": {
                   "version": "0.1.8",
-                  "from": "install@>=0.1.7 <0.2.0",
+                  "from": "https://registry.npmjs.org/install/-/install-0.1.8.tgz",
                   "resolved": "https://registry.npmjs.org/install/-/install-0.1.8.tgz"
                 },
                 "iconv-lite": {
                   "version": "0.4.8",
-                  "from": "iconv-lite@>=0.4.5 <0.5.0",
+                  "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.8.tgz",
                   "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.8.tgz"
                 }
               }
             },
             "esprima-fb": {
               "version": "13001.1.0-dev-harmony-fb",
-              "from": "esprima-fb@>=13001.1.0-dev-harmony-fb <13001.2.0",
+              "from": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-13001.1.0-dev-harmony-fb.tgz",
               "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-13001.1.0-dev-harmony-fb.tgz"
             },
             "recast": {
               "version": "0.10.12",
-              "from": "recast@>=0.10.3 <0.11.0",
+              "from": "https://registry.npmjs.org/recast/-/recast-0.10.12.tgz",
               "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.12.tgz",
               "dependencies": {
                 "esprima-fb": {
                   "version": "14001.1.0-dev-harmony-fb",
-                  "from": "esprima-fb@>=14001.1.0-dev-harmony-fb <14001.2.0",
+                  "from": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-14001.1.0-dev-harmony-fb.tgz",
                   "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-14001.1.0-dev-harmony-fb.tgz"
                 }
               }
             },
             "through": {
               "version": "2.3.7",
-              "from": "through@>=2.3.6 <2.4.0",
+              "from": "https://registry.npmjs.org/through/-/through-2.3.7.tgz",
               "resolved": "https://registry.npmjs.org/through/-/through-2.3.7.tgz"
             },
             "defs": {
               "version": "1.1.0",
-              "from": "defs@>=1.1.0 <1.2.0",
+              "from": "https://registry.npmjs.org/defs/-/defs-1.1.0.tgz",
               "resolved": "https://registry.npmjs.org/defs/-/defs-1.1.0.tgz",
               "dependencies": {
                 "alter": {
                   "version": "0.2.0",
-                  "from": "alter@>=0.2.0 <0.3.0",
+                  "from": "https://registry.npmjs.org/alter/-/alter-0.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/alter/-/alter-0.2.0.tgz",
                   "dependencies": {
                     "stable": {
                       "version": "0.1.5",
-                      "from": "stable@>=0.1.3 <0.2.0",
+                      "from": "https://registry.npmjs.org/stable/-/stable-0.1.5.tgz",
                       "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.5.tgz"
                     }
                   }
                 },
                 "ast-traverse": {
                   "version": "0.1.1",
-                  "from": "ast-traverse@>=0.1.1 <0.2.0",
+                  "from": "https://registry.npmjs.org/ast-traverse/-/ast-traverse-0.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/ast-traverse/-/ast-traverse-0.1.1.tgz"
                 },
                 "breakable": {
                   "version": "1.0.0",
-                  "from": "breakable@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/breakable/-/breakable-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/breakable/-/breakable-1.0.0.tgz"
                 },
                 "esprima-fb": {
                   "version": "8001.1001.0-dev-harmony-fb",
-                  "from": "esprima-fb@>=8001.1001.0-dev-harmony-fb <8001.1002.0",
+                  "from": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-8001.1001.0-dev-harmony-fb.tgz",
                   "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-8001.1001.0-dev-harmony-fb.tgz"
                 },
                 "simple-fmt": {
                   "version": "0.1.0",
-                  "from": "simple-fmt@>=0.1.0 <0.2.0",
+                  "from": "https://registry.npmjs.org/simple-fmt/-/simple-fmt-0.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/simple-fmt/-/simple-fmt-0.1.0.tgz"
                 },
                 "simple-is": {
                   "version": "0.2.0",
-                  "from": "simple-is@>=0.2.0 <0.3.0",
+                  "from": "https://registry.npmjs.org/simple-is/-/simple-is-0.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/simple-is/-/simple-is-0.2.0.tgz"
                 },
                 "stringmap": {
                   "version": "0.2.2",
-                  "from": "stringmap@>=0.2.2 <0.3.0",
+                  "from": "https://registry.npmjs.org/stringmap/-/stringmap-0.2.2.tgz",
                   "resolved": "https://registry.npmjs.org/stringmap/-/stringmap-0.2.2.tgz"
                 },
                 "stringset": {
                   "version": "0.2.1",
-                  "from": "stringset@>=0.2.1 <0.3.0",
+                  "from": "https://registry.npmjs.org/stringset/-/stringset-0.2.1.tgz",
                   "resolved": "https://registry.npmjs.org/stringset/-/stringset-0.2.1.tgz"
                 },
                 "tryor": {
                   "version": "0.1.2",
-                  "from": "tryor@>=0.1.2 <0.2.0",
+                  "from": "https://registry.npmjs.org/tryor/-/tryor-0.1.2.tgz",
                   "resolved": "https://registry.npmjs.org/tryor/-/tryor-0.1.2.tgz"
                 },
                 "yargs": {
                   "version": "1.3.3",
-                  "from": "yargs@>=1.3.2 <1.4.0",
+                  "from": "https://registry.npmjs.org/yargs/-/yargs-1.3.3.tgz",
                   "resolved": "https://registry.npmjs.org/yargs/-/yargs-1.3.3.tgz"
                 }
               }
@@ -869,39 +869,39 @@
         },
         "regexpu": {
           "version": "1.1.2",
-          "from": "regexpu@>=1.1.2 <2.0.0",
+          "from": "https://registry.npmjs.org/regexpu/-/regexpu-1.1.2.tgz",
           "resolved": "https://registry.npmjs.org/regexpu/-/regexpu-1.1.2.tgz",
           "dependencies": {
             "recast": {
               "version": "0.10.12",
-              "from": "recast@>=0.10.1 <0.11.0",
+              "from": "https://registry.npmjs.org/recast/-/recast-0.10.12.tgz",
               "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.12.tgz",
               "dependencies": {
                 "esprima-fb": {
                   "version": "14001.1.0-dev-harmony-fb",
-                  "from": "esprima-fb@>=14001.1.0-dev-harmony-fb <14001.2.0",
+                  "from": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-14001.1.0-dev-harmony-fb.tgz",
                   "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-14001.1.0-dev-harmony-fb.tgz"
                 }
               }
             },
             "regenerate": {
               "version": "1.2.1",
-              "from": "regenerate@>=1.2.1 <2.0.0",
+              "from": "https://registry.npmjs.org/regenerate/-/regenerate-1.2.1.tgz",
               "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.2.1.tgz"
             },
             "regjsgen": {
               "version": "0.2.0",
-              "from": "regjsgen@>=0.2.0 <0.3.0",
+              "from": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
               "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz"
             },
             "regjsparser": {
               "version": "0.1.4",
-              "from": "regjsparser@>=0.1.4 <0.2.0",
+              "from": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.4.tgz",
               "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.4.tgz",
               "dependencies": {
                 "jsesc": {
                   "version": "0.5.0",
-                  "from": "jsesc@>=0.5.0 <0.6.0",
+                  "from": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
                   "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz"
                 }
               }
@@ -910,58 +910,58 @@
         },
         "repeating": {
           "version": "1.1.2",
-          "from": "repeating@>=1.1.2 <2.0.0",
+          "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.2.tgz",
           "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.2.tgz",
           "dependencies": {
             "is-finite": {
               "version": "1.0.1",
-              "from": "is-finite@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
               "dependencies": {
                 "number-is-nan": {
                   "version": "1.0.0",
-                  "from": "number-is-nan@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                 }
               }
             },
             "meow": {
               "version": "3.1.0",
-              "from": "meow@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/meow/-/meow-3.1.0.tgz",
               "resolved": "https://registry.npmjs.org/meow/-/meow-3.1.0.tgz",
               "dependencies": {
                 "camelcase-keys": {
                   "version": "1.0.0",
-                  "from": "camelcase-keys@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
                   "dependencies": {
                     "camelcase": {
                       "version": "1.1.0",
-                      "from": "camelcase@>=1.0.1 <2.0.0",
+                      "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.1.0.tgz"
                     },
                     "map-obj": {
                       "version": "1.0.1",
-                      "from": "map-obj@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
                     }
                   }
                 },
                 "indent-string": {
                   "version": "1.2.1",
-                  "from": "indent-string@>=1.1.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.1.tgz",
                   "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.1.tgz",
                   "dependencies": {
                     "get-stdin": {
                       "version": "4.0.1",
-                      "from": "get-stdin@>=4.0.1 <5.0.0",
+                      "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
                     }
                   }
                 },
                 "object-assign": {
                   "version": "2.0.0",
-                  "from": "object-assign@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz"
                 }
               }
@@ -970,44 +970,44 @@
         },
         "resolve": {
           "version": "1.1.6",
-          "from": "resolve@>=1.1.6 <2.0.0",
+          "from": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz",
           "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz"
         },
         "shebang-regex": {
           "version": "1.0.0",
-          "from": "shebang-regex@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz"
         },
         "slash": {
           "version": "1.0.0",
-          "from": "slash@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz"
         },
         "source-map": {
           "version": "0.4.2",
-          "from": "source-map@>=0.4.0 <0.5.0",
+          "from": "https://registry.npmjs.org/source-map/-/source-map-0.4.2.tgz",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.2.tgz",
           "dependencies": {
             "amdefine": {
               "version": "0.1.0",
-              "from": "amdefine@>=0.0.4",
+              "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
               "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
             }
           }
         },
         "source-map-support": {
           "version": "0.2.10",
-          "from": "source-map-support@>=0.2.10 <0.3.0",
+          "from": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
           "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
           "dependencies": {
             "source-map": {
               "version": "0.1.32",
-              "from": "source-map@0.1.32",
+              "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
               "dependencies": {
                 "amdefine": {
                   "version": "0.1.0",
-                  "from": "amdefine@>=0.0.4",
+                  "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                 }
               }
@@ -1016,83 +1016,83 @@
         },
         "strip-json-comments": {
           "version": "1.0.2",
-          "from": "strip-json-comments@>=1.0.2 <2.0.0",
+          "from": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.2.tgz",
           "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.2.tgz"
         },
         "to-fast-properties": {
           "version": "1.0.1",
-          "from": "to-fast-properties@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz",
           "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz"
         },
         "trim-right": {
           "version": "1.0.0",
-          "from": "trim-right@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.0.tgz"
         }
       }
     },
     "babel-eslint": {
       "version": "3.1.6",
-      "from": "babel-eslint@3.1.6",
+      "from": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-3.1.6.tgz",
       "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-3.1.6.tgz",
       "dependencies": {
         "lodash.assign": {
           "version": "3.2.0",
-          "from": "lodash.assign@>=3.0.0 <4.0.0",
+          "from": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz",
           "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz",
           "dependencies": {
             "lodash._baseassign": {
               "version": "3.2.0",
-              "from": "lodash._baseassign@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
               "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
               "dependencies": {
                 "lodash._basecopy": {
                   "version": "3.0.1",
-                  "from": "lodash._basecopy@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
                 }
               }
             },
             "lodash._createassigner": {
               "version": "3.1.1",
-              "from": "lodash._createassigner@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
               "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
               "dependencies": {
                 "lodash._bindcallback": {
                   "version": "3.0.1",
-                  "from": "lodash._bindcallback@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
                 },
                 "lodash._isiterateecall": {
                   "version": "3.0.8",
-                  "from": "lodash._isiterateecall@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.8.tgz",
                   "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.8.tgz"
                 },
                 "lodash.restparam": {
                   "version": "3.6.1",
-                  "from": "lodash.restparam@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
                   "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
                 }
               }
             },
             "lodash.keys": {
               "version": "3.1.0",
-              "from": "lodash.keys@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.0.tgz",
               "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.0.tgz",
               "dependencies": {
                 "lodash._getnative": {
                   "version": "3.9.0",
-                  "from": "lodash._getnative@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.0.tgz",
                   "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.0.tgz"
                 },
                 "lodash.isarguments": {
                   "version": "3.0.3",
-                  "from": "lodash.isarguments@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.3.tgz",
                   "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.3.tgz"
                 },
                 "lodash.isarray": {
                   "version": "3.0.3",
-                  "from": "lodash.isarray@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.3.tgz",
                   "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.3.tgz"
                 }
               }
@@ -1103,27 +1103,27 @@
     },
     "babel-loader": {
       "version": "5.1.3",
-      "from": "babel-loader@5.1.3",
+      "from": "https://registry.npmjs.org/babel-loader/-/babel-loader-5.1.3.tgz",
       "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-5.1.3.tgz",
       "dependencies": {
         "object-assign": {
           "version": "2.0.0",
-          "from": "object-assign@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz"
         },
         "loader-utils": {
           "version": "0.2.7",
-          "from": "loader-utils@>=0.2.2 <0.3.0",
+          "from": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.7.tgz",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.7.tgz",
           "dependencies": {
             "json5": {
               "version": "0.1.0",
-              "from": "json5@>=0.1.0 <0.2.0",
+              "from": "https://registry.npmjs.org/json5/-/json5-0.1.0.tgz",
               "resolved": "https://registry.npmjs.org/json5/-/json5-0.1.0.tgz"
             },
             "big.js": {
               "version": "2.5.1",
-              "from": "big.js@>=2.5.1 <2.6.0",
+              "from": "https://registry.npmjs.org/big.js/-/big.js-2.5.1.tgz",
               "resolved": "https://registry.npmjs.org/big.js/-/big.js-2.5.1.tgz"
             }
           }
@@ -1132,91 +1132,203 @@
     },
     "body-parser": {
       "version": "1.12.4",
-      "from": "body-parser@1.12.4",
+      "from": "https://registry.npmjs.org/body-parser/-/body-parser-1.12.4.tgz",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.12.4.tgz",
       "dependencies": {
         "bytes": {
           "version": "1.0.0",
-          "from": "bytes@1.0.0",
+          "from": "https://registry.npmjs.org/bytes/-/bytes-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/bytes/-/bytes-1.0.0.tgz"
         },
         "content-type": {
           "version": "1.0.1",
-          "from": "content-type@>=1.0.1 <1.1.0",
+          "from": "https://registry.npmjs.org/content-type/-/content-type-1.0.1.tgz",
           "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.1.tgz"
         },
         "debug": {
           "version": "2.2.0",
-          "from": "debug@>=2.2.0 <2.3.0",
+          "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "dependencies": {
             "ms": {
               "version": "0.7.1",
-              "from": "ms@0.7.1",
+              "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
               "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
             }
           }
         },
         "depd": {
           "version": "1.0.1",
-          "from": "depd@>=1.0.1 <1.1.0",
+          "from": "https://registry.npmjs.org/depd/-/depd-1.0.1.tgz",
           "resolved": "https://registry.npmjs.org/depd/-/depd-1.0.1.tgz"
         },
         "iconv-lite": {
           "version": "0.4.8",
-          "from": "iconv-lite@0.4.8",
+          "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.8.tgz",
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.8.tgz"
         },
         "on-finished": {
           "version": "2.2.1",
-          "from": "on-finished@>=2.2.1 <2.3.0",
+          "from": "https://registry.npmjs.org/on-finished/-/on-finished-2.2.1.tgz",
           "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.2.1.tgz",
           "dependencies": {
             "ee-first": {
               "version": "1.1.0",
-              "from": "ee-first@1.1.0",
+              "from": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.0.tgz",
               "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.0.tgz"
             }
           }
         },
         "qs": {
           "version": "2.4.2",
-          "from": "qs@2.4.2",
+          "from": "https://registry.npmjs.org/qs/-/qs-2.4.2.tgz",
           "resolved": "https://registry.npmjs.org/qs/-/qs-2.4.2.tgz"
         },
         "raw-body": {
           "version": "2.0.1",
-          "from": "raw-body@>=2.0.1 <2.1.0",
+          "from": "https://registry.npmjs.org/raw-body/-/raw-body-2.0.1.tgz",
           "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.0.1.tgz",
           "dependencies": {
             "bytes": {
               "version": "2.0.1",
-              "from": "bytes@2.0.1",
+              "from": "https://registry.npmjs.org/bytes/-/bytes-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.0.1.tgz"
             }
           }
         },
         "type-is": {
           "version": "1.6.2",
-          "from": "type-is@>=1.6.2 <1.7.0",
+          "from": "https://registry.npmjs.org/type-is/-/type-is-1.6.2.tgz",
           "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.2.tgz",
           "dependencies": {
             "media-typer": {
               "version": "0.3.0",
-              "from": "media-typer@0.3.0",
+              "from": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
               "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
             },
             "mime-types": {
               "version": "2.0.12",
-              "from": "mime-types@>=2.0.11 <2.1.0",
+              "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.12.tgz",
               "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.12.tgz",
               "dependencies": {
                 "mime-db": {
                   "version": "1.10.0",
-                  "from": "mime-db@>=1.10.0 <1.11.0",
+                  "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.10.0.tgz",
                   "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.10.0.tgz"
                 }
               }
+            }
+          }
+        }
+      }
+    },
+    "cheerio": {
+      "version": "0.19.0",
+      "from": "cheerio@*",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.19.0.tgz",
+      "dependencies": {
+        "css-select": {
+          "version": "1.0.0",
+          "from": "css-select@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.0.0.tgz",
+          "dependencies": {
+            "css-what": {
+              "version": "1.0.0",
+              "from": "css-what@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/css-what/-/css-what-1.0.0.tgz"
+            },
+            "domutils": {
+              "version": "1.4.3",
+              "from": "domutils@>=1.4.0 <1.5.0",
+              "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.4.3.tgz",
+              "dependencies": {
+                "domelementtype": {
+                  "version": "1.3.0",
+                  "from": "domelementtype@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
+                }
+              }
+            },
+            "boolbase": {
+              "version": "1.0.0",
+              "from": "boolbase@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz"
+            },
+            "nth-check": {
+              "version": "1.0.1",
+              "from": "nth-check@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz"
+            }
+          }
+        },
+        "entities": {
+          "version": "1.1.1",
+          "from": "entities@>=1.1.1 <1.2.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
+        },
+        "htmlparser2": {
+          "version": "3.8.3",
+          "from": "htmlparser2@>=3.8.1 <3.9.0",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
+          "dependencies": {
+            "domhandler": {
+              "version": "2.3.0",
+              "from": "domhandler@>=2.3.0 <2.4.0",
+              "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz"
+            },
+            "domutils": {
+              "version": "1.5.1",
+              "from": "domutils@>=1.5.0 <1.6.0",
+              "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz"
+            },
+            "domelementtype": {
+              "version": "1.3.0",
+              "from": "domelementtype@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
+            },
+            "readable-stream": {
+              "version": "1.1.13",
+              "from": "readable-stream@>=1.1.0 <1.2.0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "entities": {
+              "version": "1.0.0",
+              "from": "entities@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz"
+            }
+          }
+        },
+        "dom-serializer": {
+          "version": "0.1.0",
+          "from": "dom-serializer@>=0.1.0 <0.2.0",
+          "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+          "dependencies": {
+            "domelementtype": {
+              "version": "1.1.3",
+              "from": "domelementtype@>=1.1.1 <1.2.0",
+              "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
             }
           }
         }
@@ -1304,17 +1416,17 @@
     },
     "cookie-parser": {
       "version": "1.3.5",
-      "from": "cookie-parser@1.3.5",
+      "from": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.3.5.tgz",
       "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.3.5.tgz",
       "dependencies": {
         "cookie": {
           "version": "0.1.3",
-          "from": "cookie@0.1.3",
+          "from": "https://registry.npmjs.org/cookie/-/cookie-0.1.3.tgz",
           "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.3.tgz"
         },
         "cookie-signature": {
           "version": "1.0.6",
-          "from": "cookie-signature@1.0.6",
+          "from": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
           "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz"
         }
       }
@@ -1326,34 +1438,34 @@
     },
     "css-loader": {
       "version": "0.13.1",
-      "from": "css-loader@0.13.1",
+      "from": "https://registry.npmjs.org/css-loader/-/css-loader-0.13.1.tgz",
       "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-0.13.1.tgz",
       "dependencies": {
         "clean-css": {
           "version": "3.2.10",
-          "from": "clean-css@>=3.1.9 <4.0.0",
+          "from": "https://registry.npmjs.org/clean-css/-/clean-css-3.2.10.tgz",
           "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.2.10.tgz",
           "dependencies": {
             "commander": {
               "version": "2.8.1",
-              "from": "commander@>=2.8.0 <2.9.0",
+              "from": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
               "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
               "dependencies": {
                 "graceful-readlink": {
                   "version": "1.0.1",
-                  "from": "graceful-readlink@>=1.0.0",
+                  "from": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
                 }
               }
             },
             "source-map": {
               "version": "0.4.2",
-              "from": "source-map@>=0.4.0 <0.5.0",
+              "from": "https://registry.npmjs.org/source-map/-/source-map-0.4.2.tgz",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.2.tgz",
               "dependencies": {
                 "amdefine": {
                   "version": "0.1.0",
-                  "from": "amdefine@>=0.0.4",
+                  "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                 }
               }
@@ -1362,29 +1474,29 @@
         },
         "fastparse": {
           "version": "1.0.0",
-          "from": "fastparse@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/fastparse/-/fastparse-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.0.0.tgz"
         },
         "loader-utils": {
           "version": "0.2.7",
-          "from": "loader-utils@>=0.2.2 <0.3.0",
+          "from": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.7.tgz",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.7.tgz",
           "dependencies": {
             "json5": {
               "version": "0.1.0",
-              "from": "json5@>=0.1.0 <0.2.0",
+              "from": "https://registry.npmjs.org/json5/-/json5-0.1.0.tgz",
               "resolved": "https://registry.npmjs.org/json5/-/json5-0.1.0.tgz"
             },
             "big.js": {
               "version": "2.5.1",
-              "from": "big.js@>=2.5.1 <2.6.0",
+              "from": "https://registry.npmjs.org/big.js/-/big.js-2.5.1.tgz",
               "resolved": "https://registry.npmjs.org/big.js/-/big.js-2.5.1.tgz"
             }
           }
         },
         "source-list-map": {
           "version": "0.1.5",
-          "from": "source-list-map@>=0.1.4 <0.2.0",
+          "from": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.5.tgz",
           "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.5.tgz"
         }
       }
@@ -1396,88 +1508,88 @@
     },
     "eslint": {
       "version": "0.21.2",
-      "from": "eslint@0.21.2",
+      "from": "https://registry.npmjs.org/eslint/-/eslint-0.21.2.tgz",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-0.21.2.tgz",
       "dependencies": {
         "chalk": {
           "version": "1.0.0",
-          "from": "chalk@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "2.0.1",
-              "from": "ansi-styles@>=2.0.1 <3.0.0",
+              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
             },
             "has-ansi": {
               "version": "1.0.3",
-              "from": "has-ansi@>=1.0.3 <2.0.0",
+              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "1.1.1",
-                  "from": "ansi-regex@>=1.1.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
                 },
                 "get-stdin": {
                   "version": "4.0.1",
-                  "from": "get-stdin@>=4.0.1 <5.0.0",
+                  "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "2.0.1",
-              "from": "strip-ansi@>=2.0.1 <3.0.0",
+              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "1.1.1",
-                  "from": "ansi-regex@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "1.3.1",
-              "from": "supports-color@>=1.3.0 <2.0.0",
+              "from": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
             }
           }
         },
         "concat-stream": {
           "version": "1.4.8",
-          "from": "concat-stream@>=1.4.6 <2.0.0",
+          "from": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.8.tgz",
           "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.8.tgz",
           "dependencies": {
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@>=2.0.1 <2.1.0",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "typedarray": {
               "version": "0.0.6",
-              "from": "typedarray@>=0.0.5 <0.1.0",
+              "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
               "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
             },
             "readable-stream": {
               "version": "1.1.13",
-              "from": "readable-stream@>=1.1.9 <1.2.0",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "isarray@0.0.1",
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 }
               }
@@ -1486,244 +1598,244 @@
         },
         "debug": {
           "version": "2.2.0",
-          "from": "debug@>=2.1.1 <3.0.0",
+          "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "dependencies": {
             "ms": {
               "version": "0.7.1",
-              "from": "ms@0.7.1",
+              "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
               "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
             }
           }
         },
         "doctrine": {
           "version": "0.6.4",
-          "from": "doctrine@>=0.6.2 <0.7.0",
+          "from": "https://registry.npmjs.org/doctrine/-/doctrine-0.6.4.tgz",
           "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-0.6.4.tgz",
           "dependencies": {
             "esutils": {
               "version": "1.1.6",
-              "from": "esutils@>=1.1.6 <2.0.0",
+              "from": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz",
               "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz"
             },
             "isarray": {
               "version": "0.0.1",
-              "from": "isarray@0.0.1",
+              "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
               "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
             }
           }
         },
         "escape-string-regexp": {
           "version": "1.0.3",
-          "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+          "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
         },
         "escope": {
           "version": "3.0.1",
-          "from": "escope@>=3.0.1 <4.0.0",
+          "from": "https://registry.npmjs.org/escope/-/escope-3.0.1.tgz",
           "resolved": "https://registry.npmjs.org/escope/-/escope-3.0.1.tgz",
           "dependencies": {
             "es6-map": {
               "version": "0.1.1",
-              "from": "es6-map@>=0.1.1 <0.2.0",
+              "from": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.1.tgz",
               "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.1.tgz",
               "dependencies": {
                 "d": {
                   "version": "0.1.1",
-                  "from": "d@>=0.1.1 <0.2.0",
+                  "from": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
                 },
                 "es5-ext": {
                   "version": "0.10.7",
-                  "from": "es5-ext@>=0.10.4 <0.11.0",
+                  "from": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.7.tgz",
                   "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.7.tgz",
                   "dependencies": {
                     "es6-symbol": {
                       "version": "2.0.1",
-                      "from": "es6-symbol@>=2.0.1 <2.1.0",
+                      "from": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
                     }
                   }
                 },
                 "es6-iterator": {
                   "version": "0.1.3",
-                  "from": "es6-iterator@>=0.1.1 <0.2.0",
+                  "from": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
                   "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
                   "dependencies": {
                     "es6-symbol": {
                       "version": "2.0.1",
-                      "from": "es6-symbol@>=2.0.1 <2.1.0",
+                      "from": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
                     }
                   }
                 },
                 "es6-set": {
                   "version": "0.1.1",
-                  "from": "es6-set@>=0.1.1 <0.2.0",
+                  "from": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.1.tgz"
                 },
                 "es6-symbol": {
                   "version": "0.1.1",
-                  "from": "es6-symbol@>=0.1.1 <0.2.0",
+                  "from": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-0.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-0.1.1.tgz"
                 },
                 "event-emitter": {
                   "version": "0.3.3",
-                  "from": "event-emitter@>=0.3.1 <0.4.0",
+                  "from": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.3.tgz",
                   "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.3.tgz"
                 }
               }
             },
             "es6-weak-map": {
               "version": "0.1.4",
-              "from": "es6-weak-map@>=0.1.2 <0.2.0",
+              "from": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.4.tgz",
               "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.4.tgz",
               "dependencies": {
                 "d": {
                   "version": "0.1.1",
-                  "from": "d@>=0.1.1 <0.2.0",
+                  "from": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
                 },
                 "es5-ext": {
                   "version": "0.10.7",
-                  "from": "es5-ext@>=0.10.6 <0.11.0",
+                  "from": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.7.tgz",
                   "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.7.tgz"
                 },
                 "es6-iterator": {
                   "version": "0.1.3",
-                  "from": "es6-iterator@>=0.1.3 <0.2.0",
+                  "from": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
                   "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz"
                 },
                 "es6-symbol": {
                   "version": "2.0.1",
-                  "from": "es6-symbol@>=2.0.1 <2.1.0",
+                  "from": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
                 }
               }
             },
             "esrecurse": {
               "version": "3.1.1",
-              "from": "esrecurse@>=3.1.1 <4.0.0",
+              "from": "https://registry.npmjs.org/esrecurse/-/esrecurse-3.1.1.tgz",
               "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-3.1.1.tgz"
             },
             "estraverse": {
               "version": "3.1.0",
-              "from": "estraverse@>=3.1.0 <4.0.0",
+              "from": "https://registry.npmjs.org/estraverse/-/estraverse-3.1.0.tgz",
               "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-3.1.0.tgz"
             }
           }
         },
         "espree": {
           "version": "2.0.2",
-          "from": "espree@>=2.0.1 <3.0.0",
+          "from": "https://registry.npmjs.org/espree/-/espree-2.0.2.tgz",
           "resolved": "https://registry.npmjs.org/espree/-/espree-2.0.2.tgz"
         },
         "estraverse": {
           "version": "2.0.0",
-          "from": "estraverse@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/estraverse/-/estraverse-2.0.0.tgz",
           "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-2.0.0.tgz"
         },
         "estraverse-fb": {
           "version": "1.3.1",
-          "from": "estraverse-fb@>=1.3.1 <2.0.0",
+          "from": "https://registry.npmjs.org/estraverse-fb/-/estraverse-fb-1.3.1.tgz",
           "resolved": "https://registry.npmjs.org/estraverse-fb/-/estraverse-fb-1.3.1.tgz"
         },
         "globals": {
           "version": "6.4.1",
-          "from": "globals@>=6.1.0 <7.0.0",
+          "from": "https://registry.npmjs.org/globals/-/globals-6.4.1.tgz",
           "resolved": "https://registry.npmjs.org/globals/-/globals-6.4.1.tgz"
         },
         "inquirer": {
           "version": "0.8.4",
-          "from": "inquirer@>=0.8.2 <0.9.0",
+          "from": "https://registry.npmjs.org/inquirer/-/inquirer-0.8.4.tgz",
           "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.8.4.tgz",
           "dependencies": {
             "ansi-regex": {
               "version": "1.1.1",
-              "from": "ansi-regex@>=1.1.1 <2.0.0",
+              "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
               "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
             },
             "cli-width": {
               "version": "1.0.1",
-              "from": "cli-width@>=1.0.1 <2.0.0",
+              "from": "https://registry.npmjs.org/cli-width/-/cli-width-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-1.0.1.tgz"
             },
             "figures": {
               "version": "1.3.5",
-              "from": "figures@>=1.3.5 <2.0.0",
+              "from": "https://registry.npmjs.org/figures/-/figures-1.3.5.tgz",
               "resolved": "https://registry.npmjs.org/figures/-/figures-1.3.5.tgz"
             },
             "readline2": {
               "version": "0.1.1",
-              "from": "readline2@>=0.1.1 <0.2.0",
+              "from": "https://registry.npmjs.org/readline2/-/readline2-0.1.1.tgz",
               "resolved": "https://registry.npmjs.org/readline2/-/readline2-0.1.1.tgz",
               "dependencies": {
                 "mute-stream": {
                   "version": "0.0.4",
-                  "from": "mute-stream@0.0.4",
+                  "from": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz",
                   "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz"
                 },
                 "strip-ansi": {
                   "version": "2.0.1",
-                  "from": "strip-ansi@>=2.0.1 <3.0.0",
+                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz"
                 }
               }
             },
             "rx": {
               "version": "2.5.2",
-              "from": "rx@>=2.4.3 <3.0.0",
+              "from": "https://registry.npmjs.org/rx/-/rx-2.5.2.tgz",
               "resolved": "https://registry.npmjs.org/rx/-/rx-2.5.2.tgz"
             },
             "through": {
               "version": "2.3.7",
-              "from": "through@>=2.3.6 <3.0.0",
+              "from": "https://registry.npmjs.org/through/-/through-2.3.7.tgz",
               "resolved": "https://registry.npmjs.org/through/-/through-2.3.7.tgz"
             }
           }
         },
         "js-yaml": {
           "version": "3.3.1",
-          "from": "js-yaml@>=3.2.5 <4.0.0",
+          "from": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.3.1.tgz",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.3.1.tgz",
           "dependencies": {
             "argparse": {
               "version": "1.0.2",
-              "from": "argparse@>=1.0.2 <1.1.0",
+              "from": "https://registry.npmjs.org/argparse/-/argparse-1.0.2.tgz",
               "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.2.tgz",
               "dependencies": {
                 "sprintf-js": {
                   "version": "1.0.2",
-                  "from": "sprintf-js@>=1.0.2 <1.1.0",
+                  "from": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.2.tgz"
                 }
               }
             },
             "esprima": {
               "version": "2.2.0",
-              "from": "esprima@>=2.2.0 <2.3.0",
+              "from": "https://registry.npmjs.org/esprima/-/esprima-2.2.0.tgz",
               "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.2.0.tgz"
             }
           }
         },
         "minimatch": {
           "version": "2.0.8",
-          "from": "minimatch@>=2.0.1 <3.0.0",
+          "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
           "dependencies": {
             "brace-expansion": {
               "version": "1.1.0",
-              "from": "brace-expansion@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
               "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
               "dependencies": {
                 "balanced-match": {
                   "version": "0.2.0",
-                  "from": "balanced-match@>=0.2.0 <0.3.0",
+                  "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
                 },
                 "concat-map": {
                   "version": "0.0.1",
-                  "from": "concat-map@0.0.1",
+                  "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                 }
               }
@@ -1732,69 +1844,69 @@
         },
         "object-assign": {
           "version": "2.0.0",
-          "from": "object-assign@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz"
         },
         "optionator": {
           "version": "0.5.0",
-          "from": "optionator@>=0.5.0 <0.6.0",
+          "from": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
           "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
           "dependencies": {
             "prelude-ls": {
               "version": "1.1.2",
-              "from": "prelude-ls@>=1.1.1 <1.2.0",
+              "from": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
               "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
             },
             "deep-is": {
               "version": "0.1.3",
-              "from": "deep-is@>=0.1.2 <0.2.0",
+              "from": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
               "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
             },
             "wordwrap": {
               "version": "0.0.3",
-              "from": "wordwrap@>=0.0.2 <0.1.0",
+              "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
               "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
             },
             "type-check": {
               "version": "0.3.1",
-              "from": "type-check@>=0.3.1 <0.4.0",
+              "from": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz",
               "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz"
             },
             "levn": {
               "version": "0.2.5",
-              "from": "levn@>=0.2.5 <0.3.0",
+              "from": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz",
               "resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz"
             },
             "fast-levenshtein": {
               "version": "1.0.6",
-              "from": "fast-levenshtein@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.6.tgz",
               "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.6.tgz"
             }
           }
         },
         "path-is-absolute": {
           "version": "1.0.0",
-          "from": "path-is-absolute@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
         },
         "strip-json-comments": {
           "version": "1.0.2",
-          "from": "strip-json-comments@>=1.0.1 <1.1.0",
+          "from": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.2.tgz",
           "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.2.tgz"
         },
         "text-table": {
           "version": "0.2.0",
-          "from": "text-table@>=0.2.0 <0.3.0",
+          "from": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
           "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
         },
         "user-home": {
           "version": "1.1.1",
-          "from": "user-home@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
           "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
         },
         "xml-escape": {
           "version": "1.0.0",
-          "from": "xml-escape@>=1.0.0 <1.1.0",
+          "from": "https://registry.npmjs.org/xml-escape/-/xml-escape-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/xml-escape/-/xml-escape-1.0.0.tgz"
         }
       }
@@ -1806,196 +1918,196 @@
     },
     "express": {
       "version": "4.12.4",
-      "from": "express@4.12.4",
+      "from": "https://registry.npmjs.org/express/-/express-4.12.4.tgz",
       "resolved": "https://registry.npmjs.org/express/-/express-4.12.4.tgz",
       "dependencies": {
         "accepts": {
           "version": "1.2.7",
-          "from": "accepts@>=1.2.7 <1.3.0",
+          "from": "https://registry.npmjs.org/accepts/-/accepts-1.2.7.tgz",
           "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.2.7.tgz",
           "dependencies": {
             "mime-types": {
               "version": "2.0.12",
-              "from": "mime-types@>=2.0.11 <2.1.0",
+              "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.12.tgz",
               "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.12.tgz",
               "dependencies": {
                 "mime-db": {
                   "version": "1.10.0",
-                  "from": "mime-db@>=1.10.0 <1.11.0",
+                  "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.10.0.tgz",
                   "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.10.0.tgz"
                 }
               }
             },
             "negotiator": {
               "version": "0.5.3",
-              "from": "negotiator@0.5.3",
+              "from": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz",
               "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz"
             }
           }
         },
         "content-disposition": {
           "version": "0.5.0",
-          "from": "content-disposition@0.5.0",
+          "from": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.0.tgz",
           "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.0.tgz"
         },
         "content-type": {
           "version": "1.0.1",
-          "from": "content-type@>=1.0.1 <1.1.0",
+          "from": "https://registry.npmjs.org/content-type/-/content-type-1.0.1.tgz",
           "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.1.tgz"
         },
         "cookie": {
           "version": "0.1.2",
-          "from": "cookie@0.1.2",
+          "from": "https://registry.npmjs.org/cookie/-/cookie-0.1.2.tgz",
           "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.2.tgz"
         },
         "cookie-signature": {
           "version": "1.0.6",
-          "from": "cookie-signature@1.0.6",
+          "from": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
           "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz"
         },
         "debug": {
           "version": "2.2.0",
-          "from": "debug@>=2.2.0 <2.3.0",
+          "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "dependencies": {
             "ms": {
               "version": "0.7.1",
-              "from": "ms@0.7.1",
+              "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
               "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
             }
           }
         },
         "depd": {
           "version": "1.0.1",
-          "from": "depd@>=1.0.1 <1.1.0",
+          "from": "https://registry.npmjs.org/depd/-/depd-1.0.1.tgz",
           "resolved": "https://registry.npmjs.org/depd/-/depd-1.0.1.tgz"
         },
         "escape-html": {
           "version": "1.0.1",
-          "from": "escape-html@1.0.1",
+          "from": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz",
           "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz"
         },
         "etag": {
           "version": "1.6.0",
-          "from": "etag@>=1.6.0 <1.7.0",
+          "from": "https://registry.npmjs.org/etag/-/etag-1.6.0.tgz",
           "resolved": "https://registry.npmjs.org/etag/-/etag-1.6.0.tgz",
           "dependencies": {
             "crc": {
               "version": "3.2.1",
-              "from": "crc@3.2.1",
+              "from": "https://registry.npmjs.org/crc/-/crc-3.2.1.tgz",
               "resolved": "https://registry.npmjs.org/crc/-/crc-3.2.1.tgz"
             }
           }
         },
         "finalhandler": {
           "version": "0.3.6",
-          "from": "finalhandler@0.3.6",
+          "from": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.3.6.tgz",
           "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.3.6.tgz"
         },
         "fresh": {
           "version": "0.2.4",
-          "from": "fresh@0.2.4",
+          "from": "https://registry.npmjs.org/fresh/-/fresh-0.2.4.tgz",
           "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.2.4.tgz"
         },
         "merge-descriptors": {
           "version": "1.0.0",
-          "from": "merge-descriptors@1.0.0",
+          "from": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.0.tgz"
         },
         "methods": {
           "version": "1.1.1",
-          "from": "methods@>=1.1.1 <1.2.0",
+          "from": "https://registry.npmjs.org/methods/-/methods-1.1.1.tgz",
           "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.1.tgz"
         },
         "on-finished": {
           "version": "2.2.1",
-          "from": "on-finished@>=2.2.1 <2.3.0",
+          "from": "https://registry.npmjs.org/on-finished/-/on-finished-2.2.1.tgz",
           "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.2.1.tgz",
           "dependencies": {
             "ee-first": {
               "version": "1.1.0",
-              "from": "ee-first@1.1.0",
+              "from": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.0.tgz",
               "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.0.tgz"
             }
           }
         },
         "parseurl": {
           "version": "1.3.0",
-          "from": "parseurl@>=1.3.0 <1.4.0",
+          "from": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.0.tgz",
           "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.0.tgz"
         },
         "path-to-regexp": {
           "version": "0.1.3",
-          "from": "path-to-regexp@0.1.3",
+          "from": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.3.tgz",
           "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.3.tgz"
         },
         "proxy-addr": {
           "version": "1.0.8",
-          "from": "proxy-addr@>=1.0.8 <1.1.0",
+          "from": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.8.tgz",
           "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.8.tgz",
           "dependencies": {
             "forwarded": {
               "version": "0.1.0",
-              "from": "forwarded@>=0.1.0 <0.2.0",
+              "from": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz",
               "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz"
             },
             "ipaddr.js": {
               "version": "1.0.1",
-              "from": "ipaddr.js@1.0.1",
+              "from": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.0.1.tgz"
             }
           }
         },
         "qs": {
           "version": "2.4.2",
-          "from": "qs@2.4.2",
+          "from": "https://registry.npmjs.org/qs/-/qs-2.4.2.tgz",
           "resolved": "https://registry.npmjs.org/qs/-/qs-2.4.2.tgz"
         },
         "range-parser": {
           "version": "1.0.2",
-          "from": "range-parser@>=1.0.2 <1.1.0",
+          "from": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.2.tgz",
           "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.2.tgz"
         },
         "send": {
           "version": "0.12.3",
-          "from": "send@0.12.3",
+          "from": "https://registry.npmjs.org/send/-/send-0.12.3.tgz",
           "resolved": "https://registry.npmjs.org/send/-/send-0.12.3.tgz",
           "dependencies": {
             "destroy": {
               "version": "1.0.3",
-              "from": "destroy@1.0.3",
+              "from": "https://registry.npmjs.org/destroy/-/destroy-1.0.3.tgz",
               "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.3.tgz"
             },
             "ms": {
               "version": "0.7.1",
-              "from": "ms@0.7.1",
+              "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
               "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
             }
           }
         },
         "serve-static": {
           "version": "1.9.3",
-          "from": "serve-static@>=1.9.3 <1.10.0",
+          "from": "https://registry.npmjs.org/serve-static/-/serve-static-1.9.3.tgz",
           "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.9.3.tgz"
         },
         "type-is": {
           "version": "1.6.2",
-          "from": "type-is@>=1.6.2 <1.7.0",
+          "from": "https://registry.npmjs.org/type-is/-/type-is-1.6.2.tgz",
           "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.2.tgz",
           "dependencies": {
             "media-typer": {
               "version": "0.3.0",
-              "from": "media-typer@0.3.0",
+              "from": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
               "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
             },
             "mime-types": {
               "version": "2.0.12",
-              "from": "mime-types@>=2.0.11 <2.1.0",
+              "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.12.tgz",
               "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.12.tgz",
               "dependencies": {
                 "mime-db": {
                   "version": "1.10.0",
-                  "from": "mime-db@>=1.10.0 <1.11.0",
+                  "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.10.0.tgz",
                   "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.10.0.tgz"
                 }
               }
@@ -2004,12 +2116,12 @@
         },
         "vary": {
           "version": "1.0.0",
-          "from": "vary@>=1.0.0 <1.1.0",
+          "from": "https://registry.npmjs.org/vary/-/vary-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/vary/-/vary-1.0.0.tgz"
         },
         "utils-merge": {
           "version": "1.0.0",
-          "from": "utils-merge@1.0.0",
+          "from": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
         }
       }
@@ -2122,7 +2234,7 @@
     },
     "htmltojsx": {
       "version": "0.2.3-dev",
-      "from": "git://github.com/harrison/react-magic.git#6f78be7e89113f054c10171e65bd1c55b88b0c57",
+      "from": "../../../var/folders/wq/7fbqwhks0fg353xqyg0mmkt40000gp/T/npm-23533-bb764f69/git-cache-f7a2981fa843/6f78be7e89113f054c10171e65bd1c55b88b0c57",
       "resolved": "git://github.com/harrison/react-magic.git#6f78be7e89113f054c10171e65bd1c55b88b0c57",
       "dependencies": {
         "yargs": {
@@ -2151,7 +2263,7 @@
     },
     "immutable": {
       "version": "3.7.3",
-      "from": "immutable@3.7.3",
+      "from": "https://registry.npmjs.org/immutable/-/immutable-3.7.3.tgz",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.7.3.tgz"
     },
     "jasmine": {
@@ -2202,69 +2314,69 @@
     },
     "jsdom": {
       "version": "3.1.2",
-      "from": "jsdom@3.1.2",
+      "from": "https://registry.npmjs.org/jsdom/-/jsdom-3.1.2.tgz",
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-3.1.2.tgz",
       "dependencies": {
         "browser-request": {
           "version": "0.3.3",
-          "from": "browser-request@>=0.3.1 <0.4.0",
+          "from": "https://registry.npmjs.org/browser-request/-/browser-request-0.3.3.tgz",
           "resolved": "https://registry.npmjs.org/browser-request/-/browser-request-0.3.3.tgz"
         },
         "contextify": {
           "version": "0.1.14",
-          "from": "contextify@>=0.1.9 <0.2.0",
+          "from": "https://registry.npmjs.org/contextify/-/contextify-0.1.14.tgz",
           "resolved": "https://registry.npmjs.org/contextify/-/contextify-0.1.14.tgz",
           "dependencies": {
             "bindings": {
               "version": "1.2.1",
-              "from": "bindings@*",
+              "from": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz",
               "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz"
             },
             "nan": {
               "version": "1.8.4",
-              "from": "nan@>=1.8.4 <1.9.0",
+              "from": "https://registry.npmjs.org/nan/-/nan-1.8.4.tgz",
               "resolved": "https://registry.npmjs.org/nan/-/nan-1.8.4.tgz"
             }
           }
         },
         "cssom": {
           "version": "0.3.0",
-          "from": "cssom@>=0.3.0 <0.4.0",
+          "from": "https://registry.npmjs.org/cssom/-/cssom-0.3.0.tgz",
           "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.0.tgz"
         },
         "cssstyle": {
           "version": "0.2.26",
-          "from": "cssstyle@>=0.2.21 <0.3.0",
+          "from": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.26.tgz",
           "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.26.tgz"
         },
         "htmlparser2": {
           "version": "3.8.2",
-          "from": "htmlparser2@>=3.7.3 <4.0.0",
+          "from": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.2.tgz",
           "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.2.tgz",
           "dependencies": {
             "domhandler": {
               "version": "2.3.0",
-              "from": "domhandler@>=2.3.0 <2.4.0",
+              "from": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
               "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz"
             },
             "domutils": {
               "version": "1.5.1",
-              "from": "domutils@>=1.5.0 <1.6.0",
+              "from": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
               "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
               "dependencies": {
                 "dom-serializer": {
                   "version": "0.1.0",
-                  "from": "dom-serializer@>=0.0.0 <1.0.0",
+                  "from": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
                   "dependencies": {
                     "domelementtype": {
                       "version": "1.1.3",
-                      "from": "domelementtype@>=1.1.1 <1.2.0",
+                      "from": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
                       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
                     },
                     "entities": {
                       "version": "1.1.1",
-                      "from": "entities@>=1.1.1 <1.2.0",
+                      "from": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
                       "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
                     }
                   }
@@ -2273,86 +2385,86 @@
             },
             "domelementtype": {
               "version": "1.3.0",
-              "from": "domelementtype@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
               "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
             },
             "readable-stream": {
               "version": "1.1.13",
-              "from": "readable-stream@>=1.1.0 <1.2.0",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "isarray@0.0.1",
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             },
             "entities": {
               "version": "1.0.0",
-              "from": "entities@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz"
             }
           }
         },
         "nwmatcher": {
           "version": "1.3.4",
-          "from": "nwmatcher@>=1.3.4 <2.0.0",
+          "from": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.3.4.tgz",
           "resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.3.4.tgz"
         },
         "parse5": {
           "version": "1.4.2",
-          "from": "parse5@>=1.3.1 <2.0.0",
+          "from": "https://registry.npmjs.org/parse5/-/parse5-1.4.2.tgz",
           "resolved": "https://registry.npmjs.org/parse5/-/parse5-1.4.2.tgz"
         },
         "request": {
           "version": "2.55.0",
-          "from": "request@>=2.44.0 <3.0.0",
+          "from": "https://registry.npmjs.org/request/-/request-2.55.0.tgz",
           "resolved": "https://registry.npmjs.org/request/-/request-2.55.0.tgz",
           "dependencies": {
             "bl": {
               "version": "0.9.4",
-              "from": "bl@>=0.9.0 <0.10.0",
+              "from": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
               "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
               "dependencies": {
                 "readable-stream": {
                   "version": "1.0.33",
-                  "from": "readable-stream@>=1.0.26 <1.1.0",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "isarray@0.0.1",
+                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
@@ -2361,247 +2473,247 @@
             },
             "caseless": {
               "version": "0.9.0",
-              "from": "caseless@>=0.9.0 <0.10.0",
+              "from": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz",
               "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz"
             },
             "forever-agent": {
               "version": "0.6.1",
-              "from": "forever-agent@>=0.6.0 <0.7.0",
+              "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
               "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
             },
             "form-data": {
               "version": "0.2.0",
-              "from": "form-data@>=0.2.0 <0.3.0",
+              "from": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
               "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
               "dependencies": {
                 "async": {
                   "version": "0.9.2",
-                  "from": "async@>=0.9.0 <0.10.0",
+                  "from": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
                   "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
                 }
               }
             },
             "json-stringify-safe": {
               "version": "5.0.1",
-              "from": "json-stringify-safe@>=5.0.0 <5.1.0",
+              "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
               "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
             },
             "mime-types": {
               "version": "2.0.12",
-              "from": "mime-types@>=2.0.1 <2.1.0",
+              "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.12.tgz",
               "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.12.tgz",
               "dependencies": {
                 "mime-db": {
                   "version": "1.10.0",
-                  "from": "mime-db@>=1.10.0 <1.11.0",
+                  "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.10.0.tgz",
                   "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.10.0.tgz"
                 }
               }
             },
             "node-uuid": {
               "version": "1.4.3",
-              "from": "node-uuid@>=1.4.0 <1.5.0",
+              "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz",
               "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
             },
             "qs": {
               "version": "2.4.2",
-              "from": "qs@>=2.4.0 <2.5.0",
+              "from": "https://registry.npmjs.org/qs/-/qs-2.4.2.tgz",
               "resolved": "https://registry.npmjs.org/qs/-/qs-2.4.2.tgz"
             },
             "tunnel-agent": {
               "version": "0.4.0",
-              "from": "tunnel-agent@>=0.4.0 <0.5.0",
+              "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz",
               "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
             },
             "tough-cookie": {
               "version": "1.1.0",
-              "from": "tough-cookie@>=0.12.0",
+              "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-1.1.0.tgz",
               "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-1.1.0.tgz"
             },
             "http-signature": {
               "version": "0.10.1",
-              "from": "http-signature@>=0.10.0 <0.11.0",
+              "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
               "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
               "dependencies": {
                 "assert-plus": {
                   "version": "0.1.5",
-                  "from": "assert-plus@>=0.1.5 <0.2.0",
+                  "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
                   "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
                 },
                 "asn1": {
                   "version": "0.1.11",
-                  "from": "asn1@0.1.11",
+                  "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
                   "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
                 },
                 "ctype": {
                   "version": "0.5.3",
-                  "from": "ctype@0.5.3",
+                  "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
                   "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
                 }
               }
             },
             "oauth-sign": {
               "version": "0.6.0",
-              "from": "oauth-sign@>=0.6.0 <0.7.0",
+              "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz",
               "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz"
             },
             "hawk": {
               "version": "2.3.1",
-              "from": "hawk@>=2.3.0 <2.4.0",
+              "from": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
               "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
               "dependencies": {
                 "hoek": {
                   "version": "2.13.0",
-                  "from": "hoek@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/hoek/-/hoek-2.13.0.tgz",
                   "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.13.0.tgz"
                 },
                 "boom": {
                   "version": "2.7.1",
-                  "from": "boom@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/boom/-/boom-2.7.1.tgz",
                   "resolved": "https://registry.npmjs.org/boom/-/boom-2.7.1.tgz"
                 },
                 "cryptiles": {
                   "version": "2.0.4",
-                  "from": "cryptiles@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz",
                   "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz"
                 },
                 "sntp": {
                   "version": "1.0.9",
-                  "from": "sntp@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
                   "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
                 }
               }
             },
             "aws-sign2": {
               "version": "0.5.0",
-              "from": "aws-sign2@>=0.5.0 <0.6.0",
+              "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
               "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
             },
             "stringstream": {
               "version": "0.0.4",
-              "from": "stringstream@>=0.0.4 <0.1.0",
+              "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz",
               "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
             },
             "combined-stream": {
               "version": "0.0.7",
-              "from": "combined-stream@>=0.0.5 <0.1.0",
+              "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
               "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
               "dependencies": {
                 "delayed-stream": {
                   "version": "0.0.5",
-                  "from": "delayed-stream@0.0.5",
+                  "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
                   "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
                 }
               }
             },
             "isstream": {
               "version": "0.1.2",
-              "from": "isstream@>=0.1.1 <0.2.0",
+              "from": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
               "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
             },
             "har-validator": {
               "version": "1.7.0",
-              "from": "har-validator@>=1.4.0 <2.0.0",
+              "from": "https://registry.npmjs.org/har-validator/-/har-validator-1.7.0.tgz",
               "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-1.7.0.tgz",
               "dependencies": {
                 "bluebird": {
                   "version": "2.9.25",
-                  "from": "bluebird@>=2.9.25 <3.0.0",
+                  "from": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.25.tgz",
                   "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.25.tgz"
                 },
                 "chalk": {
                   "version": "1.0.0",
-                  "from": "chalk@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
                   "dependencies": {
                     "ansi-styles": {
                       "version": "2.0.1",
-                      "from": "ansi-styles@>=2.0.1 <3.0.0",
+                      "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
                     },
                     "escape-string-regexp": {
                       "version": "1.0.3",
-                      "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                      "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
                       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
                     },
                     "has-ansi": {
                       "version": "1.0.3",
-                      "from": "has-ansi@>=1.0.3 <2.0.0",
+                      "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
                       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
                       "dependencies": {
                         "ansi-regex": {
                           "version": "1.1.1",
-                          "from": "ansi-regex@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
                           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
                         },
                         "get-stdin": {
                           "version": "4.0.1",
-                          "from": "get-stdin@>=4.0.1 <5.0.0",
+                          "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
                         }
                       }
                     },
                     "strip-ansi": {
                       "version": "2.0.1",
-                      "from": "strip-ansi@>=2.0.1 <3.0.0",
+                      "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
                       "dependencies": {
                         "ansi-regex": {
                           "version": "1.1.1",
-                          "from": "ansi-regex@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
                           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
                         }
                       }
                     },
                     "supports-color": {
                       "version": "1.3.1",
-                      "from": "supports-color@>=1.3.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz",
                       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
                     }
                   }
                 },
                 "commander": {
                   "version": "2.8.1",
-                  "from": "commander@>=2.8.1 <3.0.0",
+                  "from": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
                   "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
                   "dependencies": {
                     "graceful-readlink": {
                       "version": "1.0.1",
-                      "from": "graceful-readlink@>=1.0.0",
+                      "from": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
                     }
                   }
                 },
                 "is-my-json-valid": {
                   "version": "2.12.0",
-                  "from": "is-my-json-valid@>=2.10.1 <3.0.0",
+                  "from": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.0.tgz",
                   "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.0.tgz",
                   "dependencies": {
                     "generate-function": {
                       "version": "2.0.0",
-                      "from": "generate-function@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
                     },
                     "generate-object-property": {
                       "version": "1.2.0",
-                      "from": "generate-object-property@>=1.1.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
                       "dependencies": {
                         "is-property": {
                           "version": "1.0.2",
-                          "from": "is-property@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
                         }
                       }
                     },
                     "jsonpointer": {
                       "version": "1.1.0",
-                      "from": "jsonpointer@>=1.1.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-1.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-1.1.0.tgz"
                     },
                     "xtend": {
                       "version": "4.0.0",
-                      "from": "xtend@>=4.0.0 <5.0.0",
+                      "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
                     }
                   }
@@ -2612,96 +2724,96 @@
         },
         "xml-name-validator": {
           "version": "1.0.0",
-          "from": "xml-name-validator@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-1.0.0.tgz"
         },
         "xmlhttprequest": {
           "version": "1.7.0",
-          "from": "xmlhttprequest@>=1.6.0 <2.0.0",
+          "from": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.7.0.tgz",
           "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.7.0.tgz"
         },
         "acorn-globals": {
           "version": "1.0.4",
-          "from": "acorn-globals@>=1.0.2 <2.0.0",
+          "from": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-1.0.4.tgz",
           "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-1.0.4.tgz",
           "dependencies": {
             "acorn": {
               "version": "1.1.0",
-              "from": "acorn@>=1.0.1 <2.0.0",
+              "from": "https://registry.npmjs.org/acorn/-/acorn-1.1.0.tgz",
               "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.1.0.tgz"
             }
           }
         },
         "acorn": {
           "version": "0.11.0",
-          "from": "acorn@0.11.0",
+          "from": "https://registry.npmjs.org/acorn/-/acorn-0.11.0.tgz",
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-0.11.0.tgz"
         },
         "escodegen": {
           "version": "1.6.1",
-          "from": "escodegen@>=1.6.1 <2.0.0",
+          "from": "https://registry.npmjs.org/escodegen/-/escodegen-1.6.1.tgz",
           "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.6.1.tgz",
           "dependencies": {
             "estraverse": {
               "version": "1.9.3",
-              "from": "estraverse@>=1.9.1 <2.0.0",
+              "from": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
               "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz"
             },
             "esutils": {
               "version": "1.1.6",
-              "from": "esutils@>=1.1.6 <2.0.0",
+              "from": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz",
               "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz"
             },
             "esprima": {
               "version": "1.2.5",
-              "from": "esprima@>=1.2.2 <2.0.0",
+              "from": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz",
               "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz"
             },
             "optionator": {
               "version": "0.5.0",
-              "from": "optionator@>=0.5.0 <0.6.0",
+              "from": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
               "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
               "dependencies": {
                 "prelude-ls": {
                   "version": "1.1.2",
-                  "from": "prelude-ls@>=1.1.1 <1.2.0",
+                  "from": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
                   "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
                 },
                 "deep-is": {
                   "version": "0.1.3",
-                  "from": "deep-is@>=0.1.2 <0.2.0",
+                  "from": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
                   "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
                 },
                 "wordwrap": {
                   "version": "0.0.3",
-                  "from": "wordwrap@>=0.0.2 <0.1.0",
+                  "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
                   "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
                 },
                 "type-check": {
                   "version": "0.3.1",
-                  "from": "type-check@>=0.3.1 <0.4.0",
+                  "from": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz",
                   "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz"
                 },
                 "levn": {
                   "version": "0.2.5",
-                  "from": "levn@>=0.2.5 <0.3.0",
+                  "from": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz",
                   "resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz"
                 },
                 "fast-levenshtein": {
                   "version": "1.0.6",
-                  "from": "fast-levenshtein@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.6.tgz",
                   "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.6.tgz"
                 }
               }
             },
             "source-map": {
               "version": "0.1.43",
-              "from": "source-map@>=0.1.40 <0.2.0",
+              "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
               "dependencies": {
                 "amdefine": {
                   "version": "0.1.0",
-                  "from": "amdefine@>=0.0.4",
+                  "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                 }
               }
@@ -2717,7 +2829,7 @@
     },
     "lodash": {
       "version": "3.9.1",
-      "from": "lodash@3.9.1",
+      "from": "https://registry.npmjs.org/lodash/-/lodash-3.9.1.tgz",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.9.1.tgz"
     },
     "mime": {
@@ -2744,27 +2856,27 @@
     },
     "nock": {
       "version": "2.0.1",
-      "from": "nock@2.0.1",
+      "from": "https://registry.npmjs.org/nock/-/nock-2.0.1.tgz",
       "resolved": "https://registry.npmjs.org/nock/-/nock-2.0.1.tgz",
       "dependencies": {
         "chai": {
           "version": "1.10.0",
-          "from": "chai@>=1.9.2 <2.0.0",
+          "from": "https://registry.npmjs.org/chai/-/chai-1.10.0.tgz",
           "resolved": "https://registry.npmjs.org/chai/-/chai-1.10.0.tgz",
           "dependencies": {
             "assertion-error": {
               "version": "1.0.0",
-              "from": "assertion-error@1.0.0",
+              "from": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.0.tgz"
             },
             "deep-eql": {
               "version": "0.1.3",
-              "from": "deep-eql@0.1.3",
+              "from": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
               "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
               "dependencies": {
                 "type-detect": {
                   "version": "0.1.1",
-                  "from": "type-detect@0.1.1",
+                  "from": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz"
                 }
               }
@@ -2773,24 +2885,24 @@
         },
         "debug": {
           "version": "1.0.4",
-          "from": "debug@>=1.0.4 <2.0.0",
+          "from": "https://registry.npmjs.org/debug/-/debug-1.0.4.tgz",
           "resolved": "https://registry.npmjs.org/debug/-/debug-1.0.4.tgz",
           "dependencies": {
             "ms": {
               "version": "0.6.2",
-              "from": "ms@0.6.2",
+              "from": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz",
               "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
             }
           }
         },
         "lodash": {
           "version": "2.4.1",
-          "from": "lodash@2.4.1",
+          "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
         },
         "propagate": {
           "version": "0.3.1",
-          "from": "propagate@>=0.3.0 <0.4.0",
+          "from": "https://registry.npmjs.org/propagate/-/propagate-0.3.1.tgz",
           "resolved": "https://registry.npmjs.org/propagate/-/propagate-0.3.1.tgz"
         }
       }
@@ -3029,100 +3141,100 @@
       "dependencies": {
         "async-foreach": {
           "version": "0.1.3",
-          "from": "async-foreach@>=0.1.3 <0.2.0",
+          "from": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz",
           "resolved": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz"
         },
         "chalk": {
           "version": "1.0.0",
-          "from": "chalk@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "2.0.1",
-              "from": "ansi-styles@>=2.0.1 <3.0.0",
+              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.3",
-              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
             },
             "has-ansi": {
               "version": "1.0.3",
-              "from": "has-ansi@>=1.0.3 <2.0.0",
+              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "1.1.1",
-                  "from": "ansi-regex@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "2.0.1",
-              "from": "strip-ansi@>=2.0.1 <3.0.0",
+              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "1.1.1",
-                  "from": "ansi-regex@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "1.3.1",
-              "from": "supports-color@>=1.3.0 <2.0.0",
+              "from": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
             }
           }
         },
         "gaze": {
           "version": "0.5.1",
-          "from": "gaze@>=0.5.1 <0.6.0",
+          "from": "https://registry.npmjs.org/gaze/-/gaze-0.5.1.tgz",
           "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.1.tgz",
           "dependencies": {
             "globule": {
               "version": "0.1.0",
-              "from": "globule@>=0.1.0 <0.2.0",
+              "from": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
               "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
               "dependencies": {
                 "lodash": {
                   "version": "1.0.2",
-                  "from": "lodash@>=1.0.1 <1.1.0",
+                  "from": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz"
                 },
                 "glob": {
                   "version": "3.1.21",
-                  "from": "glob@>=3.1.21 <3.2.0",
+                  "from": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
                   "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
                   "dependencies": {
                     "graceful-fs": {
                       "version": "1.2.3",
-                      "from": "graceful-fs@>=1.2.0 <1.3.0",
+                      "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
                       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
                     },
                     "inherits": {
                       "version": "1.0.0",
-                      "from": "inherits@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
                     }
                   }
                 },
                 "minimatch": {
                   "version": "0.2.14",
-                  "from": "minimatch@>=0.2.11 <0.3.0",
+                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.6.4",
-                      "from": "lru-cache@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz",
                       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.1",
-                      "from": "sigmund@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                     }
                   }
@@ -3133,49 +3245,49 @@
         },
         "get-stdin": {
           "version": "4.0.1",
-          "from": "get-stdin@>=4.0.1 <5.0.0",
+          "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
           "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
         },
         "meow": {
           "version": "3.1.0",
-          "from": "meow@>=3.1.0 <4.0.0",
+          "from": "https://registry.npmjs.org/meow/-/meow-3.1.0.tgz",
           "resolved": "https://registry.npmjs.org/meow/-/meow-3.1.0.tgz",
           "dependencies": {
             "camelcase-keys": {
               "version": "1.0.0",
-              "from": "camelcase-keys@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
               "dependencies": {
                 "camelcase": {
                   "version": "1.1.0",
-                  "from": "camelcase@>=1.0.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.1.0.tgz"
                 },
                 "map-obj": {
                   "version": "1.0.1",
-                  "from": "map-obj@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
                 }
               }
             },
             "indent-string": {
               "version": "1.2.1",
-              "from": "indent-string@>=1.1.0 <2.0.0",
+              "from": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.1.tgz",
               "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.1.tgz",
               "dependencies": {
                 "repeating": {
                   "version": "1.1.2",
-                  "from": "repeating@>=1.1.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.2.tgz",
                   "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.2.tgz",
                   "dependencies": {
                     "is-finite": {
                       "version": "1.0.1",
-                      "from": "is-finite@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                       "dependencies": {
                         "number-is-nan": {
                           "version": "1.0.0",
-                          "from": "number-is-nan@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                         }
                       }
@@ -3186,131 +3298,131 @@
             },
             "object-assign": {
               "version": "2.0.0",
-              "from": "object-assign@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz",
               "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz"
             }
           }
         },
         "nan": {
           "version": "1.8.4",
-          "from": "nan@>=1.8.4 <2.0.0",
+          "from": "https://registry.npmjs.org/nan/-/nan-1.8.4.tgz",
           "resolved": "https://registry.npmjs.org/nan/-/nan-1.8.4.tgz"
         },
         "npmconf": {
           "version": "2.1.2",
-          "from": "npmconf@>=2.1.1 <3.0.0",
+          "from": "https://registry.npmjs.org/npmconf/-/npmconf-2.1.2.tgz",
           "resolved": "https://registry.npmjs.org/npmconf/-/npmconf-2.1.2.tgz",
           "dependencies": {
             "config-chain": {
               "version": "1.1.8",
-              "from": "config-chain@>=1.1.8 <1.2.0",
+              "from": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.8.tgz",
               "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.8.tgz",
               "dependencies": {
                 "proto-list": {
                   "version": "1.2.4",
-                  "from": "proto-list@>=1.2.1 <1.3.0",
+                  "from": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
                   "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz"
                 }
               }
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@>=2.0.0 <2.1.0",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "ini": {
               "version": "1.3.3",
-              "from": "ini@>=1.2.0 <2.0.0",
+              "from": "https://registry.npmjs.org/ini/-/ini-1.3.3.tgz",
               "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.3.tgz"
             },
             "nopt": {
               "version": "3.0.2",
-              "from": "nopt@>=3.0.1 <3.1.0",
+              "from": "https://registry.npmjs.org/nopt/-/nopt-3.0.2.tgz",
               "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.2.tgz",
               "dependencies": {
                 "abbrev": {
                   "version": "1.0.6",
-                  "from": "abbrev@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.6.tgz",
                   "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.6.tgz"
                 }
               }
             },
             "once": {
               "version": "1.3.2",
-              "from": "once@>=1.3.0 <1.4.0",
+              "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
               "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.1",
-                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
             },
             "osenv": {
               "version": "0.1.1",
-              "from": "osenv@>=0.1.0 <0.2.0",
+              "from": "https://registry.npmjs.org/osenv/-/osenv-0.1.1.tgz",
               "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.1.tgz"
             },
             "semver": {
               "version": "4.3.4",
-              "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0",
+              "from": "https://registry.npmjs.org/semver/-/semver-4.3.4.tgz",
               "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.4.tgz"
             },
             "uid-number": {
               "version": "0.0.5",
-              "from": "uid-number@0.0.5",
+              "from": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.5.tgz",
               "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.5.tgz"
             }
           }
         },
         "pangyp": {
           "version": "2.2.0",
-          "from": "pangyp@>=2.2.0 <3.0.0",
+          "from": "https://registry.npmjs.org/pangyp/-/pangyp-2.2.0.tgz",
           "resolved": "https://registry.npmjs.org/pangyp/-/pangyp-2.2.0.tgz",
           "dependencies": {
             "fstream": {
               "version": "1.0.6",
-              "from": "fstream@>=1.0.3 <1.1.0",
+              "from": "https://registry.npmjs.org/fstream/-/fstream-1.0.6.tgz",
               "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.6.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.0 <2.1.0",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             },
             "glob": {
               "version": "4.3.5",
-              "from": "glob@>=4.3.5 <4.4.0",
+              "from": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
               "resolved": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
               "dependencies": {
                 "inflight": {
                   "version": "1.0.4",
-                  "from": "inflight@>=1.0.4 <2.0.0",
+                  "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                   "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "once": {
                   "version": "1.3.2",
-                  "from": "once@>=1.3.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                   "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
@@ -3319,27 +3431,27 @@
             },
             "graceful-fs": {
               "version": "3.0.7",
-              "from": "graceful-fs@>=3.0.5 <3.1.0",
+              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.7.tgz",
               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.7.tgz"
             },
             "minimatch": {
               "version": "2.0.8",
-              "from": "minimatch@>=2.0.1 <2.1.0",
+              "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.0",
-                  "from": "brace-expansion@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                   "dependencies": {
                     "balanced-match": {
                       "version": "0.2.0",
-                      "from": "balanced-match@>=0.2.0 <0.3.0",
+                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
                     },
                     "concat-map": {
                       "version": "0.0.1",
-                      "from": "concat-map@0.0.1",
+                      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                     }
                   }
@@ -3348,59 +3460,59 @@
             },
             "nopt": {
               "version": "3.0.2",
-              "from": "nopt@>=3.0.1 <3.1.0",
+              "from": "https://registry.npmjs.org/nopt/-/nopt-3.0.2.tgz",
               "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.2.tgz",
               "dependencies": {
                 "abbrev": {
                   "version": "1.0.6",
-                  "from": "abbrev@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.6.tgz",
                   "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.6.tgz"
                 }
               }
             },
             "npmlog": {
               "version": "1.0.0",
-              "from": "npmlog@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/npmlog/-/npmlog-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-1.0.0.tgz",
               "dependencies": {
                 "ansi": {
                   "version": "0.3.0",
-                  "from": "ansi@>=0.3.0 <0.4.0",
+                  "from": "https://registry.npmjs.org/ansi/-/ansi-0.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.0.tgz"
                 },
                 "are-we-there-yet": {
                   "version": "1.0.4",
-                  "from": "are-we-there-yet@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.4.tgz",
                   "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.4.tgz",
                   "dependencies": {
                     "delegates": {
                       "version": "0.1.0",
-                      "from": "delegates@>=0.1.0 <0.2.0",
+                      "from": "https://registry.npmjs.org/delegates/-/delegates-0.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/delegates/-/delegates-0.1.0.tgz"
                     },
                     "readable-stream": {
                       "version": "1.1.13",
-                      "from": "readable-stream@>=1.1.13 <2.0.0",
+                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.1",
-                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                         },
                         "isarray": {
                           "version": "0.0.1",
-                          "from": "isarray@0.0.1",
+                          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                         },
                         "inherits": {
                           "version": "2.0.1",
-                          "from": "inherits@>=2.0.1 <2.1.0",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         }
                       }
@@ -3409,12 +3521,12 @@
                 },
                 "gauge": {
                   "version": "1.0.2",
-                  "from": "gauge@>=1.0.2 <1.1.0",
+                  "from": "https://registry.npmjs.org/gauge/-/gauge-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.0.2.tgz",
                   "dependencies": {
                     "has-unicode": {
                       "version": "1.0.0",
-                      "from": "has-unicode@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/has-unicode/-/has-unicode-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-1.0.0.tgz"
                     }
                   }
@@ -3423,42 +3535,42 @@
             },
             "osenv": {
               "version": "0.1.1",
-              "from": "osenv@>=0.0.0 <1.0.0",
+              "from": "https://registry.npmjs.org/osenv/-/osenv-0.1.1.tgz",
               "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.1.tgz"
             },
             "request": {
               "version": "2.51.0",
-              "from": "request@>=2.51.0 <2.52.0",
+              "from": "https://registry.npmjs.org/request/-/request-2.51.0.tgz",
               "resolved": "https://registry.npmjs.org/request/-/request-2.51.0.tgz",
               "dependencies": {
                 "bl": {
                   "version": "0.9.4",
-                  "from": "bl@>=0.9.0 <0.10.0",
+                  "from": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
                   "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
                   "dependencies": {
                     "readable-stream": {
                       "version": "1.0.33",
-                      "from": "readable-stream@>=1.0.26 <1.1.0",
+                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.1",
-                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                         },
                         "isarray": {
                           "version": "0.0.1",
-                          "from": "isarray@0.0.1",
+                          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                         },
                         "inherits": {
                           "version": "2.0.1",
-                          "from": "inherits@>=2.0.1 <2.1.0",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         }
                       }
@@ -3467,32 +3579,32 @@
                 },
                 "caseless": {
                   "version": "0.8.0",
-                  "from": "caseless@>=0.8.0 <0.9.0",
+                  "from": "https://registry.npmjs.org/caseless/-/caseless-0.8.0.tgz",
                   "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.8.0.tgz"
                 },
                 "forever-agent": {
                   "version": "0.5.2",
-                  "from": "forever-agent@>=0.5.0 <0.6.0",
+                  "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz",
                   "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
                 },
                 "form-data": {
                   "version": "0.2.0",
-                  "from": "form-data@>=0.2.0 <0.3.0",
+                  "from": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
                   "dependencies": {
                     "async": {
                       "version": "0.9.2",
-                      "from": "async@>=0.9.0 <0.10.0",
+                      "from": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
                       "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
                     },
                     "mime-types": {
                       "version": "2.0.12",
-                      "from": "mime-types@>=2.0.3 <2.1.0",
+                      "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.12.tgz",
                       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.12.tgz",
                       "dependencies": {
                         "mime-db": {
                           "version": "1.10.0",
-                          "from": "mime-db@>=1.10.0 <1.11.0",
+                          "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.10.0.tgz",
                           "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.10.0.tgz"
                         }
                       }
@@ -3501,106 +3613,106 @@
                 },
                 "json-stringify-safe": {
                   "version": "5.0.1",
-                  "from": "json-stringify-safe@>=5.0.0 <5.1.0",
+                  "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
                 },
                 "mime-types": {
                   "version": "1.0.2",
-                  "from": "mime-types@>=1.0.1 <1.1.0",
+                  "from": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
                 },
                 "node-uuid": {
                   "version": "1.4.3",
-                  "from": "node-uuid@>=1.4.0 <1.5.0",
+                  "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz",
                   "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
                 },
                 "qs": {
                   "version": "2.3.3",
-                  "from": "qs@>=2.3.1 <2.4.0",
+                  "from": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz",
                   "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
                 },
                 "tunnel-agent": {
                   "version": "0.4.0",
-                  "from": "tunnel-agent@>=0.4.0 <0.5.0",
+                  "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz",
                   "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
                 },
                 "tough-cookie": {
                   "version": "1.1.0",
-                  "from": "tough-cookie@>=0.12.0",
+                  "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-1.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-1.1.0.tgz"
                 },
                 "http-signature": {
                   "version": "0.10.1",
-                  "from": "http-signature@>=0.10.0 <0.11.0",
+                  "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
                   "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
                   "dependencies": {
                     "assert-plus": {
                       "version": "0.1.5",
-                      "from": "assert-plus@>=0.1.5 <0.2.0",
+                      "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
                       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
                     },
                     "asn1": {
                       "version": "0.1.11",
-                      "from": "asn1@0.1.11",
+                      "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
                       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
                     },
                     "ctype": {
                       "version": "0.5.3",
-                      "from": "ctype@0.5.3",
+                      "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
                       "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
                     }
                   }
                 },
                 "oauth-sign": {
                   "version": "0.5.0",
-                  "from": "oauth-sign@>=0.5.0 <0.6.0",
+                  "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.5.0.tgz",
                   "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.5.0.tgz"
                 },
                 "hawk": {
                   "version": "1.1.1",
-                  "from": "hawk@1.1.1",
+                  "from": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
                   "dependencies": {
                     "hoek": {
                       "version": "0.9.1",
-                      "from": "hoek@>=0.9.0 <0.10.0",
+                      "from": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz",
                       "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
                     },
                     "boom": {
                       "version": "0.4.2",
-                      "from": "boom@>=0.4.0 <0.5.0",
+                      "from": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
                       "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
                     },
                     "cryptiles": {
                       "version": "0.2.2",
-                      "from": "cryptiles@>=0.2.0 <0.3.0",
+                      "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz",
                       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
                     },
                     "sntp": {
                       "version": "0.2.4",
-                      "from": "sntp@>=0.2.0 <0.3.0",
+                      "from": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz",
                       "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
                     }
                   }
                 },
                 "aws-sign2": {
                   "version": "0.5.0",
-                  "from": "aws-sign2@>=0.5.0 <0.6.0",
+                  "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
                   "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
                 },
                 "stringstream": {
                   "version": "0.0.4",
-                  "from": "stringstream@>=0.0.4 <0.1.0",
+                  "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz",
                   "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
                 },
                 "combined-stream": {
                   "version": "0.0.7",
-                  "from": "combined-stream@>=0.0.5 <0.1.0",
+                  "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
                   "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
                   "dependencies": {
                     "delayed-stream": {
                       "version": "0.0.5",
-                      "from": "delayed-stream@0.0.5",
+                      "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
                       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
                     }
                   }
@@ -3609,71 +3721,71 @@
             },
             "rimraf": {
               "version": "2.2.8",
-              "from": "rimraf@>=2.2.8 <2.3.0",
+              "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
               "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
             },
             "semver": {
               "version": "4.2.2",
-              "from": "semver@>=4.2.0 <4.3.0",
+              "from": "https://registry.npmjs.org/semver/-/semver-4.2.2.tgz",
               "resolved": "https://registry.npmjs.org/semver/-/semver-4.2.2.tgz"
             },
             "tar": {
               "version": "1.0.3",
-              "from": "tar@>=1.0.3 <1.1.0",
+              "from": "https://registry.npmjs.org/tar/-/tar-1.0.3.tgz",
               "resolved": "https://registry.npmjs.org/tar/-/tar-1.0.3.tgz",
               "dependencies": {
                 "block-stream": {
                   "version": "0.0.8",
-                  "from": "block-stream@*",
+                  "from": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.8.tgz",
                   "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.8.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             },
             "which": {
               "version": "1.0.9",
-              "from": "which@>=1.0.8 <1.1.0",
+              "from": "https://registry.npmjs.org/which/-/which-1.0.9.tgz",
               "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz"
             }
           }
         },
         "request": {
           "version": "2.55.0",
-          "from": "request@>=2.55.0 <3.0.0",
+          "from": "https://registry.npmjs.org/request/-/request-2.55.0.tgz",
           "resolved": "https://registry.npmjs.org/request/-/request-2.55.0.tgz",
           "dependencies": {
             "bl": {
               "version": "0.9.4",
-              "from": "bl@>=0.9.0 <0.10.0",
+              "from": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
               "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
               "dependencies": {
                 "readable-stream": {
                   "version": "1.0.33",
-                  "from": "readable-stream@>=1.0.26 <1.1.0",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "isarray@0.0.1",
+                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
@@ -3682,196 +3794,196 @@
             },
             "caseless": {
               "version": "0.9.0",
-              "from": "caseless@>=0.9.0 <0.10.0",
+              "from": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz",
               "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz"
             },
             "forever-agent": {
               "version": "0.6.1",
-              "from": "forever-agent@>=0.6.0 <0.7.0",
+              "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
               "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
             },
             "form-data": {
               "version": "0.2.0",
-              "from": "form-data@>=0.2.0 <0.3.0",
+              "from": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
               "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
               "dependencies": {
                 "async": {
                   "version": "0.9.2",
-                  "from": "async@>=0.9.0 <0.10.0",
+                  "from": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
                   "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
                 }
               }
             },
             "json-stringify-safe": {
               "version": "5.0.1",
-              "from": "json-stringify-safe@>=5.0.0 <5.1.0",
+              "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
               "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
             },
             "mime-types": {
               "version": "2.0.12",
-              "from": "mime-types@>=2.0.1 <2.1.0",
+              "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.12.tgz",
               "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.12.tgz",
               "dependencies": {
                 "mime-db": {
                   "version": "1.10.0",
-                  "from": "mime-db@>=1.10.0 <1.11.0",
+                  "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.10.0.tgz",
                   "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.10.0.tgz"
                 }
               }
             },
             "node-uuid": {
               "version": "1.4.3",
-              "from": "node-uuid@>=1.4.0 <1.5.0",
+              "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz",
               "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
             },
             "qs": {
               "version": "2.4.2",
-              "from": "qs@>=2.4.0 <2.5.0",
+              "from": "https://registry.npmjs.org/qs/-/qs-2.4.2.tgz",
               "resolved": "https://registry.npmjs.org/qs/-/qs-2.4.2.tgz"
             },
             "tunnel-agent": {
               "version": "0.4.0",
-              "from": "tunnel-agent@>=0.4.0 <0.5.0",
+              "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz",
               "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
             },
             "tough-cookie": {
               "version": "1.1.0",
-              "from": "tough-cookie@>=0.12.0",
+              "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-1.1.0.tgz",
               "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-1.1.0.tgz"
             },
             "http-signature": {
               "version": "0.10.1",
-              "from": "http-signature@>=0.10.0 <0.11.0",
+              "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
               "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
               "dependencies": {
                 "assert-plus": {
                   "version": "0.1.5",
-                  "from": "assert-plus@>=0.1.5 <0.2.0",
+                  "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
                   "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
                 },
                 "asn1": {
                   "version": "0.1.11",
-                  "from": "asn1@0.1.11",
+                  "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
                   "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
                 },
                 "ctype": {
                   "version": "0.5.3",
-                  "from": "ctype@0.5.3",
+                  "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
                   "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
                 }
               }
             },
             "oauth-sign": {
               "version": "0.6.0",
-              "from": "oauth-sign@>=0.6.0 <0.7.0",
+              "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz",
               "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz"
             },
             "hawk": {
               "version": "2.3.1",
-              "from": "hawk@>=2.3.0 <2.4.0",
+              "from": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
               "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
               "dependencies": {
                 "hoek": {
                   "version": "2.13.0",
-                  "from": "hoek@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/hoek/-/hoek-2.13.0.tgz",
                   "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.13.0.tgz"
                 },
                 "boom": {
                   "version": "2.7.1",
-                  "from": "boom@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/boom/-/boom-2.7.1.tgz",
                   "resolved": "https://registry.npmjs.org/boom/-/boom-2.7.1.tgz"
                 },
                 "cryptiles": {
                   "version": "2.0.4",
-                  "from": "cryptiles@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz",
                   "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz"
                 },
                 "sntp": {
                   "version": "1.0.9",
-                  "from": "sntp@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
                   "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
                 }
               }
             },
             "aws-sign2": {
               "version": "0.5.0",
-              "from": "aws-sign2@>=0.5.0 <0.6.0",
+              "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
               "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
             },
             "stringstream": {
               "version": "0.0.4",
-              "from": "stringstream@>=0.0.4 <0.1.0",
+              "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz",
               "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
             },
             "combined-stream": {
               "version": "0.0.7",
-              "from": "combined-stream@>=0.0.5 <0.1.0",
+              "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
               "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
               "dependencies": {
                 "delayed-stream": {
                   "version": "0.0.5",
-                  "from": "delayed-stream@0.0.5",
+                  "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
                   "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
                 }
               }
             },
             "isstream": {
               "version": "0.1.2",
-              "from": "isstream@>=0.1.1 <0.2.0",
+              "from": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
               "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
             },
             "har-validator": {
               "version": "1.7.0",
-              "from": "har-validator@>=1.4.0 <2.0.0",
+              "from": "https://registry.npmjs.org/har-validator/-/har-validator-1.7.0.tgz",
               "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-1.7.0.tgz",
               "dependencies": {
                 "bluebird": {
                   "version": "2.9.25",
-                  "from": "bluebird@>=2.9.25 <3.0.0",
+                  "from": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.25.tgz",
                   "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.25.tgz"
                 },
                 "commander": {
                   "version": "2.8.1",
-                  "from": "commander@>=2.8.1 <3.0.0",
+                  "from": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
                   "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
                   "dependencies": {
                     "graceful-readlink": {
                       "version": "1.0.1",
-                      "from": "graceful-readlink@>=1.0.0",
+                      "from": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
                     }
                   }
                 },
                 "is-my-json-valid": {
                   "version": "2.12.0",
-                  "from": "is-my-json-valid@>=2.10.1 <3.0.0",
+                  "from": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.0.tgz",
                   "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.0.tgz",
                   "dependencies": {
                     "generate-function": {
                       "version": "2.0.0",
-                      "from": "generate-function@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
                     },
                     "generate-object-property": {
                       "version": "1.2.0",
-                      "from": "generate-object-property@>=1.1.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
                       "dependencies": {
                         "is-property": {
                           "version": "1.0.2",
-                          "from": "is-property@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
                         }
                       }
                     },
                     "jsonpointer": {
                       "version": "1.1.0",
-                      "from": "jsonpointer@>=1.1.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-1.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-1.1.0.tgz"
                     },
                     "xtend": {
                       "version": "4.0.0",
-                      "from": "xtend@>=4.0.0 <5.0.0",
+                      "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
                     }
                   }
@@ -3882,47 +3994,47 @@
         },
         "sass-graph": {
           "version": "2.0.0",
-          "from": "sass-graph@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.0.0.tgz",
           "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.0.0.tgz",
           "dependencies": {
             "yargs": {
               "version": "3.9.1",
-              "from": "yargs@>=3.8.0 <4.0.0",
+              "from": "https://registry.npmjs.org/yargs/-/yargs-3.9.1.tgz",
               "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.9.1.tgz",
               "dependencies": {
                 "camelcase": {
                   "version": "1.1.0",
-                  "from": "camelcase@>=1.0.2 <2.0.0",
+                  "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.1.0.tgz"
                 },
                 "cliui": {
                   "version": "2.1.0",
-                  "from": "cliui@>=2.1.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
                   "dependencies": {
                     "center-align": {
                       "version": "0.1.1",
-                      "from": "center-align@>=0.1.1 <0.2.0",
+                      "from": "https://registry.npmjs.org/center-align/-/center-align-0.1.1.tgz",
                       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.1.tgz",
                       "dependencies": {
                         "align-text": {
                           "version": "0.1.1",
-                          "from": "align-text@>=0.1.0 <0.2.0",
+                          "from": "https://registry.npmjs.org/align-text/-/align-text-0.1.1.tgz",
                           "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.1.tgz",
                           "dependencies": {
                             "kind-of": {
                               "version": "1.1.0",
-                              "from": "kind-of@>=1.1.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
                               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz"
                             },
                             "longest": {
                               "version": "1.0.1",
-                              "from": "longest@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
                             },
                             "repeat-string": {
                               "version": "1.5.2",
-                              "from": "repeat-string@>=1.5.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz",
                               "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
                             }
                           }
@@ -3931,27 +4043,27 @@
                     },
                     "right-align": {
                       "version": "0.1.1",
-                      "from": "right-align@>=0.1.1 <0.2.0",
+                      "from": "https://registry.npmjs.org/right-align/-/right-align-0.1.1.tgz",
                       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.1.tgz",
                       "dependencies": {
                         "align-text": {
                           "version": "0.1.1",
-                          "from": "align-text@>=0.1.0 <0.2.0",
+                          "from": "https://registry.npmjs.org/align-text/-/align-text-0.1.1.tgz",
                           "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.1.tgz",
                           "dependencies": {
                             "kind-of": {
                               "version": "1.1.0",
-                              "from": "kind-of@>=1.1.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
                               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz"
                             },
                             "longest": {
                               "version": "1.0.1",
-                              "from": "longest@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
                             },
                             "repeat-string": {
                               "version": "1.5.2",
-                              "from": "repeat-string@>=1.5.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz",
                               "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
                             }
                           }
@@ -3960,19 +4072,19 @@
                     },
                     "wordwrap": {
                       "version": "0.0.2",
-                      "from": "wordwrap@0.0.2",
+                      "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                     }
                   }
                 },
                 "decamelize": {
                   "version": "1.0.0",
-                  "from": "decamelize@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/decamelize/-/decamelize-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.0.0.tgz"
                 },
                 "window-size": {
                   "version": "0.1.0",
-                  "from": "window-size@0.1.0",
+                  "from": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
                 }
               }
@@ -4428,189 +4540,189 @@
     },
     "protractor": {
       "version": "2.1.0",
-      "from": "protractor@2.1.0",
+      "from": "https://registry.npmjs.org/protractor/-/protractor-2.1.0.tgz",
       "resolved": "https://registry.npmjs.org/protractor/-/protractor-2.1.0.tgz",
       "dependencies": {
         "request": {
           "version": "2.36.0",
-          "from": "request@>=2.36.0 <2.37.0",
+          "from": "https://registry.npmjs.org/request/-/request-2.36.0.tgz",
           "resolved": "https://registry.npmjs.org/request/-/request-2.36.0.tgz",
           "dependencies": {
             "qs": {
               "version": "0.6.6",
-              "from": "qs@>=0.6.0 <0.7.0",
+              "from": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz",
               "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz"
             },
             "json-stringify-safe": {
               "version": "5.0.1",
-              "from": "json-stringify-safe@>=5.0.0 <5.1.0",
+              "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
               "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
             },
             "mime": {
               "version": "1.2.11",
-              "from": "mime@>=1.2.9 <1.3.0",
+              "from": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
               "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
             },
             "forever-agent": {
               "version": "0.5.2",
-              "from": "forever-agent@>=0.5.0 <0.6.0",
+              "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz",
               "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
             },
             "node-uuid": {
               "version": "1.4.3",
-              "from": "node-uuid@>=1.4.0 <1.5.0",
+              "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz",
               "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
             },
             "tough-cookie": {
               "version": "1.1.0",
-              "from": "tough-cookie@>=0.12.0",
+              "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-1.1.0.tgz",
               "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-1.1.0.tgz"
             },
             "form-data": {
               "version": "0.1.4",
-              "from": "form-data@>=0.1.0 <0.2.0",
+              "from": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
               "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
               "dependencies": {
                 "combined-stream": {
                   "version": "0.0.7",
-                  "from": "combined-stream@>=0.0.4 <0.1.0",
+                  "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
                   "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
                   "dependencies": {
                     "delayed-stream": {
                       "version": "0.0.5",
-                      "from": "delayed-stream@0.0.5",
+                      "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
                       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
                     }
                   }
                 },
                 "async": {
                   "version": "0.9.2",
-                  "from": "async@>=0.9.0 <0.10.0",
+                  "from": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
                   "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
                 }
               }
             },
             "tunnel-agent": {
               "version": "0.4.0",
-              "from": "tunnel-agent@>=0.4.0 <0.5.0",
+              "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz",
               "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
             },
             "http-signature": {
               "version": "0.10.1",
-              "from": "http-signature@>=0.10.0 <0.11.0",
+              "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
               "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
               "dependencies": {
                 "assert-plus": {
                   "version": "0.1.5",
-                  "from": "assert-plus@>=0.1.5 <0.2.0",
+                  "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
                   "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
                 },
                 "asn1": {
                   "version": "0.1.11",
-                  "from": "asn1@0.1.11",
+                  "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
                   "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
                 },
                 "ctype": {
                   "version": "0.5.3",
-                  "from": "ctype@0.5.3",
+                  "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
                   "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
                 }
               }
             },
             "oauth-sign": {
               "version": "0.3.0",
-              "from": "oauth-sign@>=0.3.0 <0.4.0",
+              "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.3.0.tgz",
               "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.3.0.tgz"
             },
             "hawk": {
               "version": "1.0.0",
-              "from": "hawk@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/hawk/-/hawk-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.0.0.tgz",
               "dependencies": {
                 "hoek": {
                   "version": "0.9.1",
-                  "from": "hoek@>=0.9.0 <0.10.0",
+                  "from": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz",
                   "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
                 },
                 "boom": {
                   "version": "0.4.2",
-                  "from": "boom@>=0.4.0 <0.5.0",
+                  "from": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
                   "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
                 },
                 "cryptiles": {
                   "version": "0.2.2",
-                  "from": "cryptiles@>=0.2.0 <0.3.0",
+                  "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz",
                   "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
                 },
                 "sntp": {
                   "version": "0.2.4",
-                  "from": "sntp@>=0.2.0 <0.3.0",
+                  "from": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz",
                   "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
                 }
               }
             },
             "aws-sign2": {
               "version": "0.5.0",
-              "from": "aws-sign2@>=0.5.0 <0.6.0",
+              "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
               "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
             }
           }
         },
         "selenium-webdriver": {
           "version": "2.45.1",
-          "from": "selenium-webdriver@2.45.1",
+          "from": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-2.45.1.tgz",
           "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-2.45.1.tgz",
           "dependencies": {
             "tmp": {
               "version": "0.0.24",
-              "from": "tmp@0.0.24",
+              "from": "https://registry.npmjs.org/tmp/-/tmp-0.0.24.tgz",
               "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.24.tgz"
             },
             "ws": {
               "version": "0.7.2",
-              "from": "ws@>=0.7.1 <0.8.0",
+              "from": "https://registry.npmjs.org/ws/-/ws-0.7.2.tgz",
               "resolved": "https://registry.npmjs.org/ws/-/ws-0.7.2.tgz",
               "dependencies": {
                 "options": {
                   "version": "0.0.6",
-                  "from": "options@>=0.0.5",
+                  "from": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
                   "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz"
                 },
                 "ultron": {
                   "version": "1.0.1",
-                  "from": "ultron@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/ultron/-/ultron-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.1.tgz"
                 },
                 "bufferutil": {
                   "version": "1.1.0",
-                  "from": "bufferutil@>=1.1.0 <1.2.0",
+                  "from": "https://registry.npmjs.org/bufferutil/-/bufferutil-1.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-1.1.0.tgz",
                   "dependencies": {
                     "bindings": {
                       "version": "1.2.1",
-                      "from": "bindings@>=1.2.0 <1.3.0",
+                      "from": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz",
                       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz"
                     },
                     "nan": {
                       "version": "1.8.4",
-                      "from": "nan@>=1.8.0 <1.9.0",
+                      "from": "https://registry.npmjs.org/nan/-/nan-1.8.4.tgz",
                       "resolved": "https://registry.npmjs.org/nan/-/nan-1.8.4.tgz"
                     }
                   }
                 },
                 "utf-8-validate": {
                   "version": "1.1.0",
-                  "from": "utf-8-validate@>=1.1.0 <1.2.0",
+                  "from": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-1.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-1.1.0.tgz",
                   "dependencies": {
                     "bindings": {
                       "version": "1.2.1",
-                      "from": "bindings@>=1.2.0 <1.3.0",
+                      "from": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz",
                       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz"
                     },
                     "nan": {
                       "version": "1.8.4",
-                      "from": "nan@>=1.8.0 <1.9.0",
+                      "from": "https://registry.npmjs.org/nan/-/nan-1.8.4.tgz",
                       "resolved": "https://registry.npmjs.org/nan/-/nan-1.8.4.tgz"
                     }
                   }
@@ -4619,22 +4731,22 @@
             },
             "xml2js": {
               "version": "0.4.4",
-              "from": "xml2js@0.4.4",
+              "from": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.4.tgz",
               "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.4.tgz",
               "dependencies": {
                 "sax": {
                   "version": "0.6.1",
-                  "from": "sax@>=0.6.0 <0.7.0",
+                  "from": "https://registry.npmjs.org/sax/-/sax-0.6.1.tgz",
                   "resolved": "https://registry.npmjs.org/sax/-/sax-0.6.1.tgz"
                 },
                 "xmlbuilder": {
                   "version": "2.6.2",
-                  "from": "xmlbuilder@>=1.0.0",
+                  "from": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-2.6.2.tgz",
                   "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-2.6.2.tgz",
                   "dependencies": {
                     "lodash": {
                       "version": "3.5.0",
-                      "from": "lodash@>=3.5.0 <3.6.0",
+                      "from": "https://registry.npmjs.org/lodash/-/lodash-3.5.0.tgz",
                       "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.5.0.tgz"
                     }
                   }
@@ -4645,47 +4757,47 @@
         },
         "minijasminenode": {
           "version": "1.1.1",
-          "from": "minijasminenode@1.1.1",
+          "from": "https://registry.npmjs.org/minijasminenode/-/minijasminenode-1.1.1.tgz",
           "resolved": "https://registry.npmjs.org/minijasminenode/-/minijasminenode-1.1.1.tgz"
         },
         "jasminewd": {
           "version": "1.1.0",
-          "from": "jasminewd@1.1.0",
+          "from": "https://registry.npmjs.org/jasminewd/-/jasminewd-1.1.0.tgz",
           "resolved": "https://registry.npmjs.org/jasminewd/-/jasminewd-1.1.0.tgz"
         },
         "jasminewd2": {
           "version": "0.0.5",
-          "from": "jasminewd2@0.0.5",
+          "from": "https://registry.npmjs.org/jasminewd2/-/jasminewd2-0.0.5.tgz",
           "resolved": "https://registry.npmjs.org/jasminewd2/-/jasminewd2-0.0.5.tgz"
         },
         "saucelabs": {
           "version": "0.1.1",
-          "from": "saucelabs@>=0.1.0 <0.2.0",
+          "from": "https://registry.npmjs.org/saucelabs/-/saucelabs-0.1.1.tgz",
           "resolved": "https://registry.npmjs.org/saucelabs/-/saucelabs-0.1.1.tgz"
         },
         "glob": {
           "version": "3.2.11",
-          "from": "glob@>=3.2.0 <3.3.0",
+          "from": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
           "dependencies": {
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "minimatch": {
               "version": "0.3.0",
-              "from": "minimatch@>=0.3.0 <0.4.0",
+              "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
               "dependencies": {
                 "lru-cache": {
                   "version": "2.6.4",
-                  "from": "lru-cache@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz",
                   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
                 },
                 "sigmund": {
                   "version": "1.0.1",
-                  "from": "sigmund@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                 }
               }
@@ -4694,49 +4806,49 @@
         },
         "adm-zip": {
           "version": "0.4.4",
-          "from": "adm-zip@0.4.4",
+          "from": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.4.tgz",
           "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.4.tgz"
         },
         "optimist": {
           "version": "0.6.1",
-          "from": "optimist@>=0.6.0 <0.7.0",
+          "from": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
           "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
           "dependencies": {
             "wordwrap": {
               "version": "0.0.3",
-              "from": "wordwrap@>=0.0.2 <0.1.0",
+              "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
               "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
             },
             "minimist": {
               "version": "0.0.10",
-              "from": "minimist@>=0.0.1 <0.1.0",
+              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
             }
           }
         },
         "q": {
           "version": "1.0.0",
-          "from": "q@1.0.0",
+          "from": "https://registry.npmjs.org/q/-/q-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/q/-/q-1.0.0.tgz"
         },
         "lodash": {
           "version": "2.4.2",
-          "from": "lodash@>=2.4.1 <2.5.0",
+          "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
         },
         "source-map-support": {
           "version": "0.2.10",
-          "from": "source-map-support@>=0.2.6 <0.3.0",
+          "from": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
           "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
           "dependencies": {
             "source-map": {
               "version": "0.1.32",
-              "from": "source-map@0.1.32",
+              "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
               "dependencies": {
                 "amdefine": {
                   "version": "0.1.0",
-                  "from": "amdefine@>=0.0.4",
+                  "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                 }
               }
@@ -4745,12 +4857,12 @@
         },
         "html-entities": {
           "version": "1.1.2",
-          "from": "html-entities@>=1.1.1 <1.2.0",
+          "from": "https://registry.npmjs.org/html-entities/-/html-entities-1.1.2.tgz",
           "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.1.2.tgz"
         },
         "accessibility-developer-tools": {
           "version": "2.6.0",
-          "from": "accessibility-developer-tools@>=2.6.0 <2.7.0",
+          "from": "https://registry.npmjs.org/accessibility-developer-tools/-/accessibility-developer-tools-2.6.0.tgz",
           "resolved": "https://registry.npmjs.org/accessibility-developer-tools/-/accessibility-developer-tools-2.6.0.tgz"
         }
       }
@@ -4851,49 +4963,49 @@
     },
     "rimraf": {
       "version": "2.3.4",
-      "from": "rimraf@2.3.4",
+      "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.3.4.tgz",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.3.4.tgz",
       "dependencies": {
         "glob": {
           "version": "4.5.3",
-          "from": "glob@>=4.4.2 <5.0.0",
+          "from": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
           "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
           "dependencies": {
             "inflight": {
               "version": "1.0.4",
-              "from": "inflight@>=1.0.4 <2.0.0",
+              "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
               "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.1",
-                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "minimatch": {
               "version": "2.0.8",
-              "from": "minimatch@>=2.0.1 <3.0.0",
+              "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.0",
-                  "from": "brace-expansion@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                   "dependencies": {
                     "balanced-match": {
                       "version": "0.2.0",
-                      "from": "balanced-match@>=0.2.0 <0.3.0",
+                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
                     },
                     "concat-map": {
                       "version": "0.0.1",
-                      "from": "concat-map@0.0.1",
+                      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                     }
                   }
@@ -4902,12 +5014,12 @@
             },
             "once": {
               "version": "1.3.2",
-              "from": "once@>=1.3.0 <2.0.0",
+              "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
               "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.1",
-                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
@@ -5800,123 +5912,123 @@
     },
     "webpack": {
       "version": "1.9.7",
-      "from": "webpack@1.9.7",
+      "from": "https://registry.npmjs.org/webpack/-/webpack-1.9.7.tgz",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-1.9.7.tgz",
       "dependencies": {
         "async": {
           "version": "0.9.2",
-          "from": "async@>=0.9.0 <0.10.0",
+          "from": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
           "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
         },
         "clone": {
           "version": "1.0.2",
-          "from": "clone@>=1.0.2 <1.1.0",
+          "from": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
           "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
         },
         "enhanced-resolve": {
           "version": "0.8.6",
-          "from": "enhanced-resolve@>=0.8.2 <0.9.0",
+          "from": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-0.8.6.tgz",
           "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-0.8.6.tgz",
           "dependencies": {
             "graceful-fs": {
               "version": "3.0.7",
-              "from": "graceful-fs@>=3.0.5 <4.0.0",
+              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.7.tgz",
               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.7.tgz"
             }
           }
         },
         "esprima": {
           "version": "1.2.5",
-          "from": "esprima@>=1.2.0 <1.3.0",
+          "from": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz",
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz"
         },
         "interpret": {
           "version": "0.5.2",
-          "from": "interpret@>=0.5.2 <0.6.0",
+          "from": "https://registry.npmjs.org/interpret/-/interpret-0.5.2.tgz",
           "resolved": "https://registry.npmjs.org/interpret/-/interpret-0.5.2.tgz"
         },
         "memory-fs": {
           "version": "0.2.0",
-          "from": "memory-fs@>=0.2.0 <0.3.0",
+          "from": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.2.0.tgz",
           "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.2.0.tgz"
         },
         "optimist": {
           "version": "0.6.1",
-          "from": "optimist@>=0.6.0 <0.7.0",
+          "from": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
           "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
           "dependencies": {
             "wordwrap": {
               "version": "0.0.3",
-              "from": "wordwrap@>=0.0.2 <0.1.0",
+              "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
               "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
             },
             "minimist": {
               "version": "0.0.10",
-              "from": "minimist@>=0.0.1 <0.1.0",
+              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
             }
           }
         },
         "supports-color": {
           "version": "1.3.1",
-          "from": "supports-color@>=1.2.0 <2.0.0",
+          "from": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
         },
         "tapable": {
           "version": "0.1.9",
-          "from": "tapable@>=0.1.8 <0.2.0",
+          "from": "https://registry.npmjs.org/tapable/-/tapable-0.1.9.tgz",
           "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.1.9.tgz"
         },
         "uglify-js": {
           "version": "2.4.23",
-          "from": "uglify-js@>=2.4.13 <2.5.0",
+          "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.23.tgz",
           "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.23.tgz",
           "dependencies": {
             "async": {
               "version": "0.2.10",
-              "from": "async@>=0.2.6 <0.3.0",
+              "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
               "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
             },
             "source-map": {
               "version": "0.1.34",
-              "from": "source-map@0.1.34",
+              "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
               "dependencies": {
                 "amdefine": {
                   "version": "0.1.0",
-                  "from": "amdefine@>=0.0.4",
+                  "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                 }
               }
             },
             "uglify-to-browserify": {
               "version": "1.0.2",
-              "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
               "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
             },
             "yargs": {
               "version": "3.5.4",
-              "from": "yargs@>=3.5.4 <3.6.0",
+              "from": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
               "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
               "dependencies": {
                 "camelcase": {
                   "version": "1.1.0",
-                  "from": "camelcase@>=1.0.2 <2.0.0",
+                  "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.1.0.tgz"
                 },
                 "decamelize": {
                   "version": "1.0.0",
-                  "from": "decamelize@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/decamelize/-/decamelize-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.0.0.tgz"
                 },
                 "window-size": {
                   "version": "0.1.0",
-                  "from": "window-size@0.1.0",
+                  "from": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
                 },
                 "wordwrap": {
                   "version": "0.0.2",
-                  "from": "wordwrap@0.0.2",
+                  "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                 }
               }
@@ -5925,69 +6037,69 @@
         },
         "watchpack": {
           "version": "0.2.8",
-          "from": "watchpack@>=0.2.1 <0.3.0",
+          "from": "https://registry.npmjs.org/watchpack/-/watchpack-0.2.8.tgz",
           "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-0.2.8.tgz",
           "dependencies": {
             "chokidar": {
               "version": "1.0.1",
-              "from": "chokidar@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/chokidar/-/chokidar-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.0.1.tgz",
               "dependencies": {
                 "anymatch": {
                   "version": "1.3.0",
-                  "from": "anymatch@>=1.1.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
                   "dependencies": {
                     "micromatch": {
                       "version": "2.1.6",
-                      "from": "micromatch@>=2.1.5 <3.0.0",
+                      "from": "https://registry.npmjs.org/micromatch/-/micromatch-2.1.6.tgz",
                       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.1.6.tgz",
                       "dependencies": {
                         "arr-diff": {
                           "version": "1.0.1",
-                          "from": "arr-diff@>=1.0.1 <2.0.0",
+                          "from": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.0.1.tgz",
                           "dependencies": {
                             "array-slice": {
                               "version": "0.2.3",
-                              "from": "array-slice@>=0.2.2 <0.3.0",
+                              "from": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz",
                               "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz"
                             }
                           }
                         },
                         "braces": {
                           "version": "1.8.0",
-                          "from": "braces@>=1.8.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/braces/-/braces-1.8.0.tgz",
                           "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.0.tgz",
                           "dependencies": {
                             "expand-range": {
                               "version": "1.8.1",
-                              "from": "expand-range@>=1.8.1 <2.0.0",
+                              "from": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.1.tgz",
                               "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.1.tgz",
                               "dependencies": {
                                 "fill-range": {
                                   "version": "2.2.2",
-                                  "from": "fill-range@>=2.1.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.2.tgz",
                                   "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.2.tgz",
                                   "dependencies": {
                                     "is-number": {
                                       "version": "1.1.2",
-                                      "from": "is-number@>=1.1.2 <2.0.0",
+                                      "from": "https://registry.npmjs.org/is-number/-/is-number-1.1.2.tgz",
                                       "resolved": "https://registry.npmjs.org/is-number/-/is-number-1.1.2.tgz"
                                     },
                                     "isobject": {
                                       "version": "1.0.0",
-                                      "from": "isobject@>=1.0.0 <2.0.0",
+                                      "from": "https://registry.npmjs.org/isobject/-/isobject-1.0.0.tgz",
                                       "resolved": "https://registry.npmjs.org/isobject/-/isobject-1.0.0.tgz"
                                     },
                                     "randomatic": {
                                       "version": "1.1.0",
-                                      "from": "randomatic@>=1.1.0 <2.0.0",
+                                      "from": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.0.tgz",
                                       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.0.tgz"
                                     },
                                     "repeat-string": {
                                       "version": "1.5.2",
-                                      "from": "repeat-string@>=1.5.2 <2.0.0",
+                                      "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz",
                                       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
                                     }
                                   }
@@ -5996,109 +6108,109 @@
                             },
                             "preserve": {
                               "version": "0.2.0",
-                              "from": "preserve@>=0.2.0 <0.3.0",
+                              "from": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
                               "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
                             },
                             "repeat-element": {
                               "version": "1.1.2",
-                              "from": "repeat-element@>=1.1.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
                               "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
                             }
                           }
                         },
                         "debug": {
                           "version": "2.2.0",
-                          "from": "debug@>=2.1.3 <3.0.0",
+                          "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                           "dependencies": {
                             "ms": {
                               "version": "0.7.1",
-                              "from": "ms@0.7.1",
+                              "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
                               "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                             }
                           }
                         },
                         "expand-brackets": {
                           "version": "0.1.1",
-                          "from": "expand-brackets@>=0.1.1 <0.2.0",
+                          "from": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.1.tgz",
                           "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.1.tgz"
                         },
                         "filename-regex": {
                           "version": "2.0.0",
-                          "from": "filename-regex@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz"
                         },
                         "kind-of": {
                           "version": "1.1.0",
-                          "from": "kind-of@>=1.1.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
                           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz"
                         },
                         "object.omit": {
                           "version": "0.2.1",
-                          "from": "object.omit@>=0.2.1 <0.3.0",
+                          "from": "https://registry.npmjs.org/object.omit/-/object.omit-0.2.1.tgz",
                           "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-0.2.1.tgz",
                           "dependencies": {
                             "for-own": {
                               "version": "0.1.3",
-                              "from": "for-own@>=0.1.1 <0.2.0",
+                              "from": "https://registry.npmjs.org/for-own/-/for-own-0.1.3.tgz",
                               "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.3.tgz",
                               "dependencies": {
                                 "for-in": {
                                   "version": "0.1.4",
-                                  "from": "for-in@>=0.1.4 <0.2.0",
+                                  "from": "https://registry.npmjs.org/for-in/-/for-in-0.1.4.tgz",
                                   "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.4.tgz"
                                 }
                               }
                             },
                             "isobject": {
                               "version": "0.2.0",
-                              "from": "isobject@>=0.2.0 <0.3.0",
+                              "from": "https://registry.npmjs.org/isobject/-/isobject-0.2.0.tgz",
                               "resolved": "https://registry.npmjs.org/isobject/-/isobject-0.2.0.tgz"
                             }
                           }
                         },
                         "parse-glob": {
                           "version": "3.0.2",
-                          "from": "parse-glob@>=3.0.0 <4.0.0",
+                          "from": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.2.tgz",
                           "dependencies": {
                             "glob-base": {
                               "version": "0.2.0",
-                              "from": "glob-base@>=0.2.0 <0.3.0",
+                              "from": "https://registry.npmjs.org/glob-base/-/glob-base-0.2.0.tgz",
                               "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.2.0.tgz"
                             },
                             "is-dotfile": {
                               "version": "1.0.0",
-                              "from": "is-dotfile@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.0.tgz"
                             },
                             "is-extglob": {
                               "version": "1.0.0",
-                              "from": "is-extglob@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
                             }
                           }
                         },
                         "regex-cache": {
                           "version": "0.4.2",
-                          "from": "regex-cache@>=0.4.0 <0.5.0",
+                          "from": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.2.tgz",
                           "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.2.tgz",
                           "dependencies": {
                             "is-equal-shallow": {
                               "version": "0.1.2",
-                              "from": "is-equal-shallow@>=0.1.1 <0.2.0",
+                              "from": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.2.tgz",
                               "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.2.tgz",
                               "dependencies": {
                                 "is-primitive": {
                                   "version": "1.0.0",
-                                  "from": "is-primitive@>=1.0.0 <2.0.0",
+                                  "from": "https://registry.npmjs.org/is-primitive/-/is-primitive-1.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-1.0.0.tgz"
                                 }
                               }
                             },
                             "is-primitive": {
                               "version": "2.0.0",
-                              "from": "is-primitive@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
                             }
                           }
@@ -6109,86 +6221,86 @@
                 },
                 "arrify": {
                   "version": "1.0.0",
-                  "from": "arrify@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/arrify/-/arrify-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.0.tgz"
                 },
                 "async-each": {
                   "version": "0.1.6",
-                  "from": "async-each@>=0.1.5 <0.2.0",
+                  "from": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz",
                   "resolved": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz"
                 },
                 "glob-parent": {
                   "version": "1.2.0",
-                  "from": "glob-parent@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/glob-parent/-/glob-parent-1.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-1.2.0.tgz"
                 },
                 "is-binary-path": {
                   "version": "1.0.0",
-                  "from": "is-binary-path@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.0.tgz",
                   "dependencies": {
                     "binary-extensions": {
                       "version": "1.3.1",
-                      "from": "binary-extensions@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.3.1.tgz",
                       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.3.1.tgz"
                     }
                   }
                 },
                 "is-glob": {
                   "version": "1.1.3",
-                  "from": "is-glob@>=1.1.3 <2.0.0",
+                  "from": "https://registry.npmjs.org/is-glob/-/is-glob-1.1.3.tgz",
                   "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-1.1.3.tgz"
                 },
                 "readdirp": {
                   "version": "1.3.0",
-                  "from": "readdirp@>=1.3.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/readdirp/-/readdirp-1.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-1.3.0.tgz",
                   "dependencies": {
                     "graceful-fs": {
                       "version": "2.0.3",
-                      "from": "graceful-fs@>=2.0.0 <2.1.0",
+                      "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
                       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
                     },
                     "minimatch": {
                       "version": "0.2.14",
-                      "from": "minimatch@>=0.2.12 <0.3.0",
+                      "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                       "dependencies": {
                         "lru-cache": {
                           "version": "2.6.4",
-                          "from": "lru-cache@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz",
                           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
                         },
                         "sigmund": {
                           "version": "1.0.1",
-                          "from": "sigmund@>=1.0.0 <1.1.0",
+                          "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                         }
                       }
                     },
                     "readable-stream": {
                       "version": "1.0.33",
-                      "from": "readable-stream@>=1.0.26-2 <1.1.0",
+                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.1",
-                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                         },
                         "isarray": {
                           "version": "0.0.1",
-                          "from": "isarray@0.0.1",
+                          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                         },
                         "inherits": {
                           "version": "2.0.1",
-                          "from": "inherits@>=2.0.1 <2.1.0",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         }
                       }
@@ -6197,12 +6309,12 @@
                 },
                 "fsevents": {
                   "version": "0.3.6",
-                  "from": "fsevents@>=0.3.1 <0.4.0",
+                  "from": "https://registry.npmjs.org/fsevents/-/fsevents-0.3.6.tgz",
                   "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-0.3.6.tgz",
                   "dependencies": {
                     "nan": {
                       "version": "1.8.4",
-                      "from": "nan@>=1.8.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/nan/-/nan-1.8.4.tgz",
                       "resolved": "https://registry.npmjs.org/nan/-/nan-1.8.4.tgz"
                     }
                   }
@@ -6211,31 +6323,31 @@
             },
             "graceful-fs": {
               "version": "3.0.7",
-              "from": "graceful-fs@>=3.0.2 <4.0.0",
+              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.7.tgz",
               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.7.tgz"
             }
           }
         },
         "webpack-core": {
           "version": "0.6.5",
-          "from": "webpack-core@>=0.6.0 <0.7.0",
+          "from": "https://registry.npmjs.org/webpack-core/-/webpack-core-0.6.5.tgz",
           "resolved": "https://registry.npmjs.org/webpack-core/-/webpack-core-0.6.5.tgz",
           "dependencies": {
             "source-map": {
               "version": "0.4.2",
-              "from": "source-map@>=0.4.1 <0.5.0",
+              "from": "https://registry.npmjs.org/source-map/-/source-map-0.4.2.tgz",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.2.tgz",
               "dependencies": {
                 "amdefine": {
                   "version": "0.1.0",
-                  "from": "amdefine@>=0.0.4",
+                  "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                 }
               }
             },
             "source-list-map": {
               "version": "0.1.5",
-              "from": "source-list-map@>=0.1.0 <0.2.0",
+              "from": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.5.tgz",
               "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.5.tgz"
             }
           }
@@ -6869,46 +6981,58 @@
           }
         },
         "webpack": {
-          "version": "1.9.7",
+          "version": "1.10.5",
           "from": "webpack@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/webpack/-/webpack-1.9.7.tgz",
+          "resolved": "https://registry.npmjs.org/webpack/-/webpack-1.10.5.tgz",
           "dependencies": {
             "async": {
-              "version": "0.9.2",
-              "from": "async@>=0.9.0 <0.10.0",
-              "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
+              "version": "1.4.0",
+              "from": "async@>=1.3.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/async/-/async-1.4.0.tgz"
             },
             "clone": {
               "version": "1.0.2",
-              "from": "clone@>=1.0.2 <1.1.0",
+              "from": "clone@>=1.0.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
             },
             "enhanced-resolve": {
-              "version": "0.8.6",
-              "from": "enhanced-resolve@>=0.8.2 <0.9.0",
-              "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-0.8.6.tgz",
+              "version": "0.9.0",
+              "from": "enhanced-resolve@>=0.9.0 <0.10.0",
+              "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-0.9.0.tgz",
               "dependencies": {
                 "graceful-fs": {
-                  "version": "3.0.7",
+                  "version": "3.0.8",
                   "from": "graceful-fs@>=3.0.5 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.7.tgz"
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
                 }
               }
             },
             "esprima": {
               "version": "1.2.5",
-              "from": "esprima@>=1.2.0 <1.3.0",
+              "from": "esprima@>=1.2.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz"
             },
             "interpret": {
-              "version": "0.5.2",
-              "from": "interpret@>=0.5.2 <0.6.0",
-              "resolved": "https://registry.npmjs.org/interpret/-/interpret-0.5.2.tgz"
+              "version": "0.6.5",
+              "from": "interpret@>=0.6.4 <0.7.0",
+              "resolved": "https://registry.npmjs.org/interpret/-/interpret-0.6.5.tgz"
             },
             "memory-fs": {
               "version": "0.2.0",
               "from": "memory-fs@>=0.2.0 <0.3.0",
               "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.2.0.tgz"
+            },
+            "supports-color": {
+              "version": "3.1.0",
+              "from": "supports-color@>=3.1.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.0.tgz",
+              "dependencies": {
+                "has-flag": {
+                  "version": "1.0.0",
+                  "from": "has-flag@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+                }
+              }
             },
             "tapable": {
               "version": "0.1.9",
@@ -6916,9 +7040,9 @@
               "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.1.9.tgz"
             },
             "uglify-js": {
-              "version": "2.4.23",
+              "version": "2.4.24",
               "from": "uglify-js@>=2.4.13 <2.5.0",
-              "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.23.tgz",
+              "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.24.tgz",
               "dependencies": {
                 "async": {
                   "version": "0.2.10",
@@ -6931,9 +7055,9 @@
                   "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
                   "dependencies": {
                     "amdefine": {
-                      "version": "0.1.0",
+                      "version": "1.0.0",
                       "from": "amdefine@>=0.0.4",
-                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
                     }
                   }
                 },
@@ -6976,10 +7100,15 @@
               "from": "watchpack@>=0.2.1 <0.3.0",
               "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-0.2.8.tgz",
               "dependencies": {
+                "async": {
+                  "version": "0.9.2",
+                  "from": "async@>=0.9.0 <0.10.0",
+                  "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
+                },
                 "chokidar": {
-                  "version": "1.0.1",
+                  "version": "1.0.5",
                   "from": "chokidar@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.0.5.tgz",
                   "dependencies": {
                     "anymatch": {
                       "version": "1.3.0",
@@ -6987,9 +7116,9 @@
                       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
                       "dependencies": {
                         "micromatch": {
-                          "version": "2.1.6",
+                          "version": "2.2.0",
                           "from": "micromatch@>=2.1.5 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.1.6.tgz",
+                          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.2.0.tgz",
                           "dependencies": {
                             "arr-diff": {
                               "version": "1.0.1",
@@ -7002,6 +7131,11 @@
                                   "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz"
                                 }
                               }
+                            },
+                            "array-unique": {
+                              "version": "0.2.1",
+                              "from": "array-unique@>=0.2.1 <0.3.0",
+                              "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz"
                             },
                             "braces": {
                               "version": "1.8.0",
@@ -7024,9 +7158,9 @@
                                           "resolved": "https://registry.npmjs.org/is-number/-/is-number-1.1.2.tgz"
                                         },
                                         "isobject": {
-                                          "version": "1.0.0",
+                                          "version": "1.0.2",
                                           "from": "isobject@>=1.0.0 <2.0.0",
-                                          "resolved": "https://registry.npmjs.org/isobject/-/isobject-1.0.0.tgz"
+                                          "resolved": "https://registry.npmjs.org/isobject/-/isobject-1.0.2.tgz"
                                         },
                                         "randomatic": {
                                           "version": "1.1.0",
@@ -7054,22 +7188,22 @@
                                 }
                               }
                             },
-                            "debug": {
-                              "version": "2.2.0",
-                              "from": "debug@>=2.1.3 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                            "expand-brackets": {
+                              "version": "0.1.2",
+                              "from": "expand-brackets@>=0.1.1 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.2.tgz"
+                            },
+                            "extglob": {
+                              "version": "0.3.0",
+                              "from": "extglob@>=0.3.0 <0.4.0",
+                              "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.0.tgz",
                               "dependencies": {
-                                "ms": {
-                                  "version": "0.7.1",
-                                  "from": "ms@0.7.1",
-                                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                                "is-extglob": {
+                                  "version": "1.0.0",
+                                  "from": "is-extglob@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
                                 }
                               }
-                            },
-                            "expand-brackets": {
-                              "version": "0.1.1",
-                              "from": "expand-brackets@>=0.1.1 <0.2.0",
-                              "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.1.tgz"
                             },
                             "filename-regex": {
                               "version": "2.0.0",
@@ -7082,13 +7216,13 @@
                               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz"
                             },
                             "object.omit": {
-                              "version": "0.2.1",
-                              "from": "object.omit@>=0.2.1 <0.3.0",
-                              "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-0.2.1.tgz",
+                              "version": "1.1.0",
+                              "from": "object.omit@>=1.1.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-1.1.0.tgz",
                               "dependencies": {
                                 "for-own": {
                                   "version": "0.1.3",
-                                  "from": "for-own@>=0.1.1 <0.2.0",
+                                  "from": "for-own@>=0.1.3 <0.2.0",
                                   "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.3.tgz",
                                   "dependencies": {
                                     "for-in": {
@@ -7099,15 +7233,15 @@
                                   }
                                 },
                                 "isobject": {
-                                  "version": "0.2.0",
-                                  "from": "isobject@>=0.2.0 <0.3.0",
-                                  "resolved": "https://registry.npmjs.org/isobject/-/isobject-0.2.0.tgz"
+                                  "version": "1.0.2",
+                                  "from": "isobject@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/isobject/-/isobject-1.0.2.tgz"
                                 }
                               }
                             },
                             "parse-glob": {
                               "version": "3.0.2",
-                              "from": "parse-glob@>=3.0.0 <4.0.0",
+                              "from": "parse-glob@>=3.0.1 <4.0.0",
                               "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.2.tgz",
                               "dependencies": {
                                 "glob-base": {
@@ -7116,9 +7250,9 @@
                                   "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.2.0.tgz"
                                 },
                                 "is-dotfile": {
-                                  "version": "1.0.0",
+                                  "version": "1.0.1",
                                   "from": "is-dotfile@>=1.0.0 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.0.tgz"
+                                  "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.1.tgz"
                                 },
                                 "is-extglob": {
                                   "version": "1.0.0",
@@ -7129,20 +7263,13 @@
                             },
                             "regex-cache": {
                               "version": "0.4.2",
-                              "from": "regex-cache@>=0.4.0 <0.5.0",
+                              "from": "regex-cache@>=0.4.2 <0.5.0",
                               "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.2.tgz",
                               "dependencies": {
                                 "is-equal-shallow": {
-                                  "version": "0.1.2",
+                                  "version": "0.1.3",
                                   "from": "is-equal-shallow@>=0.1.1 <0.2.0",
-                                  "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.2.tgz",
-                                  "dependencies": {
-                                    "is-primitive": {
-                                      "version": "1.0.0",
-                                      "from": "is-primitive@>=1.0.0 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-1.0.0.tgz"
-                                    }
-                                  }
+                                  "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz"
                                 },
                                 "is-primitive": {
                                   "version": "2.0.0",
@@ -7171,9 +7298,9 @@
                       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-1.2.0.tgz"
                     },
                     "is-binary-path": {
-                      "version": "1.0.0",
+                      "version": "1.0.1",
                       "from": "is-binary-path@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
                       "dependencies": {
                         "binary-extensions": {
                           "version": "1.3.1",
@@ -7187,15 +7314,20 @@
                       "from": "is-glob@>=1.1.3 <2.0.0",
                       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-1.1.3.tgz"
                     },
+                    "path-is-absolute": {
+                      "version": "1.0.0",
+                      "from": "path-is-absolute@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                    },
                     "readdirp": {
-                      "version": "1.3.0",
+                      "version": "1.4.0",
                       "from": "readdirp@>=1.3.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-1.3.0.tgz",
+                      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-1.4.0.tgz",
                       "dependencies": {
                         "graceful-fs": {
-                          "version": "2.0.3",
-                          "from": "graceful-fs@>=2.0.0 <2.1.0",
-                          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
+                          "version": "4.1.2",
+                          "from": "graceful-fs@>=4.1.2 <4.2.0",
+                          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
                         },
                         "minimatch": {
                           "version": "0.2.14",
@@ -7203,9 +7335,9 @@
                           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                           "dependencies": {
                             "lru-cache": {
-                              "version": "2.6.4",
+                              "version": "2.6.5",
                               "from": "lru-cache@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
+                              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
                             },
                             "sigmund": {
                               "version": "1.0.1",
@@ -7258,26 +7390,26 @@
                   }
                 },
                 "graceful-fs": {
-                  "version": "3.0.7",
-                  "from": "graceful-fs@>=3.0.2 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.7.tgz"
+                  "version": "3.0.8",
+                  "from": "graceful-fs@>=3.0.5 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
                 }
               }
             },
             "webpack-core": {
-              "version": "0.6.5",
+              "version": "0.6.6",
               "from": "webpack-core@>=0.6.0 <0.7.0",
-              "resolved": "https://registry.npmjs.org/webpack-core/-/webpack-core-0.6.5.tgz",
+              "resolved": "https://registry.npmjs.org/webpack-core/-/webpack-core-0.6.6.tgz",
               "dependencies": {
                 "source-map": {
-                  "version": "0.4.2",
+                  "version": "0.4.4",
                   "from": "source-map@>=0.4.1 <0.5.0",
-                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.2.tgz",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
                   "dependencies": {
                     "amdefine": {
-                      "version": "0.1.0",
+                      "version": "1.0.0",
                       "from": "amdefine@>=0.0.4",
-                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
                     }
                   }
                 },

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "start": "./script/start",
     "run-production": "./script/run-production",
-    "build-production": "./script/build-prod",
+    "build-production": "TARGET=https://gocardless.com ./script/build",
+    "build-staging": "TARGET=https://staging.gocardless.com ./script/build",
     "lint": "./script/lint",
     "deploy-live-staging": "NODE_ENV=production AWS_S3_BUCKET=staging.gocardless.com ./script/deploy",
     "deploy-live-production": "NODE_ENV=production AWS_S3_BUCKET=gocardless.com ./script/deploy",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "babel-eslint": "^3.1.6",
     "babel-loader": "^5.1.3",
     "body-parser": "^1.12.4",
+    "cheeriojs": "^0.19.0",
     "classnames": "^2.1.1",
     "colors": "^1.1.0",
     "compression": "^1.4.4",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "babel-eslint": "^3.1.6",
     "babel-loader": "^5.1.3",
     "body-parser": "^1.12.4",
-    "cheeriojs": "^0.19.0",
+    "cheerio": "^0.19.0",
     "classnames": "^2.1.1",
     "colors": "^1.1.0",
     "compression": "^1.4.4",

--- a/script/build
+++ b/script/build
@@ -2,6 +2,11 @@
 
 PORT='4413'
 
+if [ -z $TARGET ]; then
+  echo "TARGET is required e.g. https://gocardless.com"
+  exit 1
+fi
+
 # check if something is already on our port
 echo exit | nc localhost $PORT
 if [ $? -eq 0 ]; then
@@ -27,7 +32,7 @@ set +e errexit
 # wait for the server to start up
 while ! echo exit | nc localhost $PORT; do sleep 1; done
 
-./script/dump-html "http://localhost:$PORT" $CWD
+./script/dump-html "http://localhost:$PORT" $CWD $TARGET
 DUMP_EXIT=$?
 
 kill $SERVER_PID

--- a/script/dump-html
+++ b/script/dump-html
@@ -12,8 +12,8 @@ const [bin, script, serverUrl, outDir, target] = process.argv;
 const sitemapDomain = target;
 const oldSitemapUrl = `${target}/sitemap.xml`;
 
-if (!serverUrl || !outDir) {
-  console.error(`Usage: ${bin} ${script} host directory`);
+if (!serverUrl || !outDir || !target) {
+  console.error(`Usage: ${bin} ${script} host directory target`);
   process.exit(1);
 }
 

--- a/script/dump-html
+++ b/script/dump-html
@@ -28,14 +28,13 @@ https.get('https://dl.dropboxusercontent.com/s/otbggbop9dohag0/sitemap.xml', fun
   console.error(`Wasn't able to download the old sitemap: ${e.message}`);
 });
 
-// Is there a better way than using a global variable?
-global.newSitemap = new SitemapUrlSet('https://gocardless.com');
+let newSitemap = new SitemapUrlSet('https://gocardless.com');
 
 const processPage = function(pagePath) {
   // TODO: Return a promise for both of these functions
   var page = fetchPage(serverUrl, pagePath);
   page.then((resolve,reject) => {
-    global.newSitemap.addUrl(resolve[0], resolve[1]);
+    newSitemap.addUrl(resolve[0], resolve[1]);
   });
   return page.then(writePage.bind(null, outDir))
     .catch(console.error.bind(console));
@@ -46,6 +45,6 @@ Promise.all(getAllPaths(availableLocales).map(processPage)).then(function(filena
   console.log(filenames.sort().map((filename) => `  ${filename}`).join('\n'));
 
   const sitemapOutputPath = path.join(outDir, 'sitemap.xml');
-  fs.writeFileSync(sitemapOutputPath, global.newSitemap.toXml());
+  fs.writeFileSync(sitemapOutputPath, newSitemap.toXml());
   console.log(`\nSitemap written to ${sitemapOutputPath}`);
 }).catch(console.error.bind(console));

--- a/script/dump-html
+++ b/script/dump-html
@@ -7,19 +7,17 @@ import { downloadOldSitemap, SitemapUrlSet } from '../app/static-build/sitemap';
 import availableLocales from '../config/available-locales';
 import { getAllPaths } from '../app/router/route-helpers';
 
-const [bin, script, serverUrl, outDir] = process.argv;
+const [bin, script, serverUrl, outDir, target] = process.argv;
 
-// TODO: Initalise SitemapUrlSet with domain name from environmental variable
-// TODO: Download sitemap.xml from live (https://gocardless.com/sitemap.xml)
-const sitemapDomain = 'https://gocardless.com';
-const oldSitemapUrl = 'https://dl.dropboxusercontent.com/s/otbggbop9dohag0/sitemap.xml';
+const sitemapDomain = target;
+const oldSitemapUrl = `${target}/sitemap.xml`;
 
 if (!serverUrl || !outDir) {
   console.error(`Usage: ${bin} ${script} host directory`);
   process.exit(1);
 }
 
-let newSitemap = new SitemapUrlSet(sitemapDomain);
+const newSitemap = new SitemapUrlSet(sitemapDomain);
 
 const processPage = function(pagePath) {
   return fetchPage(serverUrl, pagePath)

--- a/script/dump-html
+++ b/script/dump-html
@@ -3,7 +3,7 @@
 const fs = require('fs');
 import path from 'path';
 import { fetchPage, writePage } from '../app/static-build/builder';
-import { downloadOldSitemap, SitemapUrlSet } from '../app/static-build/sitemap';
+import { downloadOldSitemap, Sitemap } from '../app/static-build/sitemap';
 import availableLocales from '../config/available-locales';
 import { getAllPaths } from '../app/router/route-helpers';
 
@@ -17,7 +17,7 @@ if (!serverUrl || !outDir || !target) {
   process.exit(1);
 }
 
-const newSitemap = new SitemapUrlSet(sitemapDomain);
+const newSitemap = new Sitemap(sitemapDomain);
 
 const processPage = function(pagePath) {
   return fetchPage(serverUrl, pagePath)

--- a/script/dump-html
+++ b/script/dump-html
@@ -16,18 +16,18 @@ if (!serverUrl || !outDir) {
   process.exit(1);
 }
 
-function getOldSitemap(host, sitemapUrl) {
+function downloadOldSitemap(host, sitemapUrl) {
   return new Promise(function(resolve, reject) {
     request.get(sitemapUrl).buffer().end(function(err, res) {
       if (err) {
-        console.log(`Error downloading old sitemap: ${err}. Continuing with fresh timestamp for all pages...`);
+        console.log(`Error downloading old sitemap from ${sitemapUrl}: ${err}. Continuing anyway (all pages may have lastMod of today).`);
         return resolve(new SitemapUrlSet(host));
       }
       if (res.ok) {
         console.log(`Downloaded old sitemap from ${sitemapUrl}.`);
         resolve(new SitemapUrlSet(host).fromXml(res.text));
       } else {
-        console.log(`Result of downloading sitemap was not OK. Continuing with fresh timestamp for all pages...`);
+        console.log(`Error downloading old sitemap from ${sitemapUrl}: !res.ok. Continuing anyway (all pages may have lastMod of today).`);
         resolve(new SitemapUrlSet(host));
       }
     });
@@ -51,7 +51,7 @@ Promise.all(getAllPaths(availableLocales).map(processPage)).then(function(filena
   console.log('Completed static html dump:');
   console.log(filenames.sort().map((filename) => `  ${filename}`).join('\n'));
 
-  getOldSitemap('https://gocardless.com', 'https://dl.dropboxusercontent.com/s/otbggbop9dohag0/sitemap.xml').then((oldSitemap) => {
+  downloadOldSitemap('https://gocardless.com', 'https://dl.dropboxusercontent.com/s/otbggbop9dohag0/sitemap.xml').then((oldSitemap) => {
     newSitemap.importTimestampsFromOldSitemap(oldSitemap);
     const sitemapOutputPath = path.join(outDir, 'sitemap.xml');
     fs.writeFileSync(sitemapOutputPath, newSitemap.toXml());

--- a/script/dump-html
+++ b/script/dump-html
@@ -1,6 +1,9 @@
 #!/usr/bin/env babel-node
 
+const https = require('https');
+const fs = require('fs');
 import { fetchPage, writePage } from '../app/static-build/builder';
+import { sitemapUrlSet } from '../app/static-build/sitemap';
 import availableLocales from '../config/available-locales';
 import { getAllPaths } from '../app/router/route-helpers';
 
@@ -11,13 +14,33 @@ if (!serverUrl || !outDir) {
   process.exit(1);
 }
 
+// Download the old sitemap
+// TODO: Download this from live, change gocardless.com to environmental variable
+https.get('https://dl.dropboxusercontent.com/s/otbggbop9dohag0/sitemap.xml', function(res) {
+  res.on('data', function(oldSitemapXml) {
+    const oldSitemap = new sitemapUrlSet('https://gocardless.com').fromXml(oldSitemapXml);
+  });
+}).on('error', function(e) {
+  console.error("Wasn't able to download the old sitemap.");
+})
+
+// Is there a better way than using a global variable?
+global.newSitemap = new sitemapUrlSet('https://gocardless.com');
+
 const processPage = function(pagePath) {
-  return fetchPage(serverUrl, pagePath)
-    .then(writePage.bind(null, outDir))
+  // TODO: Return a promise for both of these functions
+  var page = fetchPage(serverUrl, pagePath);
+  page.then(function(resolve,reject) {
+    global.newSitemap.addUrl(resolve[0], resolve[1]);
+  });
+  return page.then(writePage.bind(null, outDir))
     .catch(console.error.bind(console));
 };
 
 Promise.all(getAllPaths(availableLocales).map(processPage)).then(function(filenames) {
   console.log('Completed static html dump:');
   console.log(filenames.sort().map((filename) => `  ${filename}`).join('\n'));
+
+  fs.writeFileSync('dist/sitemap.xml', global.newSitemap.toXml());
+  console.log('\nSitemap written to sitemap.xml');
 }).catch(console.error.bind(console));

--- a/script/dump-html
+++ b/script/dump-html
@@ -31,12 +31,11 @@ https.get('https://dl.dropboxusercontent.com/s/otbggbop9dohag0/sitemap.xml', fun
 let newSitemap = new SitemapUrlSet('https://gocardless.com');
 
 const processPage = function(pagePath) {
-  // TODO: Return a promise for both of these functions
-  var page = fetchPage(serverUrl, pagePath);
-  page.then((resolve,reject) => {
-    newSitemap.addUrl(resolve[0], resolve[1]);
-  });
-  return page.then(writePage.bind(null, outDir))
+  return fetchPage(serverUrl, pagePath)
+    .then(([url, contents]) => {
+      newSitemap.addUrl(url, contents);
+      return writePage(outDir, [url, contents]);
+    })
     .catch(console.error.bind(console));
 };
 

--- a/script/dump-html
+++ b/script/dump-html
@@ -2,6 +2,7 @@
 
 const https = require('https');
 const fs = require('fs');
+import path from 'path';
 import { fetchPage, writePage } from '../app/static-build/builder';
 import { SitemapUrlSet } from '../app/static-build/sitemap';
 import availableLocales from '../config/available-locales';
@@ -41,6 +42,7 @@ Promise.all(getAllPaths(availableLocales).map(processPage)).then(function(filena
   console.log('Completed static html dump:');
   console.log(filenames.sort().map((filename) => `  ${filename}`).join('\n'));
 
-  fs.writeFileSync('dist/sitemap.xml', global.newSitemap.toXml());
-  console.log('\nSitemap written to sitemap.xml');
+  const sitemapOutputPath = path.join(outDir, 'sitemap.xml');
+  fs.writeFileSync(sitemapOutputPath, global.newSitemap.toXml());
+  console.log(`\nSitemap written to ${sitemapOutputPath}`);
 }).catch(console.error.bind(console));

--- a/script/dump-html
+++ b/script/dump-html
@@ -1,42 +1,25 @@
 #!/usr/bin/env babel-node
 
-const https = require('https');
 const fs = require('fs');
 import path from 'path';
-import request from 'superagent';
 import { fetchPage, writePage } from '../app/static-build/builder';
-import { SitemapUrlSet } from '../app/static-build/sitemap';
+import { downloadOldSitemap, SitemapUrlSet } from '../app/static-build/sitemap';
 import availableLocales from '../config/available-locales';
 import { getAllPaths } from '../app/router/route-helpers';
 
 const [bin, script, serverUrl, outDir] = process.argv;
+
+// TODO: Initalise SitemapUrlSet with domain name from environmental variable
+// TODO: Download sitemap.xml from live (https://gocardless.com/sitemap.xml)
+const sitemapDomain = 'https://gocardless.com';
+const oldSitemapUrl = 'https://dl.dropboxusercontent.com/s/otbggbop9dohag0/sitemap.xml';
 
 if (!serverUrl || !outDir) {
   console.error(`Usage: ${bin} ${script} host directory`);
   process.exit(1);
 }
 
-function downloadOldSitemap(host, sitemapUrl) {
-  return new Promise(function(resolve, reject) {
-    request.get(sitemapUrl).buffer().end(function(err, res) {
-      if (err) {
-        console.log(`Error downloading old sitemap from ${sitemapUrl}: ${err}. Continuing anyway (all pages may have lastMod of today).`);
-        return resolve(new SitemapUrlSet(host));
-      }
-      if (res.ok) {
-        console.log(`Downloaded old sitemap from ${sitemapUrl}.`);
-        resolve(new SitemapUrlSet(host).fromXml(res.text));
-      } else {
-        console.log(`Error downloading old sitemap from ${sitemapUrl}: !res.ok. Continuing anyway (all pages may have lastMod of today).`);
-        resolve(new SitemapUrlSet(host));
-      }
-    });
-  });
-}
-
-// TODO: Download sitemap.xml from live (https://gocardless.com/sitemap.xml)
-// TODO: Initalise SitemapUrlSet with domain name from environmental variable
-let newSitemap = new SitemapUrlSet('https://gocardless.com');
+let newSitemap = new SitemapUrlSet(sitemapDomain);
 
 const processPage = function(pagePath) {
   return fetchPage(serverUrl, pagePath)
@@ -51,7 +34,7 @@ Promise.all(getAllPaths(availableLocales).map(processPage)).then(function(filena
   console.log('Completed static html dump:');
   console.log(filenames.sort().map((filename) => `  ${filename}`).join('\n'));
 
-  downloadOldSitemap('https://gocardless.com', 'https://dl.dropboxusercontent.com/s/otbggbop9dohag0/sitemap.xml').then((oldSitemap) => {
+  downloadOldSitemap(sitemapDomain, oldSitemapUrl).then((oldSitemap) => {
     newSitemap.importTimestampsFromOldSitemap(oldSitemap);
     const sitemapOutputPath = path.join(outDir, 'sitemap.xml');
     fs.writeFileSync(sitemapOutputPath, newSitemap.toXml());

--- a/script/dump-html
+++ b/script/dump-html
@@ -20,13 +20,13 @@ if (!serverUrl || !outDir) {
 // TODO: Initalise SitemapUrlSet with domain name from environmental variable
 https.get('https://dl.dropboxusercontent.com/s/otbggbop9dohag0/sitemap.xml', function(res) {
   if (res.statusCode == 200) {
-    res.on('data', function(oldSitemapXml) {
+    res.on('data', (oldSitemapXml) => {
       const oldSitemap = new SitemapUrlSet('https://gocardless.com').fromXml(oldSitemapXml);
     });
   }
-}).on('error', function(e) {
-  console.error("Wasn't able to download the old sitemap.");
-})
+}).on('error', (e) => {
+  console.error(`Wasn't able to download the old sitemap: ${e.message}`);
+});
 
 // Is there a better way than using a global variable?
 global.newSitemap = new SitemapUrlSet('https://gocardless.com');
@@ -34,7 +34,7 @@ global.newSitemap = new SitemapUrlSet('https://gocardless.com');
 const processPage = function(pagePath) {
   // TODO: Return a promise for both of these functions
   var page = fetchPage(serverUrl, pagePath);
-  page.then(function(resolve,reject) {
+  page.then((resolve,reject) => {
     global.newSitemap.addUrl(resolve[0], resolve[1]);
   });
   return page.then(writePage.bind(null, outDir))

--- a/script/dump-html
+++ b/script/dump-html
@@ -16,11 +16,14 @@ if (!serverUrl || !outDir) {
 }
 
 // Download the old sitemap
-// TODO: Download this from live, change gocardless.com to environmental variable
+// TODO: Download this from live (https://gocardless.com/sitemap.xml)
+// TODO: Initalise SitemapUrlSet with domain name from environmental variable
 https.get('https://dl.dropboxusercontent.com/s/otbggbop9dohag0/sitemap.xml', function(res) {
-  res.on('data', function(oldSitemapXml) {
-    const oldSitemap = new SitemapUrlSet('https://gocardless.com').fromXml(oldSitemapXml);
-  });
+  if (res.statusCode == 200) {
+    res.on('data', function(oldSitemapXml) {
+      const oldSitemap = new SitemapUrlSet('https://gocardless.com').fromXml(oldSitemapXml);
+    });
+  }
 }).on('error', function(e) {
   console.error("Wasn't able to download the old sitemap.");
 })

--- a/script/dump-html
+++ b/script/dump-html
@@ -3,7 +3,7 @@
 const https = require('https');
 const fs = require('fs');
 import { fetchPage, writePage } from '../app/static-build/builder';
-import { sitemapUrlSet } from '../app/static-build/sitemap';
+import { SitemapUrlSet } from '../app/static-build/sitemap';
 import availableLocales from '../config/available-locales';
 import { getAllPaths } from '../app/router/route-helpers';
 
@@ -18,14 +18,14 @@ if (!serverUrl || !outDir) {
 // TODO: Download this from live, change gocardless.com to environmental variable
 https.get('https://dl.dropboxusercontent.com/s/otbggbop9dohag0/sitemap.xml', function(res) {
   res.on('data', function(oldSitemapXml) {
-    const oldSitemap = new sitemapUrlSet('https://gocardless.com').fromXml(oldSitemapXml);
+    const oldSitemap = new SitemapUrlSet('https://gocardless.com').fromXml(oldSitemapXml);
   });
 }).on('error', function(e) {
   console.error("Wasn't able to download the old sitemap.");
 })
 
 // Is there a better way than using a global variable?
-global.newSitemap = new sitemapUrlSet('https://gocardless.com');
+global.newSitemap = new SitemapUrlSet('https://gocardless.com');
 
 const processPage = function(pagePath) {
   // TODO: Return a promise for both of these functions

--- a/script/dump-html
+++ b/script/dump-html
@@ -3,6 +3,7 @@
 const https = require('https');
 const fs = require('fs');
 import path from 'path';
+import request from 'superagent';
 import { fetchPage, writePage } from '../app/static-build/builder';
 import { SitemapUrlSet } from '../app/static-build/sitemap';
 import availableLocales from '../config/available-locales';
@@ -15,19 +16,26 @@ if (!serverUrl || !outDir) {
   process.exit(1);
 }
 
-// Download the old sitemap
-// TODO: Download this from live (https://gocardless.com/sitemap.xml)
-// TODO: Initalise SitemapUrlSet with domain name from environmental variable
-https.get('https://dl.dropboxusercontent.com/s/otbggbop9dohag0/sitemap.xml', function(res) {
-  if (res.statusCode == 200) {
-    res.on('data', (oldSitemapXml) => {
-      const oldSitemap = new SitemapUrlSet('https://gocardless.com').fromXml(oldSitemapXml);
+function getOldSitemap(host, sitemapUrl) {
+  return new Promise(function(resolve, reject) {
+    request.get(sitemapUrl).buffer().end(function(err, res) {
+      if (err) {
+        console.log(`Error downloading old sitemap: ${err}. Continuing with fresh timestamp for all pages...`);
+        return resolve(new SitemapUrlSet(host));
+      }
+      if (res.ok) {
+        console.log(`Downloaded old sitemap from ${sitemapUrl}.`);
+        resolve(new SitemapUrlSet(host).fromXml(res.text));
+      } else {
+        console.log(`Result of downloading sitemap was not OK. Continuing with fresh timestamp for all pages...`);
+        resolve(new SitemapUrlSet(host));
+      }
     });
-  }
-}).on('error', (e) => {
-  console.error(`Wasn't able to download the old sitemap: ${e.message}`);
-});
+  });
+}
 
+// TODO: Download sitemap.xml from live (https://gocardless.com/sitemap.xml)
+// TODO: Initalise SitemapUrlSet with domain name from environmental variable
 let newSitemap = new SitemapUrlSet('https://gocardless.com');
 
 const processPage = function(pagePath) {
@@ -43,7 +51,10 @@ Promise.all(getAllPaths(availableLocales).map(processPage)).then(function(filena
   console.log('Completed static html dump:');
   console.log(filenames.sort().map((filename) => `  ${filename}`).join('\n'));
 
-  const sitemapOutputPath = path.join(outDir, 'sitemap.xml');
-  fs.writeFileSync(sitemapOutputPath, newSitemap.toXml());
-  console.log(`\nSitemap written to ${sitemapOutputPath}`);
+  getOldSitemap('https://gocardless.com', 'https://dl.dropboxusercontent.com/s/otbggbop9dohag0/sitemap.xml').then((oldSitemap) => {
+    newSitemap.importTimestampsFromOldSitemap(oldSitemap);
+    const sitemapOutputPath = path.join(outDir, 'sitemap.xml');
+    fs.writeFileSync(sitemapOutputPath, newSitemap.toXml());
+    console.log(`New sitemap written to ${sitemapOutputPath}`);
+  });
 }).catch(console.error.bind(console));

--- a/script/e2e
+++ b/script/e2e
@@ -12,7 +12,7 @@ fi
 
 set -e errexit
 
-ANIMATIONS_DISABLED=true ./script/build-prod
+ANIMATIONS_DISABLED=true TARGET=https://localhost:$PORT ./script/build
 
 ./node_modules/.bin/serve -p $PORT dist/ &>.e2e_server_log &
 SERVER_PID=$!


### PR DESCRIPTION
A second version of our XML sitemap generation following the discussion last week.

Creates a XML sitemap file from the list of all routes as part of the static site build.
* Calculates a MD5 hash of the page by stripping the Javascript and running `$('body').text()`
* Loads in the currently deployed version of the sitemaps (gocardless.com/sitemap.xml for master, staging.gocardless.com/sitemap.xml for dev).
  * Where the MD5 hash for a page hasn't changed since the previous deploy, the `<lastmod>` value is kept from the old sitemap.
  * Where the MD5 hash value differs, use the current date for `<lastmod>`
