### PR TITLE
Always use ?s= parameter when linking to contact_sales route

### DIFF
--- a/app/components/link/link.js
+++ b/app/components/link/link.js
@@ -1,3 +1,4 @@
+import assign from 'lodash/object/assign';
 import React, { PropTypes, Component } from 'react';
 import Message from '../message/message';
 import Router from 'react-router';
@@ -17,9 +18,19 @@ export default class Link extends Component {
     onClick: PropTypes.func,
   }
 
+  static contextTypes = {
+    routeName: PropTypes.string.isRequired,
+  }
+
   render() {
+    const { routeName } = this.context;
+    const props = assign({}, this.props);
+    if (props.to === 'contact_sales') {
+      props.query = { s: routeName };
+    }
+
     return (
-      <RouterLink {...this.props} activeClassName='is-active'>
+      <RouterLink {...props} activeClassName='is-active'>
         { this.props.pointer &&
           (<Message pointer={this.props.pointer} />) || this.props.children }
       </RouterLink>

--- a/app/pages/partners/partners.de.js
+++ b/app/pages/partners/partners.de.js
@@ -58,8 +58,7 @@ export default class PartnersDe extends React.Component {
                 </a>
               </li>
             </ul>
-            <Link to='contact_sales' query={{ s: 'partners' }}
-            id='track-partners-sticky-nav-contact-sales'
+            <Link to='contact_sales'
             className={
               'sticky-nav__cta btn btn--small btn--hollow u-pull-end ' +
               'u-text-transform-none u-text-light u-text-xxs u-text-no-smoothing'
@@ -149,8 +148,6 @@ export default class PartnersDe extends React.Component {
                   <br/> Nur 1 % pro erfolgreicher Transaktion und höchstens <Message pointer="pricing.cost_cap" />.
                 </p>
                 <Link to='contact_sales'
-                query={{ s: 'partners' }}
-                id='track-partners-find-out-more'
                 className='btn btn--hollow u-margin-Ts'>
                   Erfahren Sie mehr
                 </Link>
@@ -418,8 +415,6 @@ export default class PartnersDe extends React.Component {
                 kontaktieren Sie uns – wir beraten Sie gerne.
               </p>
               <Link to='contact_sales'
-              query={{ s: 'partners' }}
-              id='track-partners-contact-sales'
               className='btn btn--hollow u-margin-Ts'>
                 <Message pointer='cta.pro' />
               </Link>

--- a/app/pages/partners/partners.en.js
+++ b/app/pages/partners/partners.en.js
@@ -64,8 +64,7 @@ export default class PartnersEn extends React.Component {
                 </a>
               </li>
             </ul>
-            <Link to='contact_sales' query={{ s: 'partners' }}
-            id='track-partners-sticky-nav-contact-sales'
+            <Link to='contact_sales'
             className={
               'sticky-nav__cta btn btn--small btn--hollow u-pull-end ' +
               'u-text-transform-none u-text-light u-text-xxs u-text-no-smoothing'
@@ -159,8 +158,6 @@ export default class PartnersEn extends React.Component {
                   </p>
                 </Translation>
                 <Link to='contact_sales'
-                query={{ s: 'partners' }}
-                id='track-partners-find-out-more'
                 className='btn btn--hollow u-margin-Ts'>
                   Find out more
                 </Link>
@@ -421,10 +418,7 @@ export default class PartnersEn extends React.Component {
                 If you think that your business can benefit from partnering with GoCardless,
                 <br />please get in touch – we’ll be happy to help.
               </p>
-              <Link to='contact_sales'
-              query={{ s: 'partners' }}
-              id='track-partners-contact-sales'
-              className='btn btn--hollow u-margin-Ts'>
+              <Link to='contact_sales' className='btn btn--hollow u-margin-Ts'>
                 <Message pointer='cta.pro' />
               </Link>
             </div>

--- a/app/pages/partners/partners.es.js
+++ b/app/pages/partners/partners.es.js
@@ -57,8 +57,7 @@ export default class PartnersEs extends React.Component {
                 </a>
               </li>
             </ul>
-            <Link to='contact_sales' query={{ s: 'partners' }}
-            id='track-partners-sticky-nav-contact-sales'
+            <Link to='contact_sales'
             className={
               'sticky-nav__cta btn btn--small btn--hollow u-pull-end ' +
               'u-text-transform-none u-text-light u-text-xxs u-text-no-smoothing'
@@ -148,8 +147,6 @@ export default class PartnersEs extends React.Component {
                   de <Message pointer="pricing.cost_cap" />.
                 </p>
                 <Link to='contact_sales'
-                query={{ s: 'partners' }}
-                id='track-partners-find-out-more'
                 className='btn btn--hollow u-margin-Ts'>
                   Saber más
                 </Link>
@@ -417,8 +414,6 @@ export default class PartnersEs extends React.Component {
                 <br />por favor ponte en contacto con nosotros – estaremos encantados de ayudar.
               </p>
               <Link to='contact_sales'
-              query={{ s: 'partners' }}
-              id='track-partners-contact-sales'
               className='btn btn--hollow u-margin-Ts'>
                 <Message pointer='cta.pro' />
               </Link>

--- a/app/pages/partners/partners.fr.js
+++ b/app/pages/partners/partners.fr.js
@@ -57,8 +57,7 @@ export default class PartnersFr extends React.Component {
                 </a>
               </li>
             </ul>
-            <Link to='contact_sales' query={{ s: 'partners' }}
-            id='track-partners-sticky-nav-contact-sales'
+            <Link to='contact_sales'
             className={
               'sticky-nav__cta btn btn--small btn--hollow u-pull-end ' +
               'u-text-transform-none u-text-light u-text-xxs u-text-no-smoothing'
@@ -146,10 +145,7 @@ export default class PartnersFr extends React.Component {
                   Pas de frais de mise en place, mensuels, de mandat, de rejet... <br/>Seulement 1% par transaction réussie,
                   plafonné à <Message pointer="pricing.cost_cap" /> par transaction.
                 </p>
-                <Link to='contact_sales'
-                query={{ s: 'partners' }}
-                id='track-partners-find-out-more'
-                className='btn btn--hollow u-margin-Ts'>
+                <Link to='contact_sales' className='btn btn--hollow u-margin-Ts'>
                   Apprenez-en plus
                 </Link>
               </div>
@@ -416,10 +412,7 @@ export default class PartnersFr extends React.Component {
                 Si vous pensez que votre entreprise peut bénéficier d'un partenariat avec GoCardless,
                 <br />contactez-nous - nous serons ravis de vous aider.
               </p>
-              <Link to='contact_sales'
-              query={{ s: 'partners' }}
-              id='track-partners-contact-sales'
-              className='btn btn--hollow u-margin-Ts'>
+              <Link to='contact_sales' className='btn btn--hollow u-margin-Ts'>
                 <Message pointer='cta.pro' />
               </Link>
             </div>

--- a/app/pages/partners/partners.nl.js
+++ b/app/pages/partners/partners.nl.js
@@ -57,8 +57,7 @@ export default class PartnersNl extends React.Component {
                 </a>
               </li>
             </ul>
-            <Link to='contact_sales' query={{ s: 'partners' }}
-            id='track-partners-sticky-nav-contact-sales'
+            <Link to='contact_sales'
             className={
               'sticky-nav__cta btn btn--small btn--hollow u-pull-end ' +
               'u-text-transform-none u-text-light u-text-xxs u-text-no-smoothing'
@@ -149,10 +148,7 @@ export default class PartnersNl extends React.Component {
                   Geen opstartkosten of verborgen kosten.
                   <br/> Slechts 1% per succesvolle transactie met een maximum van <Message pointer="pricing.cost_cap" />.
                 </p>
-                <Link to='contact_sales'
-                query={{ s: 'partners' }}
-                id='track-partners-find-out-more'
-                className='btn btn--hollow u-margin-Ts'>
+                <Link to='contact_sales' className='btn btn--hollow u-margin-Ts'>
                   Meer weten
                 </Link>
               </div>
@@ -426,10 +422,7 @@ export default class PartnersNl extends React.Component {
               <p className='u-text-xs u-color-dark-gray u-margin-Vxs'>
                 Kan jouw bedrijf profiteren van een samenwerking met GoCardless? Neem dan contact met ons op. We helpen je graag verder.
               </p>
-              <Link to='contact_sales'
-              query={{ s: 'partners' }}
-              id='track-partners-contact-sales'
-              className='btn btn--hollow u-margin-Ts'>
+              <Link to='contact_sales' className='btn btn--hollow u-margin-Ts'>
                 <Message pointer='cta.pro' />
               </Link>
             </div>

--- a/app/pages/pricing/pricing.de.js
+++ b/app/pages/pricing/pricing.de.js
@@ -67,7 +67,7 @@ export default class PricingDe extends React.Component {
                       </IfLocale>
 
                       <IfLocale hasInstantSignup={false}>
-                        <Link to='contact_sales' query={{ s: 'pricing' }} className='btn btn--hollow u-size-full'>Fragen Sie uns</Link>
+                        <Link to='contact_sales' className='btn btn--hollow u-size-full'>Fragen Sie uns</Link>
                       </IfLocale>
                     </div>
                   </div>
@@ -108,7 +108,7 @@ export default class PricingDe extends React.Component {
                         </p>
                       </div>
 
-                      <Link to='contact_sales' query={{ s: 'pricing' }} className='btn btn--hollow u-size-full'>Fragen Sie uns</Link>
+                      <Link to='contact_sales' className='btn btn--hollow u-size-full'>Fragen Sie uns</Link>
                     </div>
                   </div>
               </div>
@@ -148,7 +148,7 @@ export default class PricingDe extends React.Component {
                         </p>
                       </div>
 
-                      <Link to='contact_sales' query={{ s: 'pricing' }} className='btn btn--hollow u-size-full'>Fragen Sie uns</Link>
+                      <Link to='contact_sales' className='btn btn--hollow u-size-full'>Fragen Sie uns</Link>
                     </div>
                   </div>
               </div>
@@ -210,7 +210,7 @@ export default class PricingDe extends React.Component {
           <div className='u-padding-Vxl'>
             <h2 className='u-text-heading u-text-l u-color-dark-gray u-text-light'>Haben Sie Fragen?</h2>
             <p className='u-color-dark-gray u-margin-Ts'>Sprechen Sie mit einem unserer Zahlungsexperten: <Message pointer='phone_local' /></p>
-            <Link to='contact_sales' query={{ s: 'pricing' }} className='btn btn--hollow u-margin-Tm'>Kontakt</Link>
+            <Link to='contact_sales' className='btn btn--hollow u-margin-Tm'>Kontakt</Link>
           </div>
         </div>
       </Translation>

--- a/app/pages/pricing/pricing.en.js
+++ b/app/pages/pricing/pricing.en.js
@@ -77,7 +77,7 @@ export default class PricingEn extends React.Component {
                           <Href to='signup.path' className='btn u-size-full'>Sign up today</Href>
                         </IfLocale>
                         <IfLocale hasInstantSignup={false}>
-                          <Link to='contact_sales' query={{ s: 'pricing' }} className='btn u-size-full'>Contact sales</Link>
+                          <Link to='contact_sales' className='btn u-size-full'>Contact sales</Link>
                         </IfLocale>
                       </div>
                     </div>
@@ -122,7 +122,7 @@ export default class PricingEn extends React.Component {
                           Per transaction, plus <Message pointer='pricing.pro_monthly_fee' /> a month
                         </p>
                       </div>
-                      <Link to='contact_sales' query={{ s: 'pricing' }} className='btn btn--hollow u-size-full'>Contact sales</Link>
+                      <Link to='contact_sales' className='btn btn--hollow u-size-full'>Contact sales</Link>
                     </div>
                   </div>
                 </div>
@@ -177,7 +177,7 @@ export default class PricingEn extends React.Component {
                         <Href to='signup.path' className='btn u-size-full'>Sign up today</Href>
                       </IfLocale>
                       <IfLocale hasInstantSignup={false}>
-                        <Link to='contact_sales' query={{ s: 'pricing' }} className='btn u-size-full'>Contact sales</Link>
+                        <Link to='contact_sales' className='btn u-size-full'>Contact sales</Link>
                       </IfLocale>
                     </div>
                   </div>
@@ -213,7 +213,7 @@ export default class PricingEn extends React.Component {
                           Per transaction, plus <strong>100 €</strong> a month
                         </p>
                       </div>
-                      <Link to='contact_sales' query={{ s: 'pricing' }} className='btn btn--hollow u-size-full'>Contact sales</Link>
+                      <Link to='contact_sales' className='btn btn--hollow u-size-full'>Contact sales</Link>
                     </div>
                   </div>
                 </div>
@@ -248,7 +248,7 @@ export default class PricingEn extends React.Component {
                           Per transaction, plus <strong>250 €</strong> a month
                         </p>
                       </div>
-                      <Link to='contact_sales' query={{ s: 'pricing' }} className='btn btn--hollow u-size-full'>Contact sales</Link>
+                      <Link to='contact_sales' className='btn btn--hollow u-size-full'>Contact sales</Link>
                     </div>
                   </div>
                 </div>
@@ -338,7 +338,7 @@ export default class PricingEn extends React.Component {
               <Href to='signup.path' className='btn btn--hollow u-margin-Tm'>Start taking payments</Href>
             </IfLocale>
             <IfLocale hasInstantSignup={false}>
-              <Link to='contact_sales' query={{ s: 'pricing' }} className='btn btn--hollow u-margin-Tm'>Contact sales</Link>
+              <Link to='contact_sales' className='btn btn--hollow u-margin-Tm'>Contact sales</Link>
             </IfLocale>
           </div>
         </div>

--- a/app/pages/pricing/pricing.es.js
+++ b/app/pages/pricing/pricing.es.js
@@ -67,7 +67,7 @@ export default class PricingEs extends React.Component {
                       </IfLocale>
 
                       <IfLocale hasInstantSignup={false}>
-                        <Link to='contact_sales' query={{ s: 'pricing' }} className='btn btn--hollow u-size-full'>Contacta con nosotros</Link>
+                        <Link to='contact_sales' className='btn btn--hollow u-size-full'>Contacta con nosotros</Link>
                       </IfLocale>
                     </div>
                   </div>
@@ -108,7 +108,7 @@ export default class PricingEs extends React.Component {
                         </p>
                       </div>
 
-                      <Link to='contact_sales' query={{ s: 'pricing' }} className='btn btn--hollow u-size-full'>Contacta con nosotros</Link>
+                      <Link to='contact_sales' className='btn btn--hollow u-size-full'>Contacta con nosotros</Link>
                     </div>
                   </div>
               </div>
@@ -149,7 +149,7 @@ export default class PricingEs extends React.Component {
                         </p>
                       </div>
 
-                      <Link to='contact_sales' query={{ s: 'pricing' }} className='btn btn--hollow u-size-full'>Contacta con nosotros</Link>
+                      <Link to='contact_sales' className='btn btn--hollow u-size-full'>Contacta con nosotros</Link>
                     </div>
                   </div>
               </div>
@@ -234,7 +234,7 @@ export default class PricingEs extends React.Component {
             </IfLocale>
 
             <IfLocale hasInstantSignup={false}>
-              <Link to='contact_sales' query={{ s: 'pricing' }} className='btn btn--hollow u-margin-Tm'>Contacta con nosotros</Link>
+              <Link to='contact_sales' className='btn btn--hollow u-margin-Tm'>Contacta con nosotros</Link>
             </IfLocale>
           </div>
         </div>

--- a/app/pages/pricing/pricing.fr.js
+++ b/app/pages/pricing/pricing.fr.js
@@ -67,7 +67,7 @@ export default class PricingFr extends React.Component {
                       </IfLocale>
 
                       <IfLocale hasInstantSignup={false}>
-                        <Link to='contact_sales' query={{ s: 'pricing' }} className='btn btn--hollow u-size-full'>Contactez-nous</Link>
+                        <Link to='contact_sales' className='btn btn--hollow u-size-full'>Contactez-nous</Link>
                       </IfLocale>
                     </div>
                   </div>
@@ -108,7 +108,7 @@ export default class PricingFr extends React.Component {
                         </p>
                       </div>
 
-                      <Link to='contact_sales' query={{ s: 'pricing' }} className='btn btn--hollow u-size-full'>Contactez-nous</Link>
+                      <Link to='contact_sales' className='btn btn--hollow u-size-full'>Contactez-nous</Link>
                     </div>
                   </div>
               </div>
@@ -148,7 +148,7 @@ export default class PricingFr extends React.Component {
                         </p>
                       </div>
 
-                      <Link to='contact_sales' query={{ s: 'pricing' }} className='btn btn--hollow u-size-full'>Contactez-nous</Link>
+                      <Link to='contact_sales' className='btn btn--hollow u-size-full'>Contactez-nous</Link>
                     </div>
                   </div>
               </div>
@@ -220,7 +220,7 @@ export default class PricingFr extends React.Component {
                   </Href>
                 </IfLocale>
                 <IfLocale hasInstantSignup={false}>
-                  <Link to='contact_sales' query={{ s: 'pricing' }} className='btn btn--hollow u-margin-Tm'>Contactez-nous</Link>
+                  <Link to='contact_sales' className='btn btn--hollow u-margin-Tm'>Contactez-nous</Link>
                 </IfLocale>
               </div>
             </div>

--- a/app/pages/pricing/pricing.nl.js
+++ b/app/pages/pricing/pricing.nl.js
@@ -52,7 +52,7 @@ export default class PricingNl extends React.Component {
                         <Href to='signup.path' className='btn u-size-full'>Registreer nu</Href>
                       </IfLocale>
                       <IfLocale hasInstantSignup={false}>
-                        <Link to='contact_sales' query={{ s: 'pricing' }} className='btn u-size-full'>Neem contact op</Link>
+                        <Link to='contact_sales' className='btn u-size-full'>Neem contact op</Link>
                       </IfLocale>
                     </li>
                   </ul>
@@ -83,7 +83,7 @@ export default class PricingNl extends React.Component {
                     <Link to='pro'>Meer over GoCardless Pro</Link>
                   </li>
                   <li className='pricing-options__list-button'>
-                    <Link to='contact_sales' query={{ s: 'pricing' }} className='btn btn--hollow u-size-full'>Neem contact op</Link>
+                    <Link to='contact_sales' className='btn btn--hollow u-size-full'>Neem contact op</Link>
                   </li>
                 </ul>
               </div>
@@ -172,7 +172,7 @@ export default class PricingNl extends React.Component {
               <Href to='signup.path' className='btn btn--hollow u-margin-Tm'>Registreer nu</Href>
             </IfLocale>
             <IfLocale hasInstantSignup={false}>
-              <Link to='contact_sales' query={{ s: 'pricing' }} className='btn btn--hollow u-margin-Tm'>Neem contact op</Link>
+              <Link to='contact_sales' className='btn btn--hollow u-margin-Tm'>Neem contact op</Link>
             </IfLocale>
           </div>
         </div>

--- a/app/pages/pro/pro.de.js
+++ b/app/pages/pro/pro.de.js
@@ -49,8 +49,7 @@ export default class ProDe extends React.Component {
                   </a>
                 </li>
               </ul>
-              <Link to='contact_sales' query={{ s: 'pro' }}
-              id='track-sticky-nav-contact-sales'
+              <Link to='contact_sales'
               className={
                 'sticky-nav__cta btn btn--small btn--hollow u-pull-end ' +
                 'u-text-transform-none u-text-light u-text-xxs u-text-no-smoothing'
@@ -202,7 +201,7 @@ export default class ProDe extends React.Component {
                       Sprechen Sie mit einem unserer Zahlungsexperten, um herauszufinden, wie GoCardless Ihnen helfen kann.
                     </p>
                   </div>
-                  <Link to='contact_sales' query={{ s: 'pro' }} id='track-cta-contact-sales'
+                  <Link to='contact_sales'
                   className='btn btn--hollow u-margin-Tm'>
                     <Message pointer='cta.pro' />
                   </Link>
@@ -280,8 +279,7 @@ export default class ProDe extends React.Component {
                 <h2 className='u-text-heading u-color-dark-gray u-text-light u-text-l u-margin-Bm'>
                   Kontaktieren Sie uns für ein kostenloses Angebot
                 </h2>
-                <Link to='contact_sales' query={{ s: 'pro' }}
-                id='track-cta-contact-sales' className='btn u-margin-Rm'>
+                <Link to='contact_sales' className='btn u-margin-Rm'>
                   <Message pointer='cta.pro' />
                 </Link>
                 <a href='https://manage-sandbox.gocardless.com/signup'

--- a/app/pages/pro/pro.en.js
+++ b/app/pages/pro/pro.en.js
@@ -43,8 +43,7 @@ export default class ProEn extends React.Component {
                   </a>
                 </li>
               </ul>
-              <Link to='contact_sales' query={{ s: 'pro' }}
-              id='track-sticky-nav-contact-sales'
+              <Link to='contact_sales'
               className={
                 'sticky-nav__cta btn btn--small btn--hollow u-pull-end ' +
                 'u-text-transform-none u-text-light u-text-xxs u-text-no-smoothing'
@@ -194,8 +193,7 @@ export default class ProEn extends React.Component {
                       Speak with one of our payments experts to learn how GoCardless can help your business.
                     </p>
                   </div>
-                  <Link to='contact_sales' query={{ s: 'pro' }} id='track-cta-contact-sales'
-                  className='btn btn--hollow u-margin-Tm'>
+                  <Link to='contact_sales' className='btn btn--hollow u-margin-Tm'>
                     <Message pointer='cta.pro' />
                   </Link>
                 </div>
@@ -273,8 +271,7 @@ export default class ProEn extends React.Component {
                 <h2 className='u-text-heading u-color-dark-gray u-text-light u-text-l u-margin-Bm'>
                   Get in touch for a free quote
                 </h2>
-                <Link to='contact_sales' query={{ s: 'pro' }}
-                id='track-cta-contact-sales' className='btn u-margin-Rm'>
+                <Link to='contact_sales' className='btn u-margin-Rm'>
                   <Message pointer='cta.pro' />
                 </Link>
                 <a href='https://manage-sandbox.gocardless.com/signup'

--- a/app/pages/pro/pro.es.js
+++ b/app/pages/pro/pro.es.js
@@ -51,8 +51,7 @@ export default class ProEs extends React.Component {
                   </a>
                 </li>
               </ul>
-              <Link to='contact_sales' query={{ s: 'pro' }}
-              id='track-sticky-nav-contact-sales'
+              <Link to='contact_sales'
               className={
                 'sticky-nav__cta btn btn--small btn--hollow u-pull-end ' +
                 'u-text-transform-none u-text-light u-text-xxs u-text-no-smoothing'
@@ -211,8 +210,7 @@ export default class ProEs extends React.Component {
                       Habla con uno de nuestros expertos en Cobros y descubre como GoCardless puede ayudar a tu negocio.
                     </p>
                   </div>
-                  <Link to='contact_sales' query={{ s: 'pro' }} id='track-cta-contact-sales'
-                  className='btn btn--hollow u-margin-Tm'>
+                  <Link to='contact_sales' className='btn btn--hollow u-margin-Tm'>
                     <Message pointer='cta.pro' />
                   </Link>
                 </div>
@@ -289,8 +287,7 @@ export default class ProEs extends React.Component {
                 <h2 className='u-text-heading u-color-dark-gray u-text-light u-text-l u-margin-Bm'>
                   Ponte en contacto para una cotización gratuita
                 </h2>
-                <Link to='contact_sales' query={{ s: 'pro' }}
-                id='track-cta-contact-sales' className='btn u-margin-Rm'>
+                <Link to='contact_sales' className='btn u-margin-Rm'>
                   <Message pointer='cta.pro' />
                 </Link>
                 <a href='https://manage-sandbox.gocardless.com/signup'

--- a/app/pages/pro/pro.fr.js
+++ b/app/pages/pro/pro.fr.js
@@ -43,7 +43,7 @@ export default class ProFr extends React.Component {
                 </a>
               </li>
             </ul>
-            <Link to='contact_sales' query={{ s: 'pro' }}
+            <Link to='contact_sales'
               className={
                 'sticky-nav__cta btn btn--small btn--hollow u-pull-end ' +
                 'u-text-transform-none u-text-light u-text-xxs u-text-no-smoothing'
@@ -170,7 +170,7 @@ export default class ProFr extends React.Component {
                       Parlez avec nos experts de vos problématiques paiements.
                     </p>
                   </div>
-                  <Link to='contact_sales' query={{ s: 'pro' }} id='track-cta-contact-sales'
+                  <Link to='contact_sales'
                   className='btn btn--hollow u-margin-Tm'>
                     <Message pointer='cta.pro' />
                   </Link>

--- a/app/pages/pro/pro.nl.js
+++ b/app/pages/pro/pro.nl.js
@@ -57,8 +57,7 @@ export default class ProNl extends React.Component {
                   </a>
                 </li>
               </ul>
-              <Link to='contact_sales' query={{ s: 'pro' }}
-              id='track-sticky-nav-contact-sales'
+              <Link to='contact_sales'
               className={
                 'sticky-nav__cta btn btn--small btn--hollow u-pull-end ' +
                 'u-text-transform-none u-text-light u-text-xxs u-text-no-smoothing'
@@ -223,8 +222,7 @@ export default class ProNl extends React.Component {
                       Neem contact met ons op en ontdek hoe GoCardless jouw bedrijf kan helpen.
                     </p>
                   </div>
-                  <Link to='contact_sales' query={{ s: 'pro' }} id='track-cta-contact-sales'
-                  className='btn btn--hollow u-margin-Tm'>
+                  <Link to='contact_sales' className='btn btn--hollow u-margin-Tm'>
                     <Message pointer='cta.pro' />
                   </Link>
                 </div>
@@ -301,8 +299,7 @@ export default class ProNl extends React.Component {
                 <h2 className='u-text-heading u-color-dark-gray u-text-light u-text-l u-margin-Bm'>
                   Neem contact met ons op voor een vrijblijvende offerte
                 </h2>
-                <Link to='contact_sales' query={{ s: 'pro' }}
-                id='track-cta-contact-sales' className='btn u-margin-Rm'>
+                <Link to='contact_sales' className='btn u-margin-Rm'>
                   <Message pointer='cta.pro' />
                 </Link>
                 <a href='https://manage-sandbox.gocardless.com/signup'

--- a/app/pages/security/security.de.js
+++ b/app/pages/security/security.de.js
@@ -81,7 +81,7 @@ export default class SecurityDe extends React.Component {
             <div className='u-padding-Vxl'>
               <h2 className='u-text-heading u-text-l u-color-dark-gray u-text-light'>Haben Sie Fragen?</h2>
               <p className='u-color-dark-gray u-margin-Ts'>Sprechen Sie mit einem unserer Experten unter <Message pointer='phone_local' /></p>
-              <Link to='contact_sales' query={{ s: 'security' }} className='btn btn--hollow u-margin-Tm'>Fragen Sie uns</Link>
+              <Link to='contact_sales' className='btn btn--hollow u-margin-Tm'>Fragen Sie uns</Link>
             </div>
           </div>
         </IfLocale>

--- a/app/pages/security/security.en.js
+++ b/app/pages/security/security.en.js
@@ -79,7 +79,7 @@ export default class SecurityEn extends React.Component {
             <div className='u-padding-Vxl'>
               <h2 className='u-text-heading u-text-l u-color-dark-gray u-text-light'>Got any questions?</h2>
               <p className='u-color-dark-gray u-margin-Ts'>Speak with one of our experts on <Message pointer='phone_local' /></p>
-              <Link to='contact_sales' query={{ s: 'security' }} className='btn btn--hollow u-margin-Tm'>Contact sales</Link>
+              <Link to='contact_sales' className='btn btn--hollow u-margin-Tm'>Contact sales</Link>
             </div>
           </div>
         </IfLocale>

--- a/app/pages/security/security.es.js
+++ b/app/pages/security/security.es.js
@@ -79,7 +79,7 @@ export default class SecurityEs extends React.Component {
             <div className='u-padding-Vxl'>
               <h2 className='u-text-heading u-text-l u-color-dark-gray u-text-light'>¿Alguna pregunta?</h2>
               <p className='u-color-dark-gray u-margin-Ts'>Habla con uno de nuestros expertos en <Message pointer='phone_local' /></p>
-              <Link to='contact_sales' query={{ s: 'security' }} className='btn btn--hollow u-margin-Tm'>Contacta con nosotros</Link>
+              <Link to='contact_sales' className='btn btn--hollow u-margin-Tm'>Contacta con nosotros</Link>
             </div>
           </div>
         </IfLocale>

--- a/app/pages/security/security.fr.js
+++ b/app/pages/security/security.fr.js
@@ -76,7 +76,7 @@ export default class SecurityFr extends React.Component {
               <h2 className='u-text-heading u-color-dark-gray u-text-light u-text-l u-margin-Bm'>
                 Prenez contact avec notre équipe
               </h2>
-              <Link to='contact_sales' query={{ s: 'pro' }} className='btn'>
+              <Link to='contact_sales' className='btn'>
                 Contactez-nous
               </Link>
             </IfLocale>

--- a/app/pages/security/security.nl.js
+++ b/app/pages/security/security.nl.js
@@ -79,7 +79,7 @@ export default class SecurityNl extends React.Component {
             <div className='u-padding-Vxl'>
               <h2 className='u-text-heading u-text-l u-color-dark-gray u-text-light'>Vragen?</h2>
               <p className='u-color-dark-gray u-margin-Ts'>Neem contact met ons op via <Message pointer='phone_local' /></p>
-              <Link to='contact_sales' query={{ s: 'security' }} className='btn btn--hollow u-margin-Tm'>Neem contact op</Link>
+              <Link to='contact_sales' className='btn btn--hollow u-margin-Tm'>Neem contact op</Link>
             </div>
           </div>
         </IfLocale>


### PR DESCRIPTION
The sales team would like better insight on how people get to the Contact Sales page. At the moment, we provide this insight in Salesforce by tracking the Contact Sales URL and `s` parameter.
e.g. `/contact-sales/?s=pricing` or `/contact-sales/?s=pro`.

Unfortunately, we aren't currently using the `s` parameter very consistently. This PR does two things:
- Remove hard-coded query parameters (easy to make mistakes e.g. when copying & pasting into another file)
- Automatically generate the query parameters within the `<Link>` component when `to="contact_sales"` is specified.
