### PR TITLE
Get rid of weird Swedish contact sales messaging 🇸🇪

### DIFF
--- a/app/messages/en-SE.js
+++ b/app/messages/en-SE.js
@@ -11,7 +11,6 @@ export default {
     has_percentage_pricing: true,
   },
   prospect_form: {
-    intro_message: 'We are currently beta testing our Autogiro service. Participants can collect Autogiro payments for free during the trial.',
     name_placeholder: 'William Johansson',
     email_placeholder: 'example@companyname.se',
     phone_placeholder: '0844 680 379',

--- a/app/pages/contact-sales/contact-sales.js
+++ b/app/pages/contact-sales/contact-sales.js
@@ -23,14 +23,6 @@ export default class ContactSales extends React.Component {
 
         <div className='site-container grid grid--center u-margin-Vxl u-padding-Vxl'>
           <div className='grid__cell u-size-1of2'>
-            <Translation locales='en-SE'>
-              <p className='u-color-meta u-margin-Bs'>
-                <Message pointer='prospect_form.intro_message' />
-              </p>
-              <p className='u-color-meta u-margin-Bs'>
-                Enter your contact details to learn more:
-              </p>
-            </Translation>
             <ProspectForm prospectType='sales' />
             <hr />
             <p className='u-text-center u-color-meta u-margin-Bs'>


### PR DESCRIPTION
This looked really strange, Autogiro is no longer free, and I'm not convinced the contact sales page is the right place to communicate that we're in beta in Sweden, especially with open signups!