### PR TITLE
Add a press page to our splash pages

### DIFF
--- a/app/components/footer/footer.js
+++ b/app/components/footer/footer.js
@@ -106,6 +106,9 @@ class Footer extends React.Component {
               <IfLinkExists to='jobs' tagName='li'>
                 <Link to='jobs' pointer='jobs.nav_title' className='page-footer__link u-link-invert' />
               </IfLinkExists>
+              <IfLinkExists to='press' tagName='li'>
+                <Link to='press' pointer='press.nav_title' className='page-footer__link u-link-invert' />
+              </IfLinkExists>
             </ul>
           </div>
           <div className='grid__cell u-size-1of2'>

--- a/app/css/components/sticky-nav.scss
+++ b/app/css/components/sticky-nav.scss
@@ -50,5 +50,5 @@
   content: "";
   border-bottom: 6px solid $primary-color;
   position: relative;
-  top: 24px;
+  top: 22px;
 }

--- a/app/css/utils/color.scss
+++ b/app/css/utils/color.scss
@@ -4,6 +4,10 @@
   color: $dark-gray;
 }
 
+.u-color-medium-gray {
+  color: $medium-gray;
+}
+
 .u-color-invert {
   color: white;
 }

--- a/app/icons/svg/close-modal.js
+++ b/app/icons/svg/close-modal.js
@@ -25,4 +25,3 @@ export default class CloseModalIcon extends React.Component {
     );
   }
 }
-

--- a/app/icons/svg/phone.js
+++ b/app/icons/svg/phone.js
@@ -22,4 +22,3 @@ export default class PhoneIcon extends React.Component {
     );
   }
 }
-

--- a/app/messages/en.js
+++ b/app/messages/en.js
@@ -509,6 +509,11 @@ export default {
     description: '',
     nav_title: 'Team',
   },
+  press: {
+    title: 'Press',
+    description: '',
+    nav_title: 'Press',
+  },
   jobs: {
     title: 'Jobs',
     description: '',

--- a/app/pages/about/about-header.js
+++ b/app/pages/about/about-header.js
@@ -41,6 +41,11 @@ export default class AboutHeader extends React.Component {
                   <Message pointer='jobs.nav_title' />
                 </Link>
               </IfLinkExists>
+              <IfLinkExists to='press' tagName='li' className='sticky-nav__item'>
+                <Link to='press' className='sticky-nav__link'>
+                  <Message pointer='press.nav_title' />
+                </Link>
+              </IfLinkExists>
             </ul>
             <a href='https://gocardless.com/blog'
               className={

--- a/app/pages/about/about.en.js
+++ b/app/pages/about/about.en.js
@@ -53,7 +53,7 @@ export default class AboutEn extends React.Component {
               </p>
             </div>
             <div className='grid__cell u-size-1of3'>
-              <div className='u-margin-Txxl'>
+              <div className='u-margin-Tm'>
                 <img src='/images/press/publications-stacked.jpg' />
                 <p className='u-text-xs u-color-dark-gray u-margin-Txxl'>
                   For any press enquiries, please contact <a href='mailto:press@gocardless.com'>the GoCardless PR team</a>,

--- a/app/pages/about/press/press.js
+++ b/app/pages/about/press/press.js
@@ -1,0 +1,104 @@
+import React from 'react';
+import Page from '../../../components/page/page';
+import AboutHeader from '../about-header';
+
+let pressArticles = [
+  {
+    vendor: 'The Guardian',
+    title: 'Should UK fintech startups get into bed with the banks?',
+    link: 'https://www.theguardian.com/media-network/2015/jun/30/fintech-startups-incubators-banks',
+    date: '30.06.16',
+  },
+  {
+    vendor: 'VentureBeat',
+    title: 'U.K.entrepreneurs react to Brexit vote',
+    link: 'http://venturebeat.com/2016/06/24/u-k-entrepreneurs-react-to-brexit-vote/',
+    date: '24.06.16',
+  },
+  {
+    vendor: 'Business Insider',
+    title: '16 hot UK fintech startups that could one day be worth $1 billion',
+    link: 'uk.businessinsider.com/uk-fintech-startups-1-billion-unicorns-2016-5',
+    date: '08.06.16',
+  },
+  {
+    vendor: 'TechCrunch',
+    title: 'London fintech startup GoCardless raises $13M to bring recurring payments platform to more countries',
+    link: 'http://techcrunch.com/2016/03/23/go-get-funding/',
+    date: '23.03.16',
+  },
+  {
+    vendor: 'The Drum',
+    title: 'How to get clients to pay you faster',
+    link: 'http://www.thedrum.com/opinion/2016/03/09/how-get-clients-pay-you-faster',
+    date: '09.03.16',
+  },
+  {
+    vendor: 'The Telegraph',
+    title: 'Two-thirds of Europe’s young tech champions hail from UK',
+    link: 'www.telegraph.co.uk/finance/businessclub/technology/12107371/Two-thirds-of-Europes-young-tech-champions-hail-from-UK.html',
+    date: '19.01.16',
+  },
+  {
+    vendor: 'Payment Week',
+    date: '15.01.16',
+    title: 'Thomas Cook Partners with GoCardless to Offer Direct Debit and Installment Payment Option',
+    link: 'http://paymentweek.com/2016-1-15-thomas-cook-partners-with-gocardless-to-offer-direct-debit-and-installment-payment-option-9384/',
+  },
+  {
+    vendor: 'Forbes',
+    title: 'The Upward March Of Fin Tech - GoCardless Breaks The $1B Barrier',
+    link: 'www.forbes.com/sites/trevorclawson/2015/07/24/the-upward-march-of-fin-tech-gocardless-breaks-the-1bn-barrier/',
+    date: '24.07.15',
+  },
+  {
+    vendor: 'Wired',
+    title: 'How We Beat The Banks With Design',
+    link: 'http://www.wired.co.uk/article/gocardless-hiroki-takeuchi-wired-money-2015',
+    date: '8.07.15',
+  },
+  {
+    vendor: 'Tech.eu',
+    title: 'Inside GoCardless: Meet the quiet Londoners who want to help you get paid faster (and more)',
+    link: 'http://tech.eu/features/2699/gocardless-profile/',
+    date: '16.09.14',
+  },
+];
+
+export default class Press extends React.Component {
+  displayName = 'Press'
+
+  render() {
+    return (
+      <Page>
+        <AboutHeader />
+          <div className="site-container u-padding-Vxxl">
+            <div className='grid u-padding-Vxl'>
+              <div className='grid__cell u-size-1of4 u-padding-Rl'>
+                <div className="u-margin-Bxl">
+                  <h3 className="u-text-heading-light u-text-m u-color-dark-gray u-margin-Bs">Contact</h3>
+                  <p className="u-color-dark-gray">For any press enquiries, please contact the <a href="mailto:press@gocardless.com">GoCardless PR team</a>.</p>
+                </div>
+                <div>
+                  <h3 className="u-text-heading-light u-text-m u-color-dark-gray u-margin-Bs">Resources</h3>
+                  <p className="u-color-dark-gray">Download logos, photos and other resources <a href="https://www.dropbox.com/sh/4i9h27y8oaa3hcq/AABWlVX0T44UBFb4bh78Y5HVa?dl=0" target="_blank">here</a>.</p>
+                </div>
+              </div>
+              <div className='grid__cell u-size-3of4'>
+                <h2 className="u-text-heading u-color-dark-gray u-text-light u-margin-Bm">Articles</h2>
+                { pressArticles.map((pressArticle) => {
+                  return (
+                    <div className="press-article grid u-margin-Bm">
+                      <span className="grid__cell u-size-2of8 u-color-dark-gray">{ pressArticle.vendor }</span>
+                      <a href={ pressArticle.link } className="grid__cell u-size-5of8">{ pressArticle.title }</a>
+                      <span className="grid__cell u-size-1of8 u-color-medium-gray u-text-end">{ pressArticle.date }</span>
+                    </div>
+                  );
+                }) }
+              </div>
+            </div>
+          </div>
+      </Page>
+    );
+  }
+}

--- a/app/router/routes.js
+++ b/app/router/routes.js
@@ -28,6 +28,7 @@ import ExampleCheckout from '../pages/example-checkout/example-checkout';
 
 import About from '../pages/about/about';
 import Team from '../pages/about/team/team';
+import Press from '../pages/about/press/press';
 
 import Jobs from '../pages/about/jobs/jobs';
 import SoftwareEngineer from '../pages/about/jobs/positions/software-engineer';
@@ -425,6 +426,12 @@ export const config = Immutable.fromJS([
       },
       nl: {
         path: '/over-ons/team',
+      },
+    },
+  ],
+  [Press, { name: 'press' }, {
+      en: {
+        path: '/about/press',
       },
     },
   ],

--- a/config/redirects.json
+++ b/config/redirects.json
@@ -150,7 +150,7 @@
   "/partners/whmcs-details/index.html": "https://github.com/gocardless/gocardless-whmcs",
   "/paylinks/index.html": "/features/api",
   "/payment-timings/index.html": "https://help.gocardless.com/customer/portal/articles/1563666",
-  "/press/index.html": "/about",
+  "/press/index.html": "/about/press",
   "/privacy/index.html": "/legal/privacy",
   "/products/dashboard/index.html": "/features",
   "/products/index.html": "/features",


### PR DESCRIPTION
**What is it?**
Add a shiny new press page to our splash pages that shows all of the lovely articles about us and links to our press pack and contacts.

**To do**
- [x] Remove dummy press links
- [x] Add actual press links
- [ ] Hand over to marketing

![press gocardless](https://cloud.githubusercontent.com/assets/1385001/16555550/348aeb9a-41cd-11e6-94f1-5b83ab1e6d87.png)
