### PR TITLE
Adding locale-specific job listings to DE, FR & ES sites

### DIFF
--- a/app/messages/de.js
+++ b/app/messages/de.js
@@ -129,9 +129,9 @@ export default {
     nav_title: 'Team',
   },
   jobs: {
-    title: 'Karrieren',
+    title: 'Jobs',
     description: '',
-    nav_title: 'Karrieren',
+    nav_title: 'Jobs',
     open_positions: 'Offene Stellen',
     engineering: {
       title: 'Software Engineering & Data Science',

--- a/app/messages/de.js
+++ b/app/messages/de.js
@@ -129,9 +129,9 @@ export default {
     nav_title: 'Team',
   },
   jobs: {
-    title: 'Jobs',
+    title: 'Karrieren',
     description: '',
-    nav_title: 'Jobs',
+    nav_title: 'Karrieren',
     open_positions: 'Offene Stellen',
     engineering: {
       title: 'Software Engineering & Data Science',
@@ -182,6 +182,10 @@ export default {
   },
   jobs_customer_support: {
     title: 'Customer Support',
+    description: '',
+  },
+  jobs_sales_development_representative_germany: {
+    title: 'SDR: Germany',
     description: '',
   },
   api_docs: {

--- a/app/messages/es.js
+++ b/app/messages/es.js
@@ -290,6 +290,30 @@ export default {
     time_saved: 'Tiempo ahorrado usando GoCardless',
     start_journey: 'Comienza ahora tu historia con GoCardless',
   },
+  jobs: {
+    title: 'Empleo',
+    description: '',
+    nav_title: 'Empleo',
+    open_positions: 'Open positions',
+    engineering: {
+      title: 'Software Engineering & Data Science',
+    },
+    ux_design: {
+      title: 'UX & Design',
+    },
+    sales: {
+      title: 'Sales',
+    },
+    business_development: {
+      title: 'Business Development',
+    },
+    marketing: {
+      title: 'Marketing',
+    },
+    operations: {
+      title: 'Operations',
+    },
+  },
   stories_impact_hub: {
     title: 'Impact Hub - Casos de éxito',
     description: '',
@@ -324,6 +348,10 @@ export default {
   legal_restrictions: {
     title: 'Términos y Condiciones - Restricciones',
     nav_title: 'Actividades Restringidas',
+    description: '',
+  },
+  jobs_inside_account_executive_spain: {
+    title: 'Account Executive, Inside Sales: Spain',
     description: '',
   },
 };

--- a/app/messages/fr.js
+++ b/app/messages/fr.js
@@ -255,6 +255,14 @@ export default {
       title: 'Opérations',
     },
   },
+  jobs_head_of_sales_france: {
+    title: 'Head of Sales: France',
+    description: '',
+  },
+  jobs_customer_support_france: {
+    title: 'Customer Support: France',
+    description: '',
+  },
   pro: {
     title: 'Le contrôle total de vos prélèvements',
     nav_title: 'GoCardless Pro',

--- a/app/pages/about/jobs/jobs-page.js
+++ b/app/pages/about/jobs/jobs-page.js
@@ -2,6 +2,7 @@ import React from 'react';
 import rest from 'lodash/array/rest';
 import { filterRouteByCategory } from '../../../router/route-helpers';
 import Message from '../../../components/message/message';
+import Translation from '../../../components/translation/translation';
 import Link from '../../../components/link/link';
 import IfLinkExists from '../../../components/if-link-exists/if-link-exists';
 import AboutHeader from '../about-header';
@@ -60,6 +61,14 @@ export default class JobsPage extends React.Component {
                 <ul className='nav nav-tabs u-margin-Ts'>
                   { jobsNav }
                 </ul>
+
+                <Translation locales={['es', 'de', 'fr']}>
+                  <a href='https://gocardless.com/about/jobs'
+                  className='u-margin-Tl u-inline-block u-text-upcase
+                  u-text-xxs u-text-semi'>
+                    View all our open positions
+                  </a>
+                </Translation>
               </div>
               <div className='grid__cell u-size-2of3 u-padding-Tl u-padding-Ll'>
                 {this.props.children}
@@ -84,22 +93,24 @@ export default class JobsPage extends React.Component {
           </div>
         </div>
 
-        <IfLinkExists to='team'>
-          <div className='u-text-center u-padding-Vxxl'>
-            <div className='site-container u-padding-Vxl'>
-              <div className='u-size-2of3 u-center'>
-                <h2 className='u-text-heading u-color-dark-gray u-text-light u-text-l'>
-                  Find out more about working at GoCardless
-                </h2>
+        <Translation locales='en'>
+          <IfLinkExists to='team'>
+            <div className='u-text-center u-padding-Vxxl'>
+              <div className='site-container u-padding-Vxl'>
+                <div className='u-size-2of3 u-center'>
+                  <h2 className='u-text-heading u-color-dark-gray u-text-light u-text-l'>
+                    Find out more about working at GoCardless
+                  </h2>
 
-                <Link to='team'
-                className='btn btn--hollow u-margin-Tm'>
-                  Visit our team page
-                </Link>
+                  <Link to='team'
+                  className='btn btn--hollow u-margin-Tm'>
+                    Visit our team page
+                  </Link>
+                </div>
               </div>
             </div>
-          </div>
-        </IfLinkExists>
+          </IfLinkExists>
+        </Translation>
       </Page>
     );
   }

--- a/app/router/routes.js
+++ b/app/router/routes.js
@@ -439,7 +439,7 @@ export const config = Immutable.fromJS([
         path: '/about/jobs',
       },
       de: {
-        path: '/ueber-uns/karrieren',
+        path: '/ueber-uns/jobs',
       },
       es: {
         path: '/sobre-nosotros/empleo',
@@ -514,7 +514,7 @@ export const config = Immutable.fromJS([
         path: '/about/jobs/sales-development-representative-germany',
       },
       de: {
-        path: '/ueber-uns/karrieren/sales-development-representative-germany',
+        path: '/ueber-uns/jobs/sales-development-representative-germany',
       },
     },
   ],

--- a/app/router/routes.js
+++ b/app/router/routes.js
@@ -438,6 +438,15 @@ export const config = Immutable.fromJS([
       en: {
         path: '/about/jobs',
       },
+      de: {
+        path: '/ueber-uns/karrieren',
+      },
+      es: {
+        path: '/sobre-nosotros/empleo',
+      },
+      fr: {
+        path: '/a-propos/recrutement',
+      },
     },
   ],
   [DataEngineer, { name: 'jobs_data_engineer', category: 'jobs.engineering' }, {
@@ -486,17 +495,26 @@ export const config = Immutable.fromJS([
       en: {
         path: '/about/jobs/inside-account-executive-spain',
       },
+      es: {
+        path: '/sobre-nosotros/empleo/inside-account-executive-spain',
+      },
     },
   ],
   [HeadofSalesFrance, { name: 'jobs_head_of_sales_france', category: 'jobs.sales' }, {
       en: {
         path: '/about/jobs/head-of-sales-france',
       },
+      fr: {
+        path: '/a-propos/recrutement/head-of-sales-france',
+      },
     },
   ],
   [SalesDevelopmentRepresentativeGermany, { name: 'jobs_sales_development_representative_germany', category: 'jobs.sales' }, {
       en: {
         path: '/about/jobs/sales-development-representative-germany',
+      },
+      de: {
+        path: '/ueber-uns/karrieren/sales-development-representative-germany',
       },
     },
   ],
@@ -533,6 +551,9 @@ export const config = Immutable.fromJS([
   [CustomerSupportFrance, { name: 'jobs_customer_support_france', category: 'jobs.operations' }, {
       en: {
         path: '/about/jobs/customer-support-france',
+      },
+      fr: {
+        path: '/a-propos/recrutement/customer-support-france',
       },
     },
   ],


### PR DESCRIPTION
Making locale-specific positions available on their respective sites, eg:

![image](https://cloud.githubusercontent.com/assets/883598/19153092/ef74f1b4-8bcc-11e6-81bc-a331375d04dc.png)

Includes link to our main UK jobs page if applicants are interested in seeing all available jobs.

In English to encourage applicants who are comfortable speaking English, as requested — however we should still aim for the other strings eg the equivalent of 'Jobs' in FR, DE & ES, so will follow up with some requests for help with that before merging.
