### PR TITLE
Adding class for partners instruction screenshot

### DIFF
--- a/app/css/components/partners-page.scss
+++ b/app/css/components/partners-page.scss
@@ -54,3 +54,7 @@
   max-width: 2000px;
   height: 385px;
 }
+
+.partners-page__quickbooks-instruction-screenshot {
+  margin-right: -35px;
+}

--- a/app/pages/partners/quickbooks/partners-quickbooks.js
+++ b/app/pages/partners/quickbooks/partners-quickbooks.js
@@ -113,7 +113,8 @@ export default class PartnersQuickbooks extends React.Component {
             </div>
 
             <div className='grid__cell u-size-1of2 u-text-center'>
-              <img src='/images/partners/quickbooks-instruction-1.jpg' />
+              <img className='partners-page__quickbooks-instruction-screenshot'
+              src='/images/partners/quickbooks-instruction-1.jpg' />
             </div>
           </div>
         </div>
@@ -135,7 +136,8 @@ export default class PartnersQuickbooks extends React.Component {
             </div>
 
             <div className='grid__cell u-size-1of2 u-text-center'>
-              <img src='/images/partners/quickbooks-instruction-2.jpg' />
+              <img className='partners-page__quickbooks-instruction-screenshot'
+              src='/images/partners/quickbooks-instruction-2.jpg' />
             </div>
           </div>
         </div>
@@ -157,7 +159,8 @@ export default class PartnersQuickbooks extends React.Component {
             </div>
 
             <div className='grid__cell u-size-1of2 u-text-center'>
-              <img src='/images/partners/quickbooks-instruction-3.jpg' />
+              <img className='partners-page__quickbooks-instruction-screenshot'
+              src='/images/partners/quickbooks-instruction-3.jpg' />
             </div>
           </div>
         </div>
@@ -179,7 +182,8 @@ export default class PartnersQuickbooks extends React.Component {
             </div>
 
             <div className='grid__cell u-size-1of2 u-text-center'>
-              <img src='/images/partners/quickbooks-instruction-4.jpg' />
+              <img className='partners-page__quickbooks-instruction-screenshot'
+              src='/images/partners/quickbooks-instruction-4.jpg' />
             </div>
           </div>
         </div>


### PR DESCRIPTION
Ensuring edge of screenshots are aligned with the ends of the horizontal rules on the new partner page design:

![image](https://cloud.githubusercontent.com/assets/883598/14605018/6dd25636-056e-11e6-93c3-750299223c16.png)
