### PR TITLE
In the country selector, adjusting position of flag labels and their corresponding svg's.

### DIFF
--- a/app/css/components/checkmark-icon.scss
+++ b/app/css/components/checkmark-icon.scss
@@ -1,4 +1,4 @@
 .checkmark-icon {
   position: relative;
-  top: 3px;
+  top: 2px;
 }

--- a/app/css/components/country-select-label.scss
+++ b/app/css/components/country-select-label.scss
@@ -1,4 +1,4 @@
 .country-select-label {
   position: relative;
-  top: -4px;
+  top: -3px;
 }

--- a/app/css/components/popover.scss
+++ b/app/css/components/popover.scss
@@ -68,6 +68,11 @@
   border-top-color: white;
 }
 
+.popover-link--invert span {
+  position: relative;
+  top: 1px;
+}
+
 .popover--country-select {
   bottom: 0;
   margin-bottom: 44px;


### PR DESCRIPTION
The country labels are now vertically aligned correctly, both in the popover and in the `selected country` component.

<img width="711" alt="screen shot 2015-10-16 at 14 05 11" src="https://cloud.githubusercontent.com/assets/1385001/10542274/f2cfe750-740e-11e5-8ea0-62f5932ea944.png">
