### PR TITLE
Adding payment timings page to legal section

### DIFF
--- a/app/css/components/table.scss
+++ b/app/css/components/table.scss
@@ -18,3 +18,28 @@
 .table--faq th {
   padding: $space-small 0;
 }
+
+.table--payment-timings {
+  @extend .table;
+  @extend .u-color-dark-gray;
+  border-bottom: 1px solid $gray;
+}
+
+.table--payment-timings tr {
+  border-top: 1px solid $gray;
+}
+
+.table--payment-timings tr:nth-child(1) {
+  border-top: none;
+}
+
+.table--payment-timings td,
+.table--payment-timings th {
+  width: 33%;
+  padding: $space-small;
+}
+
+.table--payment-timings td {
+  border-right: 1px solid $gray;
+  border-left: 1px solid $gray;
+}

--- a/app/messages/en.js
+++ b/app/messages/en.js
@@ -276,6 +276,11 @@ export default {
     nav_title: 'Customer agreement',
     description: '',
   },
+  legal_payment_timings: {
+    title: 'Our terms of service - Payment timings',
+    nav_title: 'Payment timings',
+    description: '',
+  },
   legal_merchants: {
     title: 'Our terms of service - Merchants',
     nav_title: 'Merchant agreement',

--- a/app/pages/legal/legal-page.js
+++ b/app/pages/legal/legal-page.js
@@ -21,7 +21,6 @@ export default class LegalPage extends React.Component {
     const { currentLocale, availableLocales } = this.context;
     const pages = filterRouteByCategory('legal', currentLocale, availableLocales);
 
-
     const legalNav = pages.map(function(page) {
       return (<li key={page.routeConfig.name}>
         <Link to={page.localeConfig.path} className='nav-tabs__link u-text-no-smoothing'>

--- a/app/pages/legal/payment-timings/legal-payment-timings.js
+++ b/app/pages/legal/payment-timings/legal-payment-timings.js
@@ -1,0 +1,122 @@
+import React from 'react';
+import LegalPage from '../legal-page';
+
+export default class LegalPaymentTimings extends React.Component {
+  displayName = 'LegalPaymentTimings'
+
+  render() {
+    return (
+      <LegalPage>
+        <h2 className='u-text-heading-light u-text-m u-color-dark-gray'>
+          Payment timings
+        </h2>
+
+        <table className='table table--payment-timings u-margin-Tm'>
+          <tr>
+            <th>Event/request</th>
+            <th>Payment scheme</th>
+            <th>Timing</th>
+          </tr>
+
+          <tr>
+            <td rowSpan='3'>
+              Receipt by GoCardless into the GoCardless Client Account of funds from a Customer’s bank, following establishment of a new Payment Scheme Mandate and submission of a Payment Order
+            </td>
+
+            <td>UK Direct Debit</td>
+
+            <td>4 Business Days following the Payment Order</td>
+          </tr>
+
+          <tr>
+            <td>SEPA</td>
+
+            <td>
+              3-6 Business Days following the Payment Order
+            </td>
+          </tr>
+
+          <tr>
+            <td>Autogiro (Sweden)</td>
+
+            <td>
+              2 Business Days following the Payment Order (with the Payment Scheme Mandate set up 8 Business Days prior)
+            </td>
+          </tr>
+
+          <tr>
+            <td rowSpan='3'>
+              Receipt by GoCardless into the GoCardless Client Account of funds from a Customer’s bank, following submission of a Payment Order against an existing Payment Scheme Mandate
+            </td>
+
+            <td>UK Direct Debit</td>
+
+            <td>3 Business Days following the Payment Order</td>
+          </tr>
+
+          <tr>
+            <td>SEPA</td>
+
+            <td>2 Business Days following the Payment Order</td>
+
+          </tr>
+
+          <tr>
+            <td>Autogiro (Sweden)</td>
+
+            <td>2 Business Days following the Payment Order</td>
+
+          </tr>
+
+          <tr>
+            <td rowSpan='3'>
+              Latest time by which a Merchant or Customer may cancel a Payment Scheme Mandate or Payment Order
+            </td>
+
+            <td>UK Direct Debit</td>
+
+            <td>4pm 2 Business Days before the Payment Date</td>
+          </tr>
+
+          <tr>
+            <td>SEPA</td>
+
+            <td>
+              4pm:<br/>
+                (a) 6 Business Days before the Payment Date for the first Payment Order under a Payment Scheme Mandate or<br/>
+                (b) 3 Business Days before the Payment Date for subsequent Payment Orders
+            </td>
+          </tr>
+
+          <tr>
+            <td>Autogiro (Sweden)</td>
+
+            <td>4pm 2 Business Days before the Payment Date</td>
+          </tr>
+
+          <tr>
+            <td rowSpan='3'>
+              Time taken to complete a transfer of funds from the GoCardless Client Account to the Merchant’s Nominated Account
+            </td>
+
+            <td>UK Direct Debit</td>
+
+            <td>2 Business Days following the Payment Date</td>
+          </tr>
+
+          <tr>
+            <td>SEPA</td>
+
+            <td>3-4 Business Days following the Payment Date</td>
+          </tr>
+
+          <tr>
+            <td>Autogiro (Sweden)</td>
+
+            <td>2 Business Days following the Payment Date</td>
+          </tr>
+        </table>
+      </LegalPage>
+    );
+  }
+}

--- a/app/router/routes.js
+++ b/app/router/routes.js
@@ -46,6 +46,7 @@ import LegalOldRestrictions20140919 from '../pages/legal/old-restrictions/2014-0
 import LegalPartners from '../pages/legal/partners/legal-partners';
 import LegalPrivacy from '../pages/legal/privacy/legal-privacy';
 import LegalRestrictions from '../pages/legal/restrictions/legal-restrictions';
+import LegalPaymentTimings from '../pages/legal/payment-timings/legal-payment-timings';
 
 import Partners from '../pages/partners/partners';
 import PartnersClearBooks from '../pages/partners/clearbooks/partners-clearbooks';
@@ -633,6 +634,23 @@ export const config = Immutable.fromJS([
       },
       es: {
         path: '/legal/privacidad',
+      },
+    },
+  ],
+  // Payment timings route doesn't have category because it shouldn't
+  // appear in sidebar for the time being
+  [LegalPaymentTimings, { name: 'legal_payment_timings' }, {
+      'en-GB': {
+        path: '/legal/payment-timings',
+      },
+      'en-EU': {
+        path: '/legal/payment-timings',
+      },
+      'en-IE': {
+        path: '/legal/payment-timings',
+      },
+      'en-SE': {
+        path: '/legal/payment-timings',
       },
     },
   ],


### PR DESCRIPTION
This PR adds a new 'Payment timings' page to our legal section.

It won't appear in the Legal sidebar for the time being as it's only directly concerned with contracts (there will be a link to it in contracts, and means that the entire contract doesn't have to be changed if any of this information changes, as the link will still be correct) - but `/legal/` seems like a good place for it to live.

Currently looking like this:

![our terms of service payment timings gocardless](https://cloud.githubusercontent.com/assets/883598/12847508/ab02154c-cc0b-11e5-8ef3-46ea61e37548.png)


