### PR TITLE
[Fix] Add how-to page

### DIFF
--- a/app/components/frame/frame.js
+++ b/app/components/frame/frame.js
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default class Frame extends React.Component {
+  displayName = 'Frame'
+
+  render() {
+    return <iframe {...this.props} />;
+  }
+}

--- a/app/components/video-tile/video-tile.js
+++ b/app/components/video-tile/video-tile.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import classNames from 'classnames';
+
+export default class VideoTile extends React.Component {
+  displayName = 'VideoTile'
+
+  static propTypes = {
+    title: React.PropTypes.string.isRequired,
+    duration: React.PropTypes.string.isRequired,
+    slug: React.PropTypes.string.isRequired,
+    isActive: React.PropTypes.bool.isRequired,
+  }
+
+  render() {
+    const {title, duration, slug, isActive} = this.props;
+
+    const containerClassName = classNames({
+      'is-active': isActive,
+      'u-margin-Hs': true,
+      'u-margin-Bs': true,
+      'video-tile': true,
+    });
+
+    return (
+      <div className="grid__cell u-size-1of4 u-text-center u-margin-Bl" title={ title }>
+        <a className="u-link-clean" href={`#${ slug }`}>
+          <div className={containerClassName}>
+            <div className="u-size-5of6 u-center">
+              <i className="video-tile__play-button u-margin-Tl u-margin-Bs"></i>
+              <p className="video-tile__title u-text-light u-text-no-smoothing u-text-m u-link-clean u-cf u-color-heading">{ title }</p>
+              <p className="u-margin-Ts u-color-base video-tile__time">{ duration }</p>
+            </div>
+          </div>
+        </a>
+      </div>
+    );
+  }
+}

--- a/app/css/components/videos-container.scss
+++ b/app/css/components/videos-container.scss
@@ -9,49 +9,38 @@
   box-shadow: 0 0px 4px rgba(0,0,0,0.3);
 }
 
-.videos-container__thumbnail {
+.video-tile {
   height: 190px;
   background: $site-background-color;
+  color: $xdark-gray;
   transition: background 0.4s ease;
 }
 
-.videos-container__thumbnail:hover {
-  cursor: pointer;
+.video-tile:hover {
   background: $light-gray;
   transition: background 0.2s ease;
 }
 
-.videos-container__thumbnail.is-active,
-.videos-container__thumbnail.is-active:hover {
+.video-tile__title {
+  height: 58px;
+}
+
+.video-tile__time {
+  color: $medium-gray;
+}
+
+.video-tile.is-active {
   background: $primary-color;
 }
 
-.videos-container__select-a-video, .videos-container__secondary-content {
-  background: white;
+.video-tile.is-active * {
+  color: white;
 }
 
-.videos-container__play-button {
+.video-tile__play-button {
   @include icon('/images/videos/play-button', 32px, 32px);
 }
 
-.videos-container__play-button.is-active {
+.video-tile.is-active .video-tile__play-button {
   @include icon('/images/videos/play-button--active', 32px, 32px);
-}
-
-.videos-container__link:hover {
-  color: $xdark-gray;
-}
-
-.videos-container__link.is-active,
-.videos-container__link.is-active:hover {
-  color: white;
-}
-
-.videos-container__time.is-active {
-  color: white;
-}
-
-.videos-container--features {
-  height: 310px;
-  box-shadow: 0 2px 18px rgba(0,0,0,0.5);
 }

--- a/app/messages/en.js
+++ b/app/messages/en.js
@@ -627,6 +627,11 @@ export default {
     title: 'Support',
     nav_title: 'Support',
   },
+  'how-to': {
+    title: 'How to',
+    nav_title: 'How to',
+    description: 'How to use GoCardless',
+  },
   stories_has_bean_coffee: {
     title: 'Has Bean Coffee',
     description: 'Has Bean Coffee improved their cashflow by 30% using Direct Debit with GoCardless. See their testimonial of taking subscriptions using GoCardless.',

--- a/app/pages/how-to/how-to.en.js
+++ b/app/pages/how-to/how-to.en.js
@@ -1,0 +1,100 @@
+import React from 'react';
+import Translation from '../../components/translation/translation';
+import Message from '../../components/message/message';
+import Immutable from 'immutable';
+import Href from '../../components/href/href';
+import Frame from '../../components/frame/frame';
+import VideoTile from '../../components/video-tile/video-tile';
+
+export default class HowToEn extends React.Component {
+  displayName = 'HowToEn'
+
+  constructor(props) {
+    super(props);
+
+    const videos = Immutable.fromJS([
+      { id: 167890582, title: 'Adding customers', duration: '01:49', slug: 'adding-customers' },
+      { id: 167887618, title: 'Plans', duration: '02:32', slug: 'plans' },
+      { id: 167887615, title: 'Payments and paylinks', duration: '02:57', slug: 'payments-and-paylinks' },
+      { id: 167887610, title: 'Teams', duration: '02:11', slug: 'teams' },
+    ]);
+
+    this.locationHasChanged = this.locationHasChanged.bind(this);
+
+    this.state = {
+      videos,
+      autoplay: 0,
+      active: videos.get(0),
+    };
+  }
+
+  static contextTypes = {
+    messages: React.PropTypes.object.isRequired,
+    router: React.PropTypes.func,
+  }
+
+  componentDidMount() {
+    this.locationHasChanged();
+    window.addEventListener('hashchange', this.locationHasChanged);
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('hashchange', this.locationHasChanged);
+  }
+
+  locationHasChanged(event) {
+    const { hash } = window && window.location;
+    this.setState(() => {
+      return {
+        active: this.state.videos.find(
+          (item) => item.get('slug') === hash.substring(1)
+        ) || this.state.videos.get(0),
+        /**
+         * the presence of the event parameter indicates that we should autoplay, since
+         * it must mean that hash has changed since the initial load
+         */
+        autoplay: event ? 1 : 0,
+      };
+    });
+    window.scrollTo(window, 0);
+  }
+
+  render() {
+    return (
+      <Translation locales='en'>
+        <div className='page-hero u-relative u-size-full'>
+          <div className='u-text-center u-padding-Vl'>
+            <h1 className="u-text-heading u-text-xl u-text-light u-color-invert u-padding-Bs">Here's how it works</h1>
+            <div className="u-padding-Tl">
+              <div className="u-center videos-container__iframe u-margin-Vl">
+                <Frame src={ `https://player.vimeo.com/video/${ this.state.active.get('id') }?autoplay=${ this.state.autoplay }` } width="100%" height="100%" frameBorder="0" allowFullScreen />
+              </div>
+              <div className="u-size-2of5 u-center u-padding-Vs u-color-invert">
+                <p className="u-text-heavy u-margin-Bxs">Trying out GoCardless</p>
+                <p>The easiest way to know if GoCardless is right for you is to sign up and try it out. It's quick and free, and you can use your own details to take trial payments.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="videos-container__select-a-video u-text-center u-color-base u-padding-Vl">
+          <h2 className="u-text-heading u-color-heading u-text-l u-text-light u-padding-Vl u-margin-Bl">Select a video to learn more about our Dashboard</h2>
+
+          <div className="grid site-container">{ this.state.videos.map(video => <VideoTile key={ video.get('id') } { ...video.toJS() } isActive={ this.state.active === video } />) }</div>
+
+          <hr className="u-margin-An u-margin-Txxl"></hr>
+
+          <div className="site-container u-text-center u-padding-Vxxl">
+            <div className="u-padding-Vxl">
+              <Href to='signup.path' id='track-how-to-merchants-new' className={ 'btn' }>
+                <Message pointer='cta.basic' />
+              </Href>
+
+              <p className="u-color-p u-margin-Ts">No set up costs, no monthly fees, no hidden charges</p>
+            </div>
+          </div>
+        </div>
+      </Translation>
+    );
+  }
+}

--- a/app/pages/how-to/how-to.js
+++ b/app/pages/how-to/how-to.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import Page from '../../components/page/page';
+import Translation from '../../components/translation/translation';
+import HowToEn from './how-to.en';
+
+export default class HowTo extends React.Component {
+  displayName = 'HowTo'
+
+  render() {
+    return (
+      <div>
+        <Translation locales={['en']}>
+          <Page>
+            <HowToEn />
+          </Page>
+        </Translation>
+      </div>
+    );
+  }
+}

--- a/app/router/routes.js
+++ b/app/router/routes.js
@@ -6,6 +6,7 @@ import Pro from '../pages/pro/pro';
 import Features from '../pages/features/features';
 import Security from '../pages/security/security';
 import ContactSales from '../pages/contact-sales/contact-sales';
+import HowTo from '../pages/how-to/how-to';
 
 import PaymentsByDirectDebit from '../pages/payments-by-direct-debit/payments-by-direct-debit';
 import PaymentsByDirectDebitVariationB from '../pages/payments-by-direct-debit/payments-by-direct-debit-variation-b';
@@ -1443,6 +1444,12 @@ export const config = Immutable.fromJS([
   [StoriesHabitat, { name: 'stories_habitat', category: 'stories' }, {
       fr: {
         path: '/references/habitat',
+      },
+    },
+  ],
+  [HowTo, { name: 'how-to' }, {
+      'en-GB': {
+        path: '/how-to',
       },
     },
   ],

--- a/webpack/server.js
+++ b/webpack/server.js
@@ -6,7 +6,7 @@ import touch from 'touch';
 
 const devEnv = require('../config/dev-environment');
 
-const WEBPACK_HOST = process.env.HOST || 'localhost';
+const WEBPACK_HOST = process.env.HOST || '0.0.0.0';
 const WEBPACK_PORT = parseInt(process.env.PORT) || devEnv.webpackPort;
 
 const config = devConfig(WEBPACK_HOST, WEBPACK_PORT);


### PR DESCRIPTION
**Why?**
The How To page needed updating so that its content reflected the new dashboard. Sadly this page had not previously been moved over to the Splash Pages repo and still lived in an AWS bucket without any version control.

**How?**
We rebuilt the page in React — keeping the design from the previous page the same — and added the new videos which are hosted on Vimeo and embedded via an iframe.

**Other info**
The videos are not all the same dimensions. It is not completely obvious, but we will probably want to redo these at some point in the future. Next time round it will just be a case of uploading the new videos to Vimeo and updating the `how-to.en.js` file.

**Screens**
![how to gocardless](https://cloud.githubusercontent.com/assets/1385001/15566204/6c3a9056-2317-11e6-84e9-7ecd411389e8.jpg)