### PR TITLE
Add link to /partners to the More dropdown.

### DIFF
--- a/app/components/header/header.js
+++ b/app/components/header/header.js
@@ -141,6 +141,10 @@ class Header extends React.Component {
                       <Link to='faq_pro_dashboard' pointer='faq_pro_dashboard.link_title'
                       id='track-nav-faq-pro-dashboard' className='u-padding-Vxs u-padding-Hm u-block' />
                     </IfLinkExists>
+                    <IfLinkExists to='partners' tagName='li' className='u-text-semi'>
+                      <Link to='partners' id='track-nav-partners' className='u-padding-Vxs u-padding-Hm u-block'
+                        pointer='partners.nav_title' />
+                    </IfLinkExists>
                     <hr className='u-margin-Vs' />
                     <IfLinkExists to='about' tagName='li'>
                       <Link to='about' pointer='about.nav_title'


### PR DESCRIPTION
The previous splash page update removed /partners from the Nav entirely, this brings it back.

<img width="490" alt="screen shot 2016-03-10 at 13 45 29" src="https://cloud.githubusercontent.com/assets/1385001/13671297/ff76f248-e6c6-11e5-8af2-8006c89b9e65.png">
