### PR TITLE
Redirect for 'Mandate Contents' page on Bg Autogiro Guide

### DIFF
--- a/config/redirects.json
+++ b/config/redirects.json
@@ -100,6 +100,7 @@
   "/fr/pro/index.html": "/fr-fr/pro",
   "/fr/securite/index.html": "/fr-fr/securite",
   "/fr/tarifs/index.html": "/fr-fr/tarifs",
+  "/guides/bg-autogiro/mandatory-mandate-contents/index.html": "/guides/bg-autogiro/mandate-contents/",
   "/guides/posts/avoiding-indemnity-claims//index.html": "/guides",
   "/guides/posts/cancelling-dd/index.html": "/guides/posts/dd-guarantee-in-plain-english/",
   "/guides/posts/charity-direct-debit//index.html": "/guides/intro-to-direct-debit/charities-guide/",


### PR DESCRIPTION
Add redirect from https://gocardless.com/guides/bg-autogiro/mandatory-mandate-contents/ to https://gocardless.com/guides/bg-autogiro/mandate-contents/