### PR TITLE
Update sales contact form

### DIFF
--- a/app/components/prospect-form/prospect-form.js
+++ b/app/components/prospect-form/prospect-form.js
@@ -64,6 +64,7 @@ export default class ProspectForm extends React.Component {
 
   handleChange(event) {
     const input = event.target;
+
     var formData = assign({}, this.state.formData, {
       [input.name]: input.value,
     });
@@ -108,8 +109,6 @@ export default class ProspectForm extends React.Component {
         this.setState({ isSubmitting: false });
 
         if (response.ok) {
-          // Scroll to top showing notification
-          window.scrollTo(0, 0);
           this.setState({ isSuccess: true });
           this.setState({ responseData: response && response.data });
         } else {
@@ -131,69 +130,81 @@ export default class ProspectForm extends React.Component {
 
     let salesForm = (
       <div>
-        <form acceptCharset='UTF-8' action={endpoint} method='post' onChange={this.handleChange} onSubmit={this.onSubmit}>
-          <input className='u-is-hidden' id='prospect_nofill' name='prospect[nofill]' placeholder='Do not fill me in' type='email' />
+        <div className={classNames({ 'u-is-hidden': this.state.isSuccess })}>
 
-          <div className={classNames({
+          <form acceptCharset='UTF-8' action={endpoint} method='post' onChange={this.handleChange} onSubmit={this.onSubmit}>
+            <input className='u-is-hidden' id='prospect_nofill' name='prospect[nofill]' placeholder='Do not fill me in' type='email' />
+
+            <div className={classNames({
             'u-is-hidden notice notice--error u-margin-Bm': true,
-            'u-is-visible': !this.state.isSuccess,
-          })}>
-            { this.state.errorMessage }
-          </div>
-          <div className={classNames({
-            'u-is-hidden notice notice--success u-margin-Bm': true,
-            'u-is-visible': this.state.isSuccess,
-          })}>
-            <Message pointer={`prospect_form.sales.success_messages.${size}`} />
-          </div>
+            'u-is-visible': this.state.errorMessage})}>
+              { this.state.errorMessage }
+            </div>
 
-          <label className='label label--stacked' htmlFor='prospect_name'>
-            <Message pointer='prospect_form.sales.name_label' />
-          </label>
-          <input className='input input--stacked' id='prospect_name' name='prospect[name]'
-            placeholder={getMessage(messages, 'prospect_form.sales.name_placeholder')} required type='text' />
-
-          <label className='label label--stacked' htmlFor='prospect_email'>
-            <Message pointer='prospect_form.sales.email_label' />
-          </label>
-          <input className='input input--stacked' id='prospect_email' name='prospect[email]'
-            placeholder={getMessage(messages, 'prospect_form.sales.email_placeholder')} required type='email' />
-
-          <label className='label label--stacked' htmlFor='prospect_phone_number'>
-            <Message pointer='prospect_form.sales.phone_label' />
-          </label>
-          <input className='input input--stacked' id='prospect_phone_number' name='prospect[phone_number]'
-            placeholder={getMessage(messages, 'prospect_form.sales.phone_placeholder')} required type='text' />
-
-          <Translation locales={['en-GB', 'fr-FR']}>
-            { this.props.showNumberOfPayments &&
-              <div>
-                <label className='label label--stacked' htmlFor='prospect_metadata_number_of_payments'>
-                  <Message pointer='prospect_form.sales.number_of_payments_label' />
-                </label>
-                <select className='input--stacked'
-                id='prospect_metadata_number_of_payments'
-                name='prospect[metadata][number_of_payments]'
-                defaultValue=''>
-                  <option value=''><Message pointer='prospect_form.sales.number_of_payments_placeholder' /></option>
-                  <option value='0-100'>0-100</option>
-                  <option value='100-500'>100-500</option>
-                  <option value='500+'>500+</option>
-                </select>
-              </div>
-            }
-
-            <label className='label label--stacked' htmlFor='prospect_metadata_message'>
-              <Message pointer='prospect_form.sales.specific_needs_label' />
+            <label className='label label--stacked' htmlFor='prospect_name'>
+              <Message pointer='prospect_form.sales.name_label' />
             </label>
-            <textarea className='input input--stacked input--textarea'
-            id='prospect_metadata_message' name='prospect[metadata][message]' rows='3' />
-          </Translation>
+            <input className='input input--stacked' id='prospect_name' name='prospect[name]'
+              placeholder={getMessage(messages, 'prospect_form.sales.name_placeholder')} required type='text' />
 
-          <button className='btn btn--block u-margin-Tl' type='submit'>
-            <Message pointer='prospect_form.sales.submit' />
-          </button>
-        </form>
+            <label className='label label--stacked' htmlFor='prospect_email'>
+              <Message pointer='prospect_form.sales.email_label' />
+            </label>
+            <input className='input input--stacked' id='prospect_email' name='prospect[email]'
+              placeholder={getMessage(messages, 'prospect_form.sales.email_placeholder')} required type='email' />
+
+            <label className='label label--stacked' htmlFor='prospect_phone_number'>
+              <Message pointer='prospect_form.sales.phone_label' />
+            </label>
+            <input className='input input--stacked' id='prospect_phone_number' name='prospect[phone_number]'
+              placeholder={getMessage(messages, 'prospect_form.sales.phone_placeholder')} required type='text' />
+
+            <Translation locales={['en-GB']}>
+              <label className='label label--stacked' htmlFor='prospect_metadata_number_of_payments'>
+                How many payments could we have helped you collect last month?
+              </label>
+              <select className='input--stacked'
+              id='prospect_metadata_number_of_payments'
+              name='prospect[metadata][number_of_payments]'
+              defaultValue=''>
+                <option value=''>Select number of payments taken last month</option>
+                <option value='0-100'>0-100</option>
+                <option value='100-500'>100-500</option>
+                <option value='500+'>500+</option>
+              </select>
+
+              <label className='label label--stacked' htmlFor='prospect_metadata_message'>
+                What are your business&apos;s specific needs?
+              </label>
+              <textarea className='input input--stacked input--textarea'
+              id='prospect_metadata_message' name='prospect[metadata][message]' rows='3' />
+            </Translation>
+
+            <Translation locales='fr'>
+              <label className='label label--stacked' htmlFor='prospect_metadata_number_of_payments'>
+                Combien de paiements souhaitez-vous prélever chaque mois?
+              </label>
+              <select className='input--stacked'
+              id='prospect_metadata_number_of_payments'
+              name='prospect[metadata][number_of_payments]'
+              defaultValue=''>
+                <option value=''>Choisissez le nombre de paiements</option>
+                <option value='0-50'>0-50</option>
+                <option value='50+'>50+</option>
+              </select>
+            </Translation>
+
+            <button type='submit' className='btn btn--block u-margin-Tl contact-sales'>
+              <Message pointer='prospect_form.sales.submit' />
+            </button>
+          </form>
+        </div>
+
+        <div className={classNames({
+        'u-is-hidden notice notice--success u-margin-Bm': true,
+        'u-is-visible': this.state.isSuccess})}>
+          <Message pointer={`prospect_form.sales.success_messages.${size}`} />
+        </div>
       </div>
     );
 

--- a/app/css/components/notice.scss
+++ b/app/css/components/notice.scss
@@ -1,0 +1,18 @@
+.notice {
+  position: relative;
+  top: 0;
+  left: 0;
+  right: 0;
+  text-align: center;
+  font-size: $space-small;
+  padding-top: $space-xsmall;
+  padding-bottom: $space-xsmall;
+  display: inline-block;
+  background-color: $amber-color-light;
+  border: 1px solid $amber-color;
+  border-radius: 2px;
+}
+
+.notice--error {
+  border: 1px solid $secondary-color;
+}

--- a/app/css/main.scss
+++ b/app/css/main.scss
@@ -19,6 +19,7 @@
 @import "components/checkmark-icon";
 @import "components/chromeframe";
 @import "components/comparison-table";
+@import "components/notice";
 @import "components/country-select-label";
 @import "components/error-label";
 @import "components/email-capture";

--- a/app/css/variables.scss
+++ b/app/css/variables.scss
@@ -57,6 +57,8 @@ $primary-color: #5092DA;
 $primary-hover-color: #376BA9;
 $secondary-color: #EE6850;
 $accent-color: #3BA031;
+$amber-color: #FFBF00;
+$amber-color-light: #FFF7E0;
 
 $light-gray: #F8F8F8;
 $gray: #DDDDDD;


### PR DESCRIPTION
Previously, when the contact form was submitted, the page scrolled to
the top and the success notification was plain text that looked the same
as other text on the page. This meant potential customers don’t know if
the form has successfully submitted, so they often resubmit multiple
times. At best this produces a lot of noise in the SDR slack room and
bad metrics. At worst two different SDRs can contact the same lead 5
minutes after each other.

This commit changes the UX. When the form successfully submits it
disappears and is replaced by a bright notice box that says
’Thanks. We’ll be in touch soon.’ or something to that effect.

The behaviour used to be http://quick.as/vjl2f22ao and is now http://quick.as/x6l2cbbqj

@anothertompetty :+1: / :-1: ?