### PR TITLE
Remove eslint comment from job page

### DIFF
--- a/app/pages/about/jobs/positions/sales-development-representative.js
+++ b/app/pages/about/jobs/positions/sales-development-representative.js
@@ -36,7 +36,6 @@ export default class SalesDevelopmentRepresentative extends React.Component {
           and then trust you to be the first point of contact with all our new
           prospects.
         </p>
-        /*eslint-enable max-len*/
         <p className='para'>
           On a typical day you will be:
         </p>
@@ -98,5 +97,6 @@ export default class SalesDevelopmentRepresentative extends React.Component {
         </a>
       </JobsPage>
     );
+    /*eslint-enable max-len*/
   }
 }


### PR DESCRIPTION
An eslint enable comment got into the splash pages because it was inside the return statement of a call to `render`.

![](https://dl.dropbox.com/s/34bvnz3c1rjuez8/Screenshot%202015-10-21%2015.13.39.png?dl=0)

@waltfy cool?
props to @mcollier000 for pointing this out