### PR TITLE
Add number of payments dropdown to en-GB contact sales

### DIFF
--- a/app/components/prospect-form/prospect-form.js
+++ b/app/components/prospect-form/prospect-form.js
@@ -158,8 +158,9 @@ export default class ProspectForm extends React.Component {
             name='prospect[metadata][number_of_payments]'
             defaultValue=''>
               <option value=''>Select number of payments taken last month</option>
-              <option value='0-50'>0-50</option>
-              <option value='50+'>50+</option>
+              <option value='0-100'>0-100</option>
+              <option value='100-500'>100-500</option>
+              <option value='500+'>500+</option>
             </select>
           </Translation>
 

--- a/app/components/prospect-form/prospect-form.js
+++ b/app/components/prospect-form/prospect-form.js
@@ -149,6 +149,20 @@ export default class ProspectForm extends React.Component {
           <input className='input input--stacked' id='prospect_phone_number' name='prospect[phone_number]'
             placeholder={getMessage(messages, 'prospect_form.phone_placeholder')} required type='text' />
 
+          <Translation locales={['en-GB']}>
+            <label className='label label--stacked' htmlFor='prospect_metadata_number_of_payments'>
+              How many payments could we have helped you collect last month?
+            </label>
+            <select className='input--stacked'
+            id='prospect_metadata_number_of_payments'
+            name='prospect[metadata][number_of_payments]'
+            defaultValue=''>
+              <option value=''>Select number of payments taken last month</option>
+              <option value='0-50'>0-50</option>
+              <option value='50+'>50+</option>
+            </select>
+          </Translation>
+
           <Translation locales='fr'>
             <label className='label label--stacked' htmlFor='prospect_metadata_number_of_payments'>
               Combien de paiements souhaitez-vous prélever chaque mois?


### PR DESCRIPTION
Add number of payments dropdown to en-GB contact sales

![screen shot 2015-11-09 at 19 25 31](https://cloud.githubusercontent.com/assets/6426688/11044076/bcb80afa-8717-11e5-8588-fc5ff4fcaf11.png)
