### PR TITLE
Add a shared messages file & use consistent # of merchants across the website

### DIFF
--- a/app/messages/de-DE.js
+++ b/app/messages/de-DE.js
@@ -1,5 +1,3 @@
-
-
 export default {
   country: 'Deutschland',
   country_properties: {

--- a/app/messages/de.js
+++ b/app/messages/de.js
@@ -1,5 +1,3 @@
-
-
 export default {
   header: {
     our_products: 'Produkte',

--- a/app/messages/en-EU.js
+++ b/app/messages/en-EU.js
@@ -1,5 +1,3 @@
-
-
 export default {
   country: 'Europe',
   country_properties: {

--- a/app/messages/en-GB.js
+++ b/app/messages/en-GB.js
@@ -1,5 +1,3 @@
-
-
 export default {
   country: 'United Kingdom',
   country_properties: {

--- a/app/messages/en-IE.js
+++ b/app/messages/en-IE.js
@@ -1,5 +1,3 @@
-
-
 export default {
   country: 'Ireland',
   phone_full: '+353 76 680 5320',

--- a/app/messages/en-SE.js
+++ b/app/messages/en-SE.js
@@ -1,5 +1,3 @@
-
-
 export default {
   country: 'Sweden',
   phone_full: '+46 844 680 379',

--- a/app/messages/en.js
+++ b/app/messages/en.js
@@ -1,5 +1,3 @@
-
-
 export default {
   header: {
     our_products: 'Our products',

--- a/app/messages/es-ES.js
+++ b/app/messages/es-ES.js
@@ -1,5 +1,3 @@
-
-
 export default {
   country: 'España',
   country_properties: {

--- a/app/messages/es.js
+++ b/app/messages/es.js
@@ -1,6 +1,5 @@
-
-
 export default {
+  number_of_merchants: '13.000',
   header: {
     our_products: 'Nuestros Productos',
     login_btn: 'Login',

--- a/app/messages/fr-BE.js
+++ b/app/messages/fr-BE.js
@@ -1,5 +1,3 @@
-
-
 export default {
   country: 'Belgique',
   country_properties: {

--- a/app/messages/fr-FR.js
+++ b/app/messages/fr-FR.js
@@ -1,5 +1,3 @@
-
-
 export default {
   country: 'France',
   country_properties: {

--- a/app/messages/fr.js
+++ b/app/messages/fr.js
@@ -1,6 +1,5 @@
-
-
 export default {
+  number_of_merchants: '13.000',
   header: {
     our_products: 'Nos produits',
     login_btn: 'Se connecter',

--- a/app/messages/nl-BE.js
+++ b/app/messages/nl-BE.js
@@ -1,5 +1,3 @@
-
-
 export default {
   country: 'België',
   country_properties: {

--- a/app/messages/nl-NL.js
+++ b/app/messages/nl-NL.js
@@ -1,5 +1,3 @@
-
-
 export default {
   country: 'Nederland',
   country_properties: {

--- a/app/messages/nl.js
+++ b/app/messages/nl.js
@@ -1,5 +1,3 @@
-
-
 export default {
   header: {
     our_products: 'Onze producten',

--- a/app/messages/shared.js
+++ b/app/messages/shared.js
@@ -1,3 +1,3 @@
 export default {
   number_of_merchants: '13,000',
-}
+};

--- a/app/messages/shared.js
+++ b/app/messages/shared.js
@@ -1,0 +1,3 @@
+export default {
+  number_of_merchants: '13,000',
+}

--- a/app/pages/about/about.es.js
+++ b/app/pages/about/about.es.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import Message from '../../components/message/message';
 import Translation from '../../components/translation/translation';
 
 export default class AboutEs extends React.Component {
@@ -21,7 +22,7 @@ export default class AboutEs extends React.Component {
               <p className='para'>
                 Fundada en 2011, hemos crecido muy rápido para convertirnos en una de las institutiones de Domiciliación
                 Bancaria más grandes de Europa,
-                procesando más de mil millones de Euros para más de 12.000 empresas.
+                procesando más de mil millones de Euros para más de <Message pointer='number_of_merchants' /> empresas.
               </p>
               <p className='para'>
                 Trabajamos con todo tipo de organizaciones: pequeños gimnasios y clubes nos utilizan para reducir el

--- a/app/pages/about/about.fr.js
+++ b/app/pages/about/about.fr.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import Message from '../../components/message/message';
 import Translation from '../../components/translation/translation';
 
 export default class AboutFr extends React.Component {
@@ -15,7 +16,8 @@ export default class AboutFr extends React.Component {
             <div className='grid__cell u-size-2of3'>
               <p className='u-text-s u-color-p u-margin-Txxl u-size-5of6'>
                 GoCardless est un des leaders européens du prélèvement bancaire.
-                Nous collectons plus d'un milliard d'Euros chaque année pour plus de 10.000 entreprises et organisations dont le
+                Nous collectons plus d'un milliard d'Euros chaque année pour plus
+                de <Message pointer='number_of_merchants' /> entreprises et organisations dont le
                 Guardian, Omni Capital, Funding Circle et Pieminister, avec une croissance annuelle de 600%.<br /><br />
                 Nous nous sommes lancés en 2011 avec un seul objectif : rendre les prélèvements bancaires simples et accessibles à tous,
                 instantanément et à bas coût.
@@ -32,8 +34,8 @@ export default class AboutFr extends React.Component {
                 et habilité à prélever des paiements à travers l’Union Européenne.
                 Nous sommes financés par certains des plus importants investisseurs au monde
                 dont Balderton Capital, Accel Partners, Passion Capital et Y-Combinator.
-                Plus de 10.000 entreprises et organisations de toutes tailles utilisent GoCardless pour collecter des
-                millions d'Euros tous les jours.
+                Plus de <Message pointer='number_of_merchants' /> entreprises et organisations de toutes tailles utilisent GoCardless
+                pour collecter des millions d'Euros tous les jours.
               </p>
             </div>
             <div className='grid__cell u-size-1of3'>

--- a/app/pages/home/home.en.js
+++ b/app/pages/home/home.en.js
@@ -3,6 +3,7 @@ import Translation from '../../components/translation/translation';
 import IfLocale from '../../components/if-locale/if-locale';
 import Link from '../../components/link/link';
 import Href from '../../components/href/href';
+import Message from '../../components/message/message';
 
 import CheckListIcon from '../../icons/svg/checklist';
 import MoneyFlowerIcon from '../../icons/svg/money-flower';
@@ -84,34 +85,23 @@ export default class HomeEn extends React.Component {
                 </div>
               </IfLocale>
 
-              <Translation locales={['en']} exclude={['en-GB']}>
               <div className='grid__cell u-size-1of3 u-text-center'>
                 <figure className='svg-icon u-center'>
                   <UsersIcon className='svg-icon__image svg-icon__image--shadow u-fill-green' />
                   <UsersIcon className='svg-icon__image u-fill-dark-gray' />
                 </figure>
                 <div className='u-text-heading u-color-heading u-text-light u-text-no-smoothing u-text-m u-margin-Tm'>
-                  12,000+ merchants
+                  <Message pointer='number_of_merchants' />+ merchants
                 </div>
                 <p className='u-size-4of5 u-center u-color-p u-margin-Txs'>
-                  Powering payments for companies across Europe
+                  <Translation locales={['en']} exclude={['en-GB']}>
+                    Powering payments for companies across Europe
+                  </Translation>
+                  <Translation locales='en-GB'>
+                    Powering payments for companies across the UK and Europe
+                  </Translation>
                 </p>
               </div>
-              </Translation>
-              <Translation locales='en-GB'>
-              <div className='grid__cell u-size-1of3 u-text-center'>
-                <figure className='svg-icon u-center'>
-                  <UsersIcon className='svg-icon__image svg-icon__image--shadow u-fill-green' />
-                  <UsersIcon className='svg-icon__image u-fill-dark-gray' />
-                </figure>
-                <div className='u-text-heading u-color-heading u-text-light u-text-no-smoothing u-text-m u-margin-Tm'>
-                  12,000+ merchants
-                </div>
-                <p className='u-size-4of5 u-center u-color-p u-margin-Txs'>
-                  Powering payments for companies across the UK and Europe
-                </p>
-              </div>
-              </Translation>
             </div>
           </div>
         </div>

--- a/app/pages/home/home.es.js
+++ b/app/pages/home/home.es.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import Message from '../../components/message/message';
 import Translation from '../../components/translation/translation';
 import IfLocale from '../../components/if-locale/if-locale';
 import Link from '../../components/link/link';
@@ -54,7 +55,7 @@ export default class HomeEs extends React.Component {
                   <UsersIcon className='svg-icon__image u-fill-dark-gray' />
                 </figure>
                 <div className='u-text-heading u-color-heading u-text-light u-text-no-smoothing u-text-m u-margin-Tm'>
-                  +12.000 empresas
+                  +<Message pointer='number_of_merchants' /> empresas
                 </div>
                 <p className='u-size-4of5 u-center u-color-p u-margin-Txs'>
                   Facilitando cobros para compañías a lo largo de todo Europa, ya sean grandes o pequeñas.

--- a/app/pages/home/home.fr.js
+++ b/app/pages/home/home.fr.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import Message from '../../components/message/message';
 import Translation from '../../components/translation/translation';
 import IfLocale from '../../components/if-locale/if-locale';
 import TickSquareIcon from '../../icons/svg/tick-square';
@@ -174,7 +175,7 @@ export default class HomeFr extends React.Component {
                 Entre de bonnes mains
               </h2>
               <p className='u-text-s u-color-p u-margin-Txs'>
-                Nous collectons des millions pour plus de 10.000 clients chaque jour,
+                Nous collectons des millions pour plus de <Message pointer='number_of_merchants' /> clients chaque jour,
                 en conformité avec les règles SEPA et sous la supervision de la FCA.
                 Nous aidons les start-ups comme les plus grandes entreprises.
               </p>

--- a/app/pages/payments-by-direct-debit/easier-direct-debit.js
+++ b/app/pages/payments-by-direct-debit/easier-direct-debit.js
@@ -74,7 +74,7 @@ export default class EasierDirectDebit extends React.Component {
         <div className='site-container u-padding-Vxxl'>
           <div className='u-padding-Vxl'>
             <h2 className='u-text-heading u-color-heading u-text-l u-text-light u-text-center'>
-              GoCardless powers online Direct Debit for over 13,000 businesses
+              GoCardless powers online Direct Debit for over <Message pointer='number_of_merchants' /> businesses
             </h2>
             <div className='grid__cell u-size-1of2 u-link-clean u-padding-Rxs u-padding-Vm'>
               <div className='product-grid__container u-text-center u-padding-Vl'>
@@ -135,10 +135,10 @@ export default class EasierDirectDebit extends React.Component {
                   <UsersIcon className='svg-icon__image u-fill-dark-gray' />
                 </figure>
                 <h3 className='u-text-heading u-color-heading u-text-light u-text-no-smoothing u-text-m u-margin-Tm'>
-                  Join 13,000+ businesses
+                  Join <Message pointer='number_of_merchants' />+ businesses
                 </h3>
                 <p className='u-color-p u-margin-Txs u-size-5of6 u-center'>
-                  We've collected more than $1 billion for over 13,000 businesses.</p>
+                  We've collected more than $1 billion for over <Message pointer='number_of_merchants' /> businesses.</p>
               </div>
             </div>
           </div>

--- a/app/pages/payments-by-direct-debit/payments-by-direct-debit-variation-b.js
+++ b/app/pages/payments-by-direct-debit/payments-by-direct-debit-variation-b.js
@@ -74,7 +74,7 @@ export default class PaymentsByDirectDebitVariationB extends React.Component {
         <div className='site-container u-padding-Vxxl'>
           <div className='u-padding-Vxl'>
             <h2 className='u-text-heading u-color-heading u-text-l u-text-light u-text-center'>
-              GoCardless powers online Direct Debit for over 13,000 merchants
+              GoCardless powers online Direct Debit for over <Message pointer='number_of_merchants' /> merchants
             </h2>
             <div className='u-text-center u-margin-Tl u-padding-Vs u-center'>
               <img src='/images/logos/pro-logos@2x.png' />
@@ -132,9 +132,11 @@ export default class PaymentsByDirectDebitVariationB extends React.Component {
                   GoCardless integrates with leading accountancy software packages.</p>
               </div>
               <div className='grid__cell u-size-1of3 u-text-center'>
-                <h3 className='u-text-heading u-color-heading u-text-light u-text-no-smoothing u-text-m'>Join 13,000+ businesses</h3>
+                <h3 className='u-text-heading u-color-heading u-text-light u-text-no-smoothing u-text-m'>
+                  Join <Message pointer='number_of_merchants' />+ businesses
+                </h3>
                 <p className='u-color-p u-margin-Txs u-size-5of6 u-center'>
-                  We've collected more than $1 billion for over 13,000 merchants.</p>
+                  We've collected more than $1 billion for over <Message pointer='number_of_merchants' /> merchants.</p>
               </div>
             </div>
           </div>

--- a/app/pages/payments-by-direct-debit/payments-by-direct-debit.fr.js
+++ b/app/pages/payments-by-direct-debit/payments-by-direct-debit.fr.js
@@ -76,7 +76,7 @@ export default class PaymentsByDirectDebitFr extends React.Component {
           <div className='site-container u-padding-Vxxl'>
             <div className='u-padding-Vxl'>
               <h2 className='u-text-heading u-color-heading u-text-l u-text-light u-text-center'>
-                13.000 entreprises font confiance à GoCardless pour leurs prélèvements
+                <Message pointer='number_of_merchants' /> entreprises font confiance à GoCardless pour leurs prélèvements
               </h2>
               <div className='u-text-center u-margin-Tl u-padding-Vs u-center'>
                 <img src='/images/fr/logos/pro-logos-fr@2x.jpg' />
@@ -134,9 +134,12 @@ export default class PaymentsByDirectDebitFr extends React.Component {
                     Si vous avez déjà des mandats SEPA, GoCardless assurera leur migration gratuitement.</p>
                 </div>
                 <div className='grid__cell u-size-1of3 u-text-center'>
-                  <h3 className='u-text-heading u-color-heading u-text-light u-text-no-smoothing u-text-m'>Rejoignez 13.000 clients</h3>
+                  <h3 className='u-text-heading u-color-heading u-text-light u-text-no-smoothing u-text-m'>
+                    Rejoignez <Message pointer='number_of_merchants' /> clients
+                  </h3>
                   <p className='u-color-p u-margin-Txs u-size-5of6 u-center'>
-                    Nous avons prélevé plus de 1 milliard d'Euros pour le compte de plus de 13.000 clients.</p>
+                    Nous avons prélevé plus de 1 milliard d'Euros pour le compte de plus
+                    de <Message pointer='number_of_merchants' /> clients.</p>
                 </div>
               </div>
             </div>

--- a/config/messages.js
+++ b/config/messages.js
@@ -28,8 +28,10 @@ availableLocales.concat(availableLanguages).map(function(locale) {
   langLocales[locale[0]] = require(locale[1]);
 });
 
+var sharedMessages = require(path.join(__dirname, '..', 'app', 'messages', 'shared.js'));
+
 export default availableLocales.reduce(function(locales, locale) {
   var lang = langFromLocale(locale);
-  locales[locale] = merge({}, langLocales[lang], langLocales[locale]);
+  locales[locale] = merge({}, sharedMessages, langLocales[lang], langLocales[locale]);
   return locales;
 }, {});


### PR DESCRIPTION
This PR:
* Adds a new message file that is shared across all locales (see https://github.com/gocardless/splash-pages/issues/351)
* Defines a `number_of_merchants` message so we're always showing the same number across the whole website (and we don't need to change it in a million places)

