### PR TITLE
Remove contact details from en-GB site footer in place of Contact Sales & Help Centre links

### DIFF
--- a/app/components/footer/footer.js
+++ b/app/components/footer/footer.js
@@ -127,10 +127,27 @@ class Footer extends React.Component {
                     <Message pointer='postal_address.address_country' />
                   </SchemaItemProp>.
                 </SchemaItemProp><br />
-                <SchemaItemProp itemProp='telephone' pointer='phone_full'>
-                  <Message pointer='phone_local' />
-                </SchemaItemProp>,&nbsp;
-                <Href to='email' className='u-link-invert' itemProp='email' />
+
+                <Translation locales={availableLocales} exclude={['en-GB']}>
+                  <SchemaItemProp itemProp='telephone' pointer='phone_full'>
+                    <Message pointer='phone_local' />
+                  </SchemaItemProp>,&nbsp;
+
+                  <Href to='email' className='u-link-invert' itemProp='email' />
+                </Translation>
+
+                <Translation locales='en-GB'
+                className='u-padding-Tm u-inline-block'>
+                  <Link to='contact_sales'
+                  className='u-link-invert u-text-heavy u-margin-Rs'>
+                    Contact Sales
+                  </Link>
+
+                  <a href='https://support.gocardless.com/hc/en-us'
+                  className='u-link-invert u-text-heavy'>
+                    Visit our Support Centre
+                  </a>
+                </Translation>
               </p>
               <p className='u-text-heading u-text-xxs u-color-invert u-margin-Bm'>
                 <Message pointer='footer.description' />


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/883598/19270231/dce02760-8fb6-11e6-9bce-95143a98c4a5.png)
