### PR TITLE
Minor indentation fixes

### DIFF
--- a/app/components/product-comparison/product-comparison.nl.js
+++ b/app/components/product-comparison/product-comparison.nl.js
@@ -25,10 +25,10 @@ export default class ProductComparisonNl extends React.Component {
                   <th className='u-background-dark-gray-darken u-text-heading-light u-color-invert u-padding-Am u-border-gray'>
                     <div className='u-text-l u-margin-Bxxs'>GoCardless Pro</div>
                     <Translation locales='nl-NL'>
-                    Volledige controle over SEPA Incasso
+                      Volledige controle over SEPA Incasso
                     </Translation>
                     <Translation locales='nl-BE'>
-                    Volledige controle over domiciliëringen
+                      Volledige controle over domiciliëringen
                     </Translation>
                   </th>
                 </tr>
@@ -37,10 +37,10 @@ export default class ProductComparisonNl extends React.Component {
                 <tr className='comparison-table__row'>
                   <td className='comparison-table__cell u-text-end'>Voor wie?</td>
                   <Translation locales='nl-NL'>
-                  <td className='comparison-table__cell'>Midden- en kleinbedrijf</td>
+                    <td className='comparison-table__cell'>Midden- en kleinbedrijf</td>
                   </Translation>
                   <Translation locales='nl-BE'>
-                  <td className='comparison-table__cell'>Kleine- en middelgrote ondernemingen</td>
+                    <td className='comparison-table__cell'>Kleine- en middelgrote ondernemingen</td>
                   </Translation>
                   <td className='comparison-table__cell'>Bedrijven die volledige controle willen</td>
                 </tr>

--- a/app/pages/home/home.nl.js
+++ b/app/pages/home/home.nl.js
@@ -45,10 +45,10 @@ export default class HomeNl extends React.Component {
                 </div>
                 <p className='u-size-4of5 u-center u-color-p u-margin-Txs'>
                   <Translation locales='nl-NL'>
-                  Accepteer Nederlandse en internationale incasso. We ondersteunen reeds SEPA (Eurozone), BACS (Verenigd Koninkrijk) en Autogiro (Zweden)
+                    Accepteer Nederlandse en internationale incasso. We ondersteunen reeds SEPA (Eurozone), BACS (Verenigd Koninkrijk) en Autogiro (Zweden)
                   </Translation>
                   <Translation locales='nl-BE'>
-                  Accepteer Belgische en internationale domiciliëringen. We ondersteunen reeds SEPA (Eurozone), BACS (Verenigd Koninkrijk) en Autogiro (Zweden)
+                    Accepteer Belgische en internationale domiciliëringen. We ondersteunen reeds SEPA (Eurozone), BACS (Verenigd Koninkrijk) en Autogiro (Zweden)
                   </Translation>
                 </p>
               </div>

--- a/app/pages/partners/partners.nl.js
+++ b/app/pages/partners/partners.nl.js
@@ -31,14 +31,8 @@ export default class PartnersNl extends React.Component {
               <div className='page-hero__text'>
                 <h1 className='u-text-heading u-color-invert u-text-light u-padding-Tm'>Help uw klanten online betalingen te accepteren</h1>
                   <p className='u-text-heading-light u-text-m u-color-invert u-padding-Vs'>
-                    <Translation locales='nl-NL'>
-                    Word GoCardless partner en maak het gemakkelijk voor uw klanten om terugkerende betalingen in Nederland
-                    en andere landen te accepteren
-                    </Translation>
-                    <Translation locales='nl-BE'>
-                    Word GoCardless partner en maak het gemakkelijk voor uw klanten om terugkerende betalingen in België
-                    en andere landen te accepteren
-                    </Translation>
+                    Word GoCardless partner en maak het gemakkelijk voor uw klanten om terugkerende betalingen
+                    in <Message pointer='country' /> en andere landen te accepteren
                   </p>
                </div>
             </div>
@@ -81,12 +75,12 @@ export default class PartnersNl extends React.Component {
               </h2>
               <p className='u-size-2of3 u-center u-color-p u-padding-Ts'>
                 <Translation locales='nl-NL'>
-                GoCardless laat u toe van de lage kosten en het lage percentage niet-succesvolle verrichtingen van automatisch incasso
-                 te genieten zonder de problemen van traditionele aanbieders.
+                  GoCardless laat u toe van de lage kosten en het lage percentage niet-succesvolle verrichtingen van automatisch incasso
+                  te genieten zonder de problemen van traditionele aanbieders.
                 </Translation>
                 <Translation locales='nl-BE'>
-                GoCardless laat u toe van de lage kosten en het lage percentage niet-succesvolle verrichtingen van domiciliëringen
-                 te genieten zonder de problemen van traditionele aanbieders.
+                  GoCardless laat u toe van de lage kosten en het lage percentage niet-succesvolle verrichtingen van domiciliëringen
+                  te genieten zonder de problemen van traditionele aanbieders.
                 </Translation>
               </p>
               <div className='site-container u-padding-Txxl'>

--- a/app/pages/pro/pro.nl.js
+++ b/app/pages/pro/pro.nl.js
@@ -22,12 +22,14 @@ export default class ProNl extends React.Component {
               <div className='page-hero__inner'>
                 <div className='page-hero__text'>
                   <Translation locales='nl-NL'>
-                  <h1 className='u-text-heading u-color-invert u-text-center u-text-xl u-text-light'>Volledig controle
-                  over SEPA incasso</h1>
+                    <h1 className='u-text-heading u-color-invert u-text-center u-text-xl u-text-light'>
+                      Volledig controle over SEPA incasso
+                    </h1>
                   </Translation>
                   <Translation locales='nl-BE'>
-                  <h1 className='u-text-heading u-color-invert u-text-center u-text-xl u-text-light'>Volledig controle
-                  over SEPA domiciliëringen</h1>
+                    <h1 className='u-text-heading u-color-invert u-text-center u-text-xl u-text-light'>
+                      Volledig controle over SEPA domiciliëringen
+                    </h1>
                   </Translation>
                   <p className='u-text-heading u-text-center u-color-invert u-text-m u-text-light u-margin-Txxs u-text-no-smoothing'>
                     Een innovatief platform om uw netwerk <br />voor terugkerende betalingen te bouwen
@@ -78,18 +80,18 @@ export default class ProNl extends React.Component {
                   </h2>
                   <p className='u-text-s u-color-p u-margin-Txs'>
                     <Translation locales='nl-NL'>
-                    Ontwikkeld voor grotere bedrijven,
-                    GoCardless Pro combineert het gebruiksgemak van ons origineel
-                    GoCardless product met volledige controle over betalingen en de gebruikerservaring.
-                    Het laat u tevens toe zowel betalingen uit Nederland, de Eurozone en Verenigd Koninkrijk te ontvangen
-                    met één eenvoudige integratie.
+                      Ontwikkeld voor grotere bedrijven,
+                      GoCardless Pro combineert het gebruiksgemak van ons origineel
+                      GoCardless product met volledige controle over betalingen en de gebruikerservaring.
+                      Het laat u tevens toe zowel betalingen uit Nederland, de Eurozone en Verenigd Koninkrijk te ontvangen
+                      met één eenvoudige integratie.
                     </Translation>
                     <Translation locales='nl-BE'>
-                    Ontwikkeld voor grotere bedrijven,
-                    GoCardless Pro combineert het gebruiksgemak van ons origineel
-                    GoCardless product met volledige controle over betalingen en de gebruikerservaring.
-                    Het laat u tevens toe zowel betalingen uit België, de Eurozone, en Verenigd Koninkrijk te ontvangen
-                    met één eenvoudige integratie.
+                      Ontwikkeld voor grotere bedrijven,
+                      GoCardless Pro combineert het gebruiksgemak van ons origineel
+                      GoCardless product met volledige controle over betalingen en de gebruikerservaring.
+                      Het laat u tevens toe zowel betalingen uit België, de Eurozone, en Verenigd Koninkrijk te ontvangen
+                      met één eenvoudige integratie.
                     </Translation>
                   </p>
                 </div>
@@ -196,14 +198,14 @@ export default class ProNl extends React.Component {
                   <div className='u-center'>
                     <p className='u-text-s u-color-p u-margin-Ts'>
                       <Translation locales='nl-NL'>
-                      GoCardless Pro is het enige product dat u toelaat
-                      SEPA incasso betalingen uit de Eurozone en Verenigd Koninkrijk te ontvangen met één eenvoudige integratie.
-                      Met onze API kan uw bedrijf betalingen ontvangen van meer dan 500 miljoen mensen in 22 Europese landen.
+                        GoCardless Pro is het enige product dat u toelaat
+                        SEPA incasso betalingen uit de Eurozone en Verenigd Koninkrijk te ontvangen met één eenvoudige integratie.
+                        Met onze API kan uw bedrijf betalingen ontvangen van meer dan 500 miljoen mensen in 22 Europese landen.
                       </Translation>
                       <Translation locales='nl-BE'>
-                      GoCardless Pro is het enige product dat u toelaat
-                      SEPA domiciliëringen uit de Eurozone en Verenigd Koninkrijk te ontvangen met één eenvoudige integratie.
-                      Met onze API kan uw bedrijf betalingen ontvangen van meer dan 500 miljoen mensen in 22 Europese landen.
+                        GoCardless Pro is het enige product dat u toelaat
+                        SEPA domiciliëringen uit de Eurozone en Verenigd Koninkrijk te ontvangen met één eenvoudige integratie.
+                        Met onze API kan uw bedrijf betalingen ontvangen van meer dan 500 miljoen mensen in 22 Europese landen.
                       </Translation>
                     </p>
                   </div>


### PR DESCRIPTION
Just some minor fixes to the indentation of code for better readability.

@JoeriVankeirsbilck It looks like we have lots of cases where we just replace a single word in a sentence: e.g.
incasso <-> domiciliëringen
automatisch incasso <-> domiciliëringen
I'm thinking we should define these as messages e.g. `<Message pointer='incasso' />` would show as incasso in Netherlands and domiciliëringen in Belgium (makes it easier in the future when updating the content).

I've also replaced the hardcoded references to `Nederland` and `België` with `<Message pointer='country' />` (this will automatically be replaced with the relevant country name).