### PR TITLE
Agg `lang` param onto signup page for non-english leads

### DIFF
--- a/app/messages/de.js
+++ b/app/messages/de.js
@@ -137,7 +137,7 @@ export default {
     path: 'https://manage.gocardless.com',
   },
   signup: {
-    path: 'https://manage.gocardless.com/signup',
+    path: 'https://manage.gocardless.com/signup?lang=de',
   },
   faq: {
     title: 'Häufig gestellte Fragen',

--- a/app/messages/es.js
+++ b/app/messages/es.js
@@ -124,6 +124,9 @@ export default {
     title: 'Pro API',
     nav_title: 'Pro API',
   },
+  signup: {
+    path: 'https://manage.gocardless.com/signup?lang=es',
+  },
   blog: {
     title: 'Blog',
     nav_title: 'Blog',

--- a/app/messages/fr.js
+++ b/app/messages/fr.js
@@ -273,7 +273,7 @@ export default {
     path: 'https://manage.gocardless.com',
   },
   signup: {
-    path: 'https://manage.gocardless.com/signup',
+    path: 'https://manage.gocardless.com/signup?lang=fr',
   },
   stories: {
     title: 'Références',


### PR DESCRIPTION
Means that we can internationalise the signup page in dashboard for people we know are coming from translated splash pages.

Can be merged in now, but won't take effect until https://github.com/gocardless/enterprise-dashboard/pull/1343 has gone in.