### PR TITLE
Update example checkout to v2

### DIFF
--- a/app/pages/example-checkout/example-checkout.js
+++ b/app/pages/example-checkout/example-checkout.js
@@ -44,35 +44,35 @@ export default class ExampleCheckout extends React.Component {
             </div>
             <div className='grid__cell u-size-1of3 u-text-center'>
               <div className='u-text-heading u-color-dark-gray u-text-center u-text-m u-text-light u-text-no-smoothing'>
-                One off example
+                Subscriptions
               </div>
               <p className='u-text-center u-color-dark-gray u-margin-Txxs u-size-3of5 u-center'>
-                Demo of a single, one-off payment of £2.99
+                Authorise payments and collect £9.99/month
               </p>
-              <form acceptCharset='UTF-8' action='/api/v1/example_checkout/one_off' method='post' className='ng-pristine ng-valid'>
-                <input className='btn btn--hollow u-margin-Tm' name='commit' type='submit' defaultValue='View Example' />
+              <form acceptCharset='UTF-8' action='https://pay-sandbox.gocardless.com/AL00002GSZ5XBA' method='get' className='ng-pristine ng-valid'>
+                <input className='btn btn--hollow u-margin-Tm' type='submit' formTarget='_blank' defaultValue='View Example' />
               </form>
             </div>
             <div className='grid__cell u-size-1of3 u-text-center'>
               <div className='u-text-heading u-color-dark-gray u-text-center u-text-m u-text-light u-text-no-smoothing'>
-                Recurring example
+                Variable payments
               </div>
               <p className='u-text-center u-color-dark-gray u-margin-Txxs u-size-3of5 u-center'>
-                Demo of £99 each month, with no end date
+                Authorise payments to be collected later
               </p>
-              <form acceptCharset='UTF-8' action='/api/v1/example_checkout/subscription' method='post' className='ng-pristine ng-valid'>
-                <input className='btn btn--hollow u-margin-Tm' name='commit' type='submit' defaultValue='View Example' />
+              <form acceptCharset='UTF-8' action='https://pay-sandbox.gocardless.com/AL00002GSXVVTN' method='get' className='ng-pristine ng-valid'>
+                <input className='btn btn--hollow u-margin-Tm' type='submit' formTarget='_blank' defaultValue='View Example' />
               </form>
             </div>
             <div className='grid__cell u-size-1of3 u-text-center'>
               <div className='u-text-heading u-color-dark-gray u-text-center u-text-m u-text-light u-text-no-smoothing'>
-                Variable example
+                One-off payments
               </div>
               <p className='u-text-center u-color-dark-gray u-margin-Txxs u-size-3of5 u-center'>
-                Pre-authorise future payments of any amount
+                Authorise payments and collect a one-off £2.99
               </p>
-              <form acceptCharset='UTF-8' action='/api/v1/example_checkout/pre_auth' method='post' className='ng-pristine ng-valid'>
-                <input className='btn btn--hollow u-margin-Tm' name='commit' type='submit' defaultValue='View Example' />
+              <form acceptCharset='UTF-8' action='https://pay-sandbox.gocardless.com/AL00002GSY7TAM' method='get' className='ng-pristine ng-valid'>
+                <input className='btn btn--hollow u-margin-Tm' type='submit' formTarget='_blank' defaultValue='View Example' />
               </form>
             </div>
           </div>


### PR DESCRIPTION
https://gocardless.myjetbrains.com/youtrack/issue/UXT-22

Current links to checkout demo pages open the v1 payment pages. This change updates the link order (subscriptions first, as this is the most relevant one), and opens the *new* payment pages in a new window on click.

Note: The old payment links opened pre-filled forms (ie. with account number & sort code). With the new payment pages this is not possible anymore. We might need to reconsider how we can improve the whole checkout demo.

### Checkout example links
![screen shot 2016-07-07 at 11 43 27](https://cloud.githubusercontent.com/assets/1154924/16650848/30279f5e-4438-11e6-8025-2a160530bb5b.png)

### Subscription example
![screen shot 2016-07-07 at 11 44 08](https://cloud.githubusercontent.com/assets/1154924/16650855/36571be8-4438-11e6-90b3-626d761256fa.png)