### PR TITLE
Only show error message if there’s an error

### DIFF
--- a/app/components/prospect-form/prospect-form.js
+++ b/app/components/prospect-form/prospect-form.js
@@ -208,7 +208,7 @@ export default class ProspectForm extends React.Component {
 
           <div className={classNames({
             'u-is-hidden notice notice--error u-margin-Bm': true,
-            'u-is-visible': !this.state.isSuccess,
+            'u-is-visible': this.state.errorMessage,
           })}>
             { this.state.errorMessage }
           </div>


### PR DESCRIPTION
Steve noticed an empty error message box floating in the Aus landing page. This div will have been on the page for a while but has only displayed since I changed its styling.

![](https://dl.dropbox.com/s/t4doas26neya14f/Screenshot%202016-02-22%2011.56.16.png?dl=0)