### PR TITLE
Change background sizing to stop images being squashed

### DIFF
--- a/app/css/components/stories-spotlight.scss
+++ b/app/css/components/stories-spotlight.scss
@@ -11,32 +11,38 @@
 
 .stories-spotlight__item--has-bean-coffee {
   background: url('/images/stories/spotlight-has-bean-coffee@2x.jpg');
-  background-size: 100% 100%;
+  background-size: cover;
+  background-position: top center;
 }
 
 .stories-spotlight__item--crossfit-hackney {
   background: url('/images/stories/spotlight-crossfit-hackney@2x.jpg');
-  background-size: 100% 100%;
+  background-size: cover;
+  background-position: top center;
 }
 
 .stories-spotlight__item--zenchef {
   background: url('/images/stories/spotlight-zenchef@2x.jpg');
-  background-size: 100% 100%;
+  background-size: cover;
+  background-position: top center;
 }
 
 .stories-spotlight__item--french-talents {
   background: url('/images/stories/spotlight-french-talents@2x.jpg');
-  background-size: 100% 100%;
+  background-size: cover;
+  background-position: top center;
 }
 
 .stories-spotlight__item--crossfit-oldenburg {
   background: url('/images/stories/spotlight-crossfit-oldenburg@2x.jpg');
-  background-size: 100% 100%;
+  background-size: cover;
+  background-position: top center;
 }
 
 .stories-spotlight__item--picdrop {
   background: url('/images/stories/spotlight-picdrop@2x.jpg');
-  background-size: 100% 100%;
+  background-size: cover;
+  background-position: top center;
 }
 
 .stories-spotlight__btn {


### PR DESCRIPTION
The image container is set to 50%, and so changes size depending on the width of the screen.

This lead to slightly squashed images in some cases.

But no longer!

![screen shot 2016-05-12 at 10 19 00](https://cloud.githubusercontent.com/assets/1385001/15209778/f6f24ea2-182a-11e6-911e-0e22a5177f3e.png)

cc @jamesshedden 