### PR TITLE
Use <select defaultValue> on lead capture form

### DIFF
--- a/app/components/prospect-form/prospect-form.js
+++ b/app/components/prospect-form/prospect-form.js
@@ -155,8 +155,9 @@ export default class ProspectForm extends React.Component {
             </label>
             <select className='input--stacked'
             id='prospect_metadata_number_of_payments'
-            name='prospect[metadata][number_of_payments]'>
-              <option disabled selected>Choisissez le nombre de paiements</option>
+            name='prospect[metadata][number_of_payments]'
+            defaultValue=''>
+              <option value=''>Choisissez le nombre de paiements</option>
               <option value='0-50'>0-50</option>
               <option value='50+'>50+</option>
             </select>


### PR DESCRIPTION
The build script currently gives the following warning:
```
Warning: Use the `defaultValue` or `value` props on <select> instead of setting `selected` on <option>.
Warning: Use the `defaultValue` or `value` props on <select> instead of setting `selected` on <option>.
```

This is because [in React we should use](https://facebook.github.io/react/docs/forms.html) `<select defaultValue>` instead of `<option selected>`.