### PR TITLE
Add a <textarea> for free input to the "contact sales" form

### DIFF
--- a/app/components/prospect-form/prospect-form.js
+++ b/app/components/prospect-form/prospect-form.js
@@ -162,6 +162,12 @@ export default class ProspectForm extends React.Component {
               <option value='100-500'>100-500</option>
               <option value='500+'>500+</option>
             </select>
+
+            <label className='label label--stacked' htmlFor='prospect_metadata_message'>
+              What are your business&apos;s specific needs?
+            </label>
+            <textarea className='input input--stacked input--textarea'
+            id='prospect_metadata_message' name='prospect[metadata][message]' rows='3' />
           </Translation>
 
           <Translation locales='fr'>


### PR DESCRIPTION
This adds a `metadata[message]` parameter to what's POSTed to GoCardless. It'll only appear on the English form for now, but we might expand this if other country leads want it.

__Merge and deploy this after https://github.com/gocardless/gocardless/pull/6359__