### PR TITLE
Remove Optimizely and move GTM to start of body tag

### DIFF
--- a/app/components/html-document/html-document.js
+++ b/app/components/html-document/html-document.js
@@ -118,8 +118,13 @@ class HtmlDocument extends React.Component {
         </head>
 
         <body>
-          { config.optimizelyId &&
-            <script src={`//cdn.optimizely.com/js/${config.optimizelyId}.js`}></script>
+
+          { config.googleTagManagerId &&
+              <div dangerouslySetInnerHTML={{
+                __html: GTM.replace('{TAG_ID}', config.googleTagManagerId)
+                .replace('{PAGE_LANGUAGE}', language)
+                .replace('{PAGE_REGION}', region),
+              }} />
           }
 
           <div dangerouslySetInnerHTML={{ __html: browseHappy }} />
@@ -138,14 +143,6 @@ class HtmlDocument extends React.Component {
           { isHome &&
               <script type='application/ld+json'
                 dangerouslySetInnerHTML={{ __html: JSON.stringify(schemaDotOrgOrganisation) }} />
-          }
-
-          { config.googleTagManagerId &&
-              <div dangerouslySetInnerHTML={{
-                __html: GTM.replace('{TAG_ID}', config.googleTagManagerId)
-                .replace('{PAGE_LANGUAGE}', language)
-                .replace('{PAGE_REGION}', region),
-              }} />
           }
         </body>
       </html>

--- a/config/production.js
+++ b/config/production.js
@@ -1,5 +1,4 @@
 export default {
   googleTagManagerId: 'GTM-PRFKNC',
-  optimizelyId: '125150657',
   siteRoot: 'https://gocardless.com',
 };


### PR DESCRIPTION
Two changes:

1. Remove Optimizely (as discussed on e-mail last week)
2. Move GTM to the start of `<body>` (this is the [recommended location](https://developers.google.com/tag-manager/quickstart) from Google - it gives more reliable firing of tags & is also non-blocking async).