### PR TITLE
Special-casing EN pricing styles

### DIFF
--- a/app/css/components/page-hero.scss
+++ b/app/css/components/page-hero.scss
@@ -98,6 +98,11 @@
 }
 
 .page-hero--pricing {
+  background: $dark-gray;
+}
+
+.page-hero--one-product-pricing {
+  background: $light-gray;
   margin-top: -78px;
 }
 

--- a/app/pages/pricing/pricing.en.js
+++ b/app/pages/pricing/pricing.en.js
@@ -18,7 +18,7 @@ export default class PricingEn extends React.Component {
     const hasPercentagePricing = getMessage(this.context.messages, 'country_properties.has_percentage_pricing');
     return (
       <Translation locales='en'>
-        <div className='page-hero page-hero--pricing u-background-light-gray'>
+        <div className='page-hero page-hero--pricing page-hero--one-product-pricing'>
           <div className='site-container'>
             <div className='grid pricing-options--new u-center u-padding-Bxl'>
 

--- a/app/pages/pricing/pricing.js
+++ b/app/pages/pricing/pricing.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import Page from '../../components/page/page';
+import Translation from '../../components/translation/translation';
 import PricingEn from './pricing.en';
 import PricingFr from './pricing.fr';
 import PricingDe from './pricing.de';
@@ -11,13 +12,22 @@ export default class Pricing extends React.Component {
 
   render() {
     return (
-      <Page isInverted={false}>
-        <PricingEn />
-        <PricingFr />
-        <PricingDe />
-        <PricingEs />
-        <PricingNl />
-      </Page>
+      <div>
+        <Translation locales='en'>
+          <Page isInverted={false}>
+            <PricingEn />
+          </Page>
+        </Translation>
+
+        <Translation locales={['fr', 'de', 'es', 'nl']}>
+          <Page>
+            <PricingFr />
+            <PricingDe />
+            <PricingEs />
+            <PricingNl />
+          </Page>
+        </Translation>
+      </div>
     );
   }
 }


### PR DESCRIPTION
A change to our of our widely-used CSS classes resulted in One Product pricing page changes taking an effect across all locales (we're working our way through them individually, so they shouldn't look different right now).

Was:
<img width="1105" alt="screen shot 2016-03-14 at 11 26 49" src="https://cloud.githubusercontent.com/assets/883598/13743143/e05b9580-e9d7-11e5-9e6b-277872bae597.png">

Now:
<img width="1096" alt="screen shot 2016-03-14 at 11 26 59" src="https://cloud.githubusercontent.com/assets/883598/13743135/d70c8372-e9d7-11e5-9ddb-eb4b657cff94.png">
