### PR TITLE
Add Autogiro references

### DIFF
--- a/app/components/product-comparison/product-comparison.en.js
+++ b/app/components/product-comparison/product-comparison.en.js
@@ -108,8 +108,8 @@ export default class ProductComparisonEn extends React.Component {
             <Translation locales={['en']} exclude={['en-GB']}>
               <tr className='comparison-table__row'>
                 <td className='comparison-table__cell u-text-end'>Accept payments from...</td>
-                <td className='comparison-table__cell'>22 countries (UK, Sweden & Eurozone)</td>
-                <td className='comparison-table__cell'>22 countries (UK, Sweden & Eurozone)</td>
+                <td className='comparison-table__cell'>23 countries (UK, Sweden & Eurozone)</td>
+                <td className='comparison-table__cell'>23 countries (UK, Sweden & Eurozone)</td>
               </tr>
             </Translation>
             <Translation locales={['en-GB']}>

--- a/app/components/product-comparison/product-comparison.en.js
+++ b/app/components/product-comparison/product-comparison.en.js
@@ -108,15 +108,15 @@ export default class ProductComparisonEn extends React.Component {
             <Translation locales={['en']} exclude={['en-GB']}>
               <tr className='comparison-table__row'>
                 <td className='comparison-table__cell u-text-end'>Accept payments from...</td>
-                <td className='comparison-table__cell'>22 countries (UK & Eurozone)</td>
-                <td className='comparison-table__cell'>22 countries (UK & Eurozone)</td>
+                <td className='comparison-table__cell'>22 countries (UK, Sweden & Eurozone)</td>
+                <td className='comparison-table__cell'>22 countries (UK, Sweden & Eurozone)</td>
               </tr>
             </Translation>
             <Translation locales={['en-GB']}>
               <tr className='comparison-table__row'>
                 <td className='comparison-table__cell u-text-end'>Accept payments from...</td>
                 <td className='comparison-table__cell'>UK (& Eurozone on request)</td>
-                <td className='comparison-table__cell'>UK & Eurozone</td>
+                <td className='comparison-table__cell'>UK, Sweden & Eurozone</td>
               </tr>
             </Translation>
             <tr className='comparison-table__row'>

--- a/app/messages/en-EU.js
+++ b/app/messages/en-EU.js
@@ -9,7 +9,7 @@ export default {
   },
   hero: {
     header: 'Accept recurring payments across Europe',
-    desc: 'GoCardless allows you to collect Direct Debit payments from the UK and the Eurozone in a single integration.',
+    desc: 'GoCardless allows you to collect Direct Debit payments from the UK, the Eurozone and Sweden in a single integration.',
   },
   pricing: {
     description: 'Collect Direct Debit payments online with fees of just 1%, capped at €2. Scale pricing is available for larger organisations.',

--- a/app/pages/europe/europe.js
+++ b/app/pages/europe/europe.js
@@ -14,7 +14,7 @@ export default class Europe extends React.Component {
               <div className='page-hero__text u-text-center'>
                 <h1 className='u-text-heading u-color-invert u-text-xl u-text-light'>Accept Direct Debit across Europe</h1>
                 <p className='u-text-heading-light u-size-4of5 u-center u-color-invert u-text-m u-margin-Txxs'>
-                  GoCardless lets you take payments in the UK and across<br />the entire Eurozone via a single integration
+                  GoCardless lets you take payments in the UK, Sweden and across<br />the entire Eurozone via a single integration
                 </p>
                 <div className='u-text-center u-margin-Tl'>
                   <Link to='contact_sales' className='btn btn--invert btn--move'>

--- a/app/pages/home/home.en.js
+++ b/app/pages/home/home.en.js
@@ -49,7 +49,7 @@ export default class HomeEn extends React.Component {
                     UK &amp; Eurozone
                   </div>
                   <p className='u-size-4of5 u-center u-color-p u-margin-Txs'>
-                    Accept payments with Bacs Direct Debit and SEPA Direct Debit
+                    Accept payments with Bacs Direct Debit, SEPA Direct Debit and Swedish Autogiro
                   </p>
                 </div>
               </IfLocale>

--- a/app/pages/pro/pro.en.js
+++ b/app/pages/pro/pro.en.js
@@ -74,7 +74,7 @@ export default class ProEn extends React.Component {
                     Designed specifically for larger enterprises,
                     GoCardless Pro combines the simplicity of our original
                     GoCardless product with complete control over payments and customer experience.
-                    It also allows you to collect UK and SEPA Direct Debit via one simple integration.
+                    It also allows you to collect Direct Debits from the UK, Sweden and the Eurozone via one simple integration.
                   </p>
                 </div>
                 <div className='grid u-margin-Tl u-padding-Tm'>
@@ -181,9 +181,9 @@ export default class ProEn extends React.Component {
                   <div className='u-center'>
                     <p className='u-text-s u-color-p u-margin-Ts'>
                       GoCardless Pro is the only product that enables you to collect
-                      Direct Debit payments from the UK and the Eurozone through a single integration.
+                      Direct Debit payments from the UK, Sweden and the Eurozone through a single integration.
                       With our API, your business can take payments from over 500 million people
-                      in 22 European countries.
+                      in 23 European countries.
                     </p>
                   </div>
                 </div>

--- a/app/pages/pro/pro.en.js
+++ b/app/pages/pro/pro.en.js
@@ -74,7 +74,7 @@ export default class ProEn extends React.Component {
                     Designed specifically for larger enterprises,
                     GoCardless Pro combines the simplicity of our original
                     GoCardless product with complete control over payments and customer experience.
-                    It also allows you to collect Direct Debits from the UK, Sweden and the Eurozone via one simple integration.
+                    It also allows you to collect Direct Debit payments from the UK, Sweden and the Eurozone via one simple integration.
                   </p>
                 </div>
                 <div className='grid u-margin-Tl u-padding-Tm'>


### PR DESCRIPTION
This branch adds references to Autogiro and Sweden to the English-language European splash pages. 

@Ken-Lo and others, do you know of other references I've missed? Please also check I haven't broken anything!

A couple of other points:
- We will need to update the all the pages again as we add new schemes like the US and Australia (obviously at some point we will have to change the language rather than simply adding them). Once we finalise this set I'll make a list of the points to change so that it's easier next time
- In the long run we'll need to be careful about these updates for the non-English sites too ( @octaveauger , @jutta-frieden , @AlfonsoSB , @Jennabrown )