### PR TITLE
Use lighter grey for placeholder text

### DIFF
--- a/app/css/shared/forms.scss
+++ b/app/css/shared/forms.scss
@@ -29,20 +29,20 @@ input, textarea {
 
   // FF < 19
   &:-moz-placeholder {
-    color: $dark-gray;
+    color: $medium-gray;
   }
 
   // FF >= 19
   &::-moz-placeholder {
-    color: $dark-gray;
+    color: $medium-gray;
   }
 
   // IE 10
   &:-ms-input-placeholder {
-    color: $dark-gray;
+    color: $medium-gray;
   }
 
   &::-webkit-input-placeholder {
-    color: $dark-gray;
+    color: $medium-gray;
   }
 }

--- a/app/css/utils/color.scss
+++ b/app/css/utils/color.scss
@@ -23,4 +23,3 @@
 .u-color-accent {
   color: $accent-color;
 }
-

--- a/app/css/variables.scss
+++ b/app/css/variables.scss
@@ -60,6 +60,7 @@ $accent-color: #3BA031;
 
 $light-gray: #F8F8F8;
 $gray: #DDDDDD;
+$medium-gray: #B1B1B1;
 $dark-gray: #767676;
 $xdark-gray: #222222;
 


### PR DESCRIPTION
The previous grey was dark enough to be mistaken as "live" input text. This commit adds a `$medium-gray` colour variable and uses it for all form placeholder text, taking us from this

![](https://dl.dropboxusercontent.com/s/33zfl8ntjuzqflk/Screenshot%202016-02-08%2011.28.16.png?dl=0)

to this

![](https://dl.dropboxusercontent.com/s/05e9weml9tvck4g/Screenshot%202016-02-08%2010.19.26.png?dl=0)

@anothertompetty please would you review?