### PR TITLE
Correct links to point to the developer splash page and the API reference as appropriate

### DIFF
--- a/app/components/footer/footer.js
+++ b/app/components/footer/footer.js
@@ -84,9 +84,9 @@ class Footer extends React.Component {
                 <Link to='faq_pro_dashboard' pointer='faq_pro_dashboard.link_title' className='page-footer__link u-link-invert' />
               </IfLinkExists>
               <li>
-                <a href='https://developer.gocardless.com/' id='track-footer-api-docs' className='page-footer__link u-link-invert'>
+                <Href to='developer_link' id='track-footer-api-docs' className='page-footer__link u-link-invert'>
                   <Message pointer='api_docs.nav_title' />
-                </a>
+                </Href>
               </li>
               <IfLinkExists to='security' tagName='li'>
                 <Link to='security' pointer='security.nav_title' className='page-footer__link u-link-invert' />

--- a/app/components/header/header.js
+++ b/app/components/header/header.js
@@ -138,11 +138,11 @@ class Header extends React.Component {
               </Translation>
 
               <div className='nav__item u-relative'>
-                <a href='https://developer.gocardless.com/' className={linkClass}>
+                <Href to='developer_link' className={linkClass}>
                   <div className='nav__item-link'>
                     <Message pointer='api_docs.nav_title' />
                   </div>
-                </a>
+                </Href>
               </div>
 
               <div className='nav__item u-relative'>

--- a/app/messages/de.js
+++ b/app/messages/de.js
@@ -43,7 +43,8 @@ export default {
   phone_local: '+49 30 568373022',
   email: 'deutschland@gocardless.com',
   partners_email: 'partnerships@gocardless.com',
-  documentation_link: 'https://developer.gocardless.com/',
+  api_reference_link: 'https://developer.gocardless.com/api-reference',
+  developer_link: 'https://developer.gocardless.com',
   prospect_form: {
     sales: {
       name_label: 'Ihr Name',

--- a/app/messages/en-GB.js
+++ b/app/messages/en-GB.js
@@ -7,7 +7,6 @@ export default {
     show_holding_page: false,
   },
   phone_local: '020 7183 8674',
-  documentation_link: 'https://developer.gocardless.com/',
   signin: {
     path: '/users/sign_in',
   },

--- a/app/messages/en.js
+++ b/app/messages/en.js
@@ -42,7 +42,8 @@ export default {
   phone_local: '+44 20 7183 8674',
   email: 'help@gocardless.com',
   partners_email: 'partnerships@gocardless.com',
-  documentation_link: 'https://developer.gocardless.com/',
+  api_reference_link: 'https://developer.gocardless.com/api-reference',
+  developer_link: 'https://developer.gocardless.com',
   prospect_form: {
     sales: {
       name_label: 'Your name',

--- a/app/messages/es.js
+++ b/app/messages/es.js
@@ -40,7 +40,8 @@ export default {
     address_country_iso: 'GB',
   },
   partners_email: 'partnerships@gocardless.com',
-  documentation_link: 'https://developer.gocardless.com/',
+  api_reference_link: 'https://developer.gocardless.com/api-reference',
+  developer_link: 'https://developer.gocardless.com',
   prospect_form: {
     sales: {
       name_label: 'Nombre',

--- a/app/messages/fr.js
+++ b/app/messages/fr.js
@@ -334,4 +334,6 @@ export default {
     title: 'Foundation of Hearts',
     description: '',
   },
+  api_reference_link: 'https://developer.gocardless.com/api-reference',
+  developer_link: 'https://developer.gocardless.com/fr',
 };

--- a/app/messages/nl-BE.js
+++ b/app/messages/nl-BE.js
@@ -23,7 +23,8 @@ export default {
   phone_full: '+32 78 483 170',
   phone_local: '078 483 170',
   partners_email: 'belgium@gocardless.com',
-  documentation_link: 'https://developer.gocardless.com/',
+  api_reference_link: 'https://developer.gocardless.com/api-reference',
+  developer_link: 'https://developer.gocardless.com',
   prospect_form: {
     sales: {
       name_label: 'Naam',

--- a/app/messages/nl-NL.js
+++ b/app/messages/nl-NL.js
@@ -23,7 +23,8 @@ export default {
   phone_full: '+31 85 208 0520',
   phone_local: '085 208 0520',
   partners_email: 'netherlands@gocardless.com',
-  documentation_link: 'https://developer.gocardless.com/',
+  api_reference_link: 'https://developer.gocardless.com/api-reference',
+  developer_link: 'https://developer.gocardless.com',
   prospect_form: {
     sales: {
       name_label: 'Naam',

--- a/app/messages/pt.js
+++ b/app/messages/pt.js
@@ -74,4 +74,6 @@ export default {
     nav_title: 'Guias',
     path: '/guides',
   },
+  api_reference_link: 'https://developer.gocardless.com/api-reference',
+  developer_link: 'https://developer.gocardless.com',
 };

--- a/app/messages/shared.js
+++ b/app/messages/shared.js
@@ -9,4 +9,6 @@ export default {
     },
   },
   customer_queries_link: 'https://support.gocardless.com/hc/en-us/sections/202581129-Customer-Queries',
+  api_reference_link: 'https://developer.gocardless.com/api-reference',
+  developer_link: 'https://developer.gocardless.com',
 };

--- a/app/pages/faq/merchants/developer-api/faq-merchants-developer-api.de.js
+++ b/app/pages/faq/merchants/developer-api/faq-merchants-developer-api.de.js
@@ -66,7 +66,7 @@ export default class FaqMerchantsDeveloperApiDe extends React.Component {
           Z.B. werden Sie in Echtzeit darüber informiert, wenn sich der Status einer Zahlung oder eines Mandats ändert.
         </p>
         <p className='para'>
-          Sie können in unserer <a href='https://developer.gocardless.com/#webhooks-overview'
+          Sie können in unserer <a href='https://developer.gocardless.com/api-reference/#webhooks-overview'
           className='u-link-color-p u-text-underline'>Webhook Dokumentation</a> mehr über die Verwendung von Webhooks erfahren.
         </p>
 

--- a/app/pages/faq/merchants/developer-api/faq-merchants-developer-api.de.js
+++ b/app/pages/faq/merchants/developer-api/faq-merchants-developer-api.de.js
@@ -15,7 +15,7 @@ export default class FaqMerchantsDeveloperApiDe extends React.Component {
         </h3>
         <p className='para'>
           Unsere REST API erlaubt es Entwicklern auf einfachstem Weg mit GoCardless zu integrieren. Lernen Sie dazu
-          mehr in unserer <Href to='documentation_link' className='u-link-color-p u-text-underline'>Dokumentation</Href>.
+          mehr in unserer <Href to='api_reference_link' className='u-link-color-p u-text-underline'>Dokumentation</Href>.
         </p>
         <p className='para'>
           Sie können GoCardless integrieren, um Lastschriften von Ihren Kunden bequem über Ihr CRM Tool oder

--- a/app/pages/faq/merchants/developer-api/faq-merchants-developer-api.en.js
+++ b/app/pages/faq/merchants/developer-api/faq-merchants-developer-api.en.js
@@ -16,7 +16,7 @@ export default class FaqMerchantsDeveloperApiEn extends React.Component {
         </h3>
         <p className='para'>
           Our REST API allows developers to easily create powerful integrations with GoCardless.
-          See our <Href to='documentation_link' className='u-link-color-p u-text-underline'>documentation</Href> to
+          See our <Href to='api_reference_link' className='u-link-color-p u-text-underline'>documentation</Href> to
           find out more.
         </p>
         <Translation locales={['en']} exclude={['en-GB','en-IE']}>

--- a/app/pages/faq/merchants/developer-api/faq-merchants-developer-api.en.js
+++ b/app/pages/faq/merchants/developer-api/faq-merchants-developer-api.en.js
@@ -44,7 +44,7 @@ export default class FaqMerchantsDeveloperApiEn extends React.Component {
             requests on their behalf.
           </p>
           <p className='para'>
-            For further information, see our <a href='https://developer.gocardless.com/#guides-oauth'
+            For further information, see our <a href='https://developer.gocardless.com/getting-started/partners/introduction/'
             className='u-link-color-p u-text-underline'>partner API guide</a>.
           </p>
         </Translation>
@@ -167,14 +167,14 @@ export default class FaqMerchantsDeveloperApiEn extends React.Component {
         </p>
         <Translation locales='en-GB'>
           <p className='para'>
-            You can find out more about available webhooks and how to use them in our <a href='https://developer.gocardless.com/#webhooks-overview'
+            You can find out more about available webhooks and how to use them in our <a href='https://developer.gocardless.com/api-reference/#webhooks-overview'
             className='u-link-color-p u-text-underline'>webhook guide</a>.
           </p>
         </Translation>
         <Translation locales={['en']} exclude={['en-GB']}>
           <p className='para'>
             You can find out more about available webhooks and how to use them in
-            our <a href='https://developer.gocardless.com/#webhooks-overview'
+            our <a href='https://developer.gocardless.com/api-reference/#webhooks-overview'
             className='u-link-color-p u-text-underline'>webhook guide</a>.
           </p>
         </Translation>

--- a/app/pages/faq/merchants/developer-api/faq-merchants-developer-api.es.js
+++ b/app/pages/faq/merchants/developer-api/faq-merchants-developer-api.es.js
@@ -16,7 +16,7 @@ export default class FaqMerchantsDeveloperApiEs extends React.Component {
         </h3>
         <p className='para'>
           Nuestra API REST permite a los desarrolladores crear fácilmente integraciones potentes con GoCardless.
-          Consulta nuestra <Href to='documentation_link' className='u-link-color-p u-text-underline'>documentación</Href> para
+          Consulta nuestra <Href to='api_reference_link' className='u-link-color-p u-text-underline'>documentación</Href> para
           obtener más información.
         </p>
         <p className='para'>

--- a/app/pages/faq/merchants/developer-api/faq-merchants-developer-api.es.js
+++ b/app/pages/faq/merchants/developer-api/faq-merchants-developer-api.es.js
@@ -99,7 +99,7 @@ export default class FaqMerchantsDeveloperApiEs extends React.Component {
         </p>
         <p className='para'>
           Podrás encontrar más información acerca de nuestros webhooks disponibles y cómo utilizarlos en
-          nuestra <a href='https://developer.gocardless.com/#webhooks-overview' className='u-link-color-p u-text-underline'>guía de
+          nuestra <a href='https://developer.gocardless.com/api-reference/#webhooks-overview' className='u-link-color-p u-text-underline'>guía de
           webhooks</a>.
         </p>
 

--- a/app/pages/faq/merchants/developer-api/faq-merchants-developer-api.fr.js
+++ b/app/pages/faq/merchants/developer-api/faq-merchants-developer-api.fr.js
@@ -14,7 +14,7 @@ export default class FaqMerchantsDeveloperApiFr extends React.Component {
         </h3>
         <p className='para'>
           Notre API REST donne la possibilité aux développeurs de facilement intégrer GoCardless. Apprenez en
-          plus sur notre <a href='https://developer.gocardless.com/' className='u-link-color-p u-text-underline'>documentation</a>.
+          plus sur notre <Href to='api_reference_link' className='u-link-color-p u-text-underline'>documentation</Href>.
         </p>
         <p className='para'>
           Vous pouvez intégrer GoCardless pour prendre des paiements via prélèvement bancaire

--- a/app/pages/faq/merchants/developer-api/faq-merchants-developer-api.fr.js
+++ b/app/pages/faq/merchants/developer-api/faq-merchants-developer-api.fr.js
@@ -57,7 +57,7 @@ export default class FaqMerchantsDeveloperApiFr extends React.Component {
           objet. Par exemple, vous êtes informé en temps réel sur le statut de tous vos paiements et mandats.
         </p>
         <p className='para'>
-          Vous pouvez en apprendre plus sur nos webhooks dans notre API <a href='https://developer.gocardless.com/#webhooks-overview'
+          Vous pouvez en apprendre plus sur nos webhooks dans notre API <a href='https://developer.gocardless.com/api-reference/#webhooks-overview'
           className='u-link-color-p u-text-underline'>ici</a>.
         </p>
 

--- a/app/pages/faq/merchants/how-it-works/faq-merchants-how-it-works.en.js
+++ b/app/pages/faq/merchants/how-it-works/faq-merchants-how-it-works.en.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import Translation from '../../../../components/translation/translation';
+import Href from '../../../../components/href/href';
 
 export default class FaqMerchantsHowItWorksEn extends React.Component {
   displayName = 'FaqMerchantsHowItWorksEn'

--- a/app/pages/faq/merchants/how-it-works/faq-merchants-how-it-works.en.js
+++ b/app/pages/faq/merchants/how-it-works/faq-merchants-how-it-works.en.js
@@ -58,8 +58,7 @@ export default class FaqMerchantsHowItWorksEn extends React.Component {
           Can customers sign up on my website?
         </h3>
         <p className='para'>
-          Yes - you can either do this by integrating with our <a href='https://developer.gocardless.com/'
-          className='u-link-color-p u-text-underline'>API</a> or by generating a link for a payment
+          Yes - you can either do this by integrating with our <Href to="developer_link" className='u-link-color-p u-text-underline'>API</Href> or by generating a link for a payment
           plan and embedding this as a button on your website.
         </p>
         <p className='para'>

--- a/app/pages/faq/merchants/how-it-works/faq-merchants-how-it-works.es.js
+++ b/app/pages/faq/merchants/how-it-works/faq-merchants-how-it-works.es.js
@@ -66,7 +66,7 @@ export default class FaqMerchantsHowItWorksEs extends React.Component {
         </h3>
         <p className='para'>
           Sí - los clientes pueden autorizar el Mandato SEPA en tu propio flujo de venta, bien a través de una integración
-          con nuestra <a href='https://developer.gocardless.com/' className='u-link-color-p u-text-underline'>API</a> o
+          con nuestra <Href to='developer_link' className='u-link-color-p u-text-underline'>API</Href> o
           generando un enlace para un plan de cobros e incrustándolo como botón en tu propio sitio web.
         </p>
         <p className='para'>

--- a/app/pages/faq/merchants/how-it-works/faq-merchants-how-it-works.es.js
+++ b/app/pages/faq/merchants/how-it-works/faq-merchants-how-it-works.es.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import Translation from '../../../../components/translation/translation';
+import Href from '../../../../components/href/href';
 
 export default class FaqMerchantsHowItWorksEs extends React.Component {
   displayName = 'FaqMerchantsHowItWorksEs'

--- a/app/pages/faq/merchants/overview/faq-merchants-overview.de.js
+++ b/app/pages/faq/merchants/overview/faq-merchants-overview.de.js
@@ -25,7 +25,7 @@ export default class FaqMerchantsDe extends React.Component {
           </li>
           <li>
             <strong>Über unsere REST API</strong> - Integrieren Sie GoCardless nahtlos in Ihre Website mit
-            unserer <Href to='documentation_link' className='u-link-color-p u-text-underline'>REST API</Href>.
+            unserer <Href to='api_reference_link' className='u-link-color-p u-text-underline'>REST API</Href>.
           </li>
         </ul>
 
@@ -125,7 +125,7 @@ export default class FaqMerchantsDe extends React.Component {
           <li>
             <strong>Clevere Technik</strong> - Wir bieten Ihnen eine hochklassige Lösung, um Zahlungen zu kreieren, zu bearbeiten
             und zu verwalten. Das funktioniert über unser einfaches Online Dashboard und
-            die <Href to='documentation_link' className='u-link-color-p u-text-underline'>REST API</Href>.
+            die <Href to='api_reference_link' className='u-link-color-p u-text-underline'>REST API</Href>.
           </li>
           <li>
             <strong>Der persönliche Bezug</strong> - Unser Team ist immer bemüht Sie bestens zu unterstützen und geht dabei regelmäßig

--- a/app/pages/faq/merchants/overview/faq-merchants-overview.en.js
+++ b/app/pages/faq/merchants/overview/faq-merchants-overview.en.js
@@ -25,7 +25,7 @@ export default class FaqMerchantsEn extends React.Component {
             </li>
             <li>
               <strong>Our clean, RESTful API</strong> - Integrate GoCardless into your website using
-              our <a href='https://developer.gocardless.com/' className='u-link-color-p u-text-underline'>REST API</a>.
+              our <Href to='developer_link' className='u-link-color-p u-text-underline'>REST API</Href>.
             </li>
           </ul>
         </Translation>
@@ -45,7 +45,7 @@ export default class FaqMerchantsEn extends React.Component {
             </li>
             <li>
               <strong>Our clean, RESTful API</strong> - Integrate GoCardless into your website using
-              our <a href='https://developer.gocardless.com/' className='u-link-color-p u-text-underline'>REST API</a>.
+              our <Href to='developer_link' className='u-link-color-p u-text-underline'>REST API</Href>.
             </li>
           </ul>
         </Translation>
@@ -160,8 +160,8 @@ export default class FaqMerchantsEn extends React.Component {
           </IfLocale>
           <li>
             <strong>Powerful tools that suit you</strong> - Everything you need to set up, collect
-            and manage Direct Debit payments with our simple online tool or <a href='https://developer.gocardless.com/'
-            className='u-link-color-p u-text-underline'>REST API</a>.
+            and manage Direct Debit payments with our simple online tool or <Href to='developer_link'
+            className='u-link-color-p u-text-underline'>REST API</Href>.
           </li>
           <li>
             <strong>The personal touch</strong> - Our support team prides itself on being there to help whenever you need us.

--- a/app/pages/faq/merchants/overview/faq-merchants-overview.en.js
+++ b/app/pages/faq/merchants/overview/faq-merchants-overview.en.js
@@ -2,6 +2,7 @@ import React from 'react';
 import Translation from '../../../../components/translation/translation';
 import IfLocale from '../../../../components/if-locale/if-locale';
 import Link from '../../../../components/link/link';
+import Href from '../../../../components/href/href';
 import Message from '../../../../components/message/message';
 
 export default class FaqMerchantsEn extends React.Component {

--- a/app/pages/faq/merchants/overview/faq-merchants-overview.es.js
+++ b/app/pages/faq/merchants/overview/faq-merchants-overview.es.js
@@ -2,6 +2,7 @@ import React from 'react';
 import Translation from '../../../../components/translation/translation';
 import IfLocale from '../../../../components/if-locale/if-locale';
 import Link from '../../../../components/link/link';
+import Href from '../../../../components/href/href';
 import Message from '../../../../components/message/message';
 
 export default class FaqMerchantsEs extends React.Component {

--- a/app/pages/faq/merchants/overview/faq-merchants-overview.es.js
+++ b/app/pages/faq/merchants/overview/faq-merchants-overview.es.js
@@ -30,7 +30,7 @@ export default class FaqMerchantsEs extends React.Component {
           </li>
           <li>
             <strong>Nuestra sencilla API REST</strong> - Integra GoCardless en tu sitio web usando
-            nuestra <a href='https://developer.gocardless.com/' className='u-link-color-p u-text-underline'>API REST</a>.
+            nuestra <Href to='developer_link' className='u-link-color-p u-text-underline'>API REST</Href>.
           </li>
         </ul>
 
@@ -139,8 +139,8 @@ export default class FaqMerchantsEs extends React.Component {
           </IfLocale>
           <li>
             <strong>Potentes herramientas que se adaptan a tus necesidades</strong> - Tienes todo lo que necesitas para realizar,
-            recaudar y gestionar cobros de Adeudo Directo con nuestro sencillo panel de control o <a href='https://developer.gocardless.com/'
-            className='u-link-color-p u-text-underline'> nuestra API REST</a>.
+            recaudar y gestionar cobros de Adeudo Directo con nuestro sencillo panel de control o <Href to='developer_link'
+            className='u-link-color-p u-text-underline'>nuestra API REST</Href>.
           </li>
           <li>
             <strong>El toque personal</strong> - Nuestro equipo de asistencia se enorgullece de estar ahí siempre que nos necesites.

--- a/app/pages/faq/merchants/overview/faq-merchants-overview.fr.js
+++ b/app/pages/faq/merchants/overview/faq-merchants-overview.fr.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import Translation from '../../../../components/translation/translation';
 import Link from '../../../../components/link/link';
+import Href from '../../../../components/href/href';
 
 export default class FaqMerchantsFr extends React.Component {
   displayName = 'FaqMerchantsFr'

--- a/app/pages/faq/merchants/overview/faq-merchants-overview.fr.js
+++ b/app/pages/faq/merchants/overview/faq-merchants-overview.fr.js
@@ -22,8 +22,8 @@ export default class FaqMerchantsFr extends React.Component {
           </li>
           <li>
             <strong>GoCardless Pro</strong> - Automatisez vos prélèvements en intégrant
-            notre <a href='https://developer.gocardless.com/' className='u-link-color-p u-text-underline'>REST
-            API</a> dans votre site internet et vos systèmes informatiques.
+            notre <Href to='developer_link' className='u-link-color-p u-text-underline'>REST
+            API</Href> dans votre site internet et vos systèmes informatiques.
           </li>
           <li>
             <strong>Nos partenaires</strong> - Nous travaillons avec de multiples <Link to='partners'
@@ -68,7 +68,7 @@ export default class FaqMerchantsFr extends React.Component {
           </li>
           <li>
             <strong>Évoluez facilement</strong> - Notre tableau de bord est propulsé par
-            notre <a href='https://developer.gocardless.com/' className='u-link-color-p u-text-underline'>API REST</a>.
+            notre <Href to='developer_link' className='u-link-color-p u-text-underline'>API REST</Href>.
             Ceci vous permet de facilement évoluer vers l'API afin d'automatiser plus en profondeur au fur et
             à mesure.
           </li>

--- a/app/pages/faq/merchants/signing-up/faq-merchants-signing-up.de.js
+++ b/app/pages/faq/merchants/signing-up/faq-merchants-signing-up.de.js
@@ -48,7 +48,7 @@ export default class FaqMerchantsSigningUpDe extends React.Component {
         <p className='para'>
           Entwickler sollten sich ganz normal <Href to='signup.path' className='u-link-color-p u-text-underline'>anmelden</Href>. Sobald
           Sie angemeldet sind, können Sie Ihren Entwickler Account freischalten. Unsere API Dokumentation
-          ist <Href to='documentation_link' className='u-link-color-p u-text-underline'>hier</Href> verfügbar.
+          ist <Href to='api_reference_link' className='u-link-color-p u-text-underline'>hier</Href> verfügbar.
         </p>
 
         <h3 className='u-text-heading-light u-color-dark-gray u-margin-Vm u-text-s'>

--- a/app/pages/faq/merchants/signing-up/faq-merchants-signing-up.en.js
+++ b/app/pages/faq/merchants/signing-up/faq-merchants-signing-up.en.js
@@ -52,7 +52,7 @@ export default class FaqMerchantsSigningUpEn extends React.Component {
           </h3>
           <p className='para'>
             Developers should sign up as normal. Our API documentation can be viewed
-            <a href='https://developer.gocardless.com/' className='u-link-color-p u-text-underline'>here</a>.
+            <Href to='api_reference_link' className='u-link-color-p u-text-underline'>here</Href>.
           </p>
         </Translation>
 

--- a/app/pages/faq/merchants/signing-up/faq-merchants-signing-up.en.js
+++ b/app/pages/faq/merchants/signing-up/faq-merchants-signing-up.en.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import Translation from '../../../../components/translation/translation';
 import Link from '../../../../components/link/link';
+import Href from '../../../../components/href/href';
 
 export default class FaqMerchantsSigningUpEn extends React.Component {
   displayName = 'FaqMerchantsSigningUpEn'

--- a/app/pages/faq/merchants/signing-up/faq-merchants-signing-up.es.js
+++ b/app/pages/faq/merchants/signing-up/faq-merchants-signing-up.es.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import Translation from '../../../../components/translation/translation';
 import Link from '../../../../components/link/link';
+import Href from '../../../../components/href/href';
 
 export default class FaqMerchantsSigningUpEs extends React.Component {
   displayName = 'FaqMerchantsSigningUpEs'

--- a/app/pages/faq/merchants/signing-up/faq-merchants-signing-up.es.js
+++ b/app/pages/faq/merchants/signing-up/faq-merchants-signing-up.es.js
@@ -54,7 +54,7 @@ export default class FaqMerchantsSigningUpEs extends React.Component {
         </h3>
         <p className='para'>
           Los desarrolladores deberán registrarse normalmente. Nuestra documentación de la API la
-          puedes encontrar <a href='https://developer.gocardless.com/' className='u-link-color-p u-text-underline'>aquí</a>.
+          puedes encontrar <Href to='api_reference_link' className='u-link-color-p u-text-underline'>aquí</Href>.
         </p>
 
         <h3 className='u-text-heading-light u-color-dark-gray u-margin-Vm u-text-s'>

--- a/app/pages/features/api/features-api.js
+++ b/app/pages/features/api/features-api.js
@@ -5,6 +5,7 @@ import CheckListIcon from '../../../icons/svg/checklist';
 import SecurityIcon from '../../../icons/svg/security';
 import AddPartnerIcon from '../../../icons/svg/add-partner';
 import Link from '../../../components/link/link';
+import Href from '../../../components/href/href';
 
 export default class FeaturesAPI extends React.Component {
   displayName = 'FeaturesAPI'
@@ -86,13 +87,13 @@ export default class FeaturesAPI extends React.Component {
                 </p>
               </div>
             </div>
-            <a href='https://developer.gocardless.com/'
+            <Href link='api_reference_link'
             className={
               'u-color-primary u-text-upcase u-text-xxs ' +
               'u-text-heading u-text-semi u-block u-margin-Tm'
             }>
               Read our API documentation
-            </a>
+            </Href>
           </div>
         </div>
         <hr className='u-margin-An' />
@@ -249,9 +250,9 @@ export default class FeaturesAPI extends React.Component {
               <h2 className='u-text-heading u-color-dark-gray u-text-l u-text-light'>
                 Get started today
               </h2>
-              <a href='https://developer.gocardless.com/' target='_blank' className='btn btn--hollow u-margin-Tm'>
+              <Href link='api_reference_link' target='_blank' className='btn btn--hollow u-margin-Tm'>
                 Read our API documentation
-              </a>
+              </Href>
               <hr className='u-margin-Vxl horizontal-rule u-size-3of4 u-center' />
               <p className='u-color-dark-gray u-margin-Bxxs'>
                 <strong>Looking complete control, like custom payment pages?</strong>

--- a/app/pages/features/api/features-api.js
+++ b/app/pages/features/api/features-api.js
@@ -41,7 +41,7 @@ export default class FeaturesAPI extends React.Component {
               <a href='https://github.com/gocardless/gocardless-ruby'>Ruby</a>,&nbsp;
               <a href='https://github.com/gocardless/gocardless-php'>PHP</a>,&nbsp;
               <a href='https://github.com/gocardless/gocardless-java'>Java</a> &amp;&nbsp;
-              <a href='https://developer.gocardless.com/#overview-client-libraries'>more</a>
+              <a href='https://developer.gocardless.com/api-reference/#overview-client-libraries'>more</a>
             </p>
             <div className='grid u-margin-Vl u-padding-Vl'>
               <div className='grid__cell u-size-1of3 u-text-center'>

--- a/app/pages/features/features.de.js
+++ b/app/pages/features/features.de.js
@@ -168,7 +168,7 @@ export default class FeaturesDe extends React.Component {
                     </div>
                     <p className='u-color-dark-gray u-margin-Txs'>
                       Integrieren Sie GoCardless innerhalb von Minuten in Ihre Website oder App über unsere benutzerfreundlichen
-                      API-Bibliotheken. <a href='https://developer.gocardless.com/'>Mehr dazu</a>.
+                      API-Bibliotheken. <Href to='developer_link'>Mehr dazu</Href>.
                     </p>
                   </div>
                 </div>

--- a/app/pages/features/features.en.js
+++ b/app/pages/features/features.en.js
@@ -281,9 +281,9 @@ export default class FeaturesEn extends React.Component {
                   <p className='u-color-dark-gray u-padding-Vm'>
                     Want to use GoCardless to power payments on your site? Take a look at our REST API in the comprehensive docs.
                   </p>
-                  <a href='https://developer.gocardless.com/' className='u-color-primary u-text-upcase u-text-xxs u-text-heading u-text-semi'>
+                  <Href to='developer_link' className='u-color-primary u-text-upcase u-text-xxs u-text-heading u-text-semi'>
                     Learn more
-                  </a>
+                  </Href>
                 </div>
 
                 <div className='product-grid__section u-padding-Vl'>

--- a/app/pages/features/features.es.js
+++ b/app/pages/features/features.es.js
@@ -184,7 +184,7 @@ export default class FeaturesEs extends React.Component {
                     </div>
                       <p className='u-color-dark-gray u-margin-Txs'>
                         Añade GoCardless a tu web o app en minutos con nuestras librerias API.&nbsp;
-                        <a href='https://developer.gocardless.com/'>Descubre más</a>.
+                        <Href to='developer_link'>Descubre más</Href>.
                       </p>
                   </div>
                 </div>

--- a/app/pages/features/features.nl.js
+++ b/app/pages/features/features.nl.js
@@ -167,7 +167,7 @@ export default class FeaturesNl extends React.Component {
                       Gebruiksvriendelijke, RESTful API
                     </div>
                     <p className='u-color-dark-gray u-margin-Txs'>
-                      Voeg GoCardless in enkele minuten toe aan je website of app met onze gebruiksvriendelijke API. <a href='https://developer.gocardless.com/'>Lees meer</a>.
+                      Voeg GoCardless in enkele minuten toe aan je website of app met onze gebruiksvriendelijke API. <Href to='developer_link'>Lees meer</Href>.
                     </p>
                   </div>
                 </div>

--- a/app/pages/legal/merchants/legal-merchants.en.js
+++ b/app/pages/legal/merchants/legal-merchants.en.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import Translation from '../../../components/translation/translation';
 import Link from '../../../components/link/link';
+import Href from '../../../components/href/href';
 
 export default class LegalMerchantsEn extends React.Component {
   displayName = 'LegalMerchantsEn'
@@ -334,7 +335,7 @@ export default class LegalMerchantsEn extends React.Component {
 
         <div className='simple-terms'>
           <p className='para'>
-            You can use our API in line with the <a href="https://developer.gocardless.com/" className='u-link-color-p u-text-underline'>documentation we provide for it</a>, but not in any other way. We might require you to update certain software to work with the service.
+            You can use our API in line with the <Href to='api_reference_link' className='u-link-color-p u-text-underline'>documentation we provide for it</Href>, but not in any other way. We might require you to update certain software to work with the service.
           </p>
         </div>
 

--- a/app/pages/pro/pro.de.js
+++ b/app/pages/pro/pro.de.js
@@ -9,6 +9,7 @@ import WhiteLabelIcon from '../../icons/svg/white-label';
 import MobileIcon from '../../icons/svg/mobile';
 import PhoneIcon from '../../icons/svg/phone';
 import Link from '../../components/link/link';
+import Href from '../../components/href/href';
 
 export default class ProDe extends React.Component {
   displayName = 'ProDe'
@@ -57,10 +58,10 @@ export default class ProDe extends React.Component {
               }>
                 <Message pointer='cta.pro' />
               </Link>
-              <a href='https://developer.gocardless.com/' id='track-sticky-nav-docs'
+              <Href to='api_reference_link' id='track-sticky-nav-docs'
               className='u-pull-end u-margin-Txxs u-margin-Rm'>
                 API Dokumentation
-              </a>
+              </Href>
             </div>
           </StickyNav>
           <div className='section-scroll-target' id='overview'>
@@ -100,7 +101,7 @@ export default class ProDe extends React.Component {
                     </div>
                     <p className='u-size-4of5 u-center u-color-dark-gray u-margin-Txs'>
                       Die komplette Dokumentation zu GoCardless Pro ist kostenlos in
-                      unseren <a href='https://developer.gocardless.com/' id='track-overview-docs'>API docs</a> verfügbar.
+                      unseren <Href to='api_reference_link' id='track-overview-docs'>API docs</Href> verfügbar.
                       Wir haben hart daran gearbeitet, die Integration für Sie so einfach wie möglich zu gestalten.
                     </p>
                   </div>

--- a/app/pages/pro/pro.en.js
+++ b/app/pages/pro/pro.en.js
@@ -4,6 +4,7 @@ import Message from '../../components/message/message';
 import StickyNav from '../../components/sticky-nav/sticky-nav';
 import Tabs from '../../components/tabs/tabs';
 import Link from '../../components/link/link';
+import Href from '../../components/href/href';
 
 export default class ProEn extends React.Component {
   displayName = 'ProEn'
@@ -51,10 +52,10 @@ export default class ProEn extends React.Component {
               }>
                 <Message pointer='cta.pro' />
               </Link>
-              <a href='https://developer.gocardless.com/' id='track-sticky-nav-docs'
+              <Href to='api_reference_link' id='track-sticky-nav-docs'
               className='u-pull-end u-margin-Txxs u-margin-Rm'>
                 API Documentation
-              </a>
+              </Href>
             </div>
           </StickyNav>
           <div className='section-scroll-target' id='overview'>
@@ -89,7 +90,7 @@ export default class ProEn extends React.Component {
                     </div>
                     <p className='u-size-4of5 u-center u-color-dark-gray u-margin-Txs'>
                       All documentation for our Pro product is freely available in
-                      our <a href='https://developer.gocardless.com/' id='track-overview-docs'>API docs</a>.
+                      our <Href to='api_reference_link' id='track-overview-docs'>API docs</Href>.
                       We’ve worked hard to make integrating your systems as painless as possible.
                     </p>
                   </div>

--- a/app/pages/pro/pro.es.js
+++ b/app/pages/pro/pro.es.js
@@ -9,6 +9,7 @@ import WhiteLabelIcon from '../../icons/svg/white-label';
 import MobileIcon from '../../icons/svg/mobile';
 import PhoneIcon from '../../icons/svg/phone';
 import Link from '../../components/link/link';
+import Href from '../../components/href/href';
 import ProductComparison from '../../components/product-comparison/product-comparison';
 
 export default class ProEs extends React.Component {
@@ -59,10 +60,10 @@ export default class ProEs extends React.Component {
               }>
                 <Message pointer='cta.pro' />
               </Link>
-              <a href='https://developer.gocardless.com/' id='track-sticky-nav-docs'
+              <Href to='api_reference_link' id='track-sticky-nav-docs'
               className='u-pull-end u-margin-Txxs u-margin-Rm'>
                 Documentación API
-              </a>
+              </Href>
             </div>
           </StickyNav>
           <div className='section-scroll-target' id='overview'>
@@ -103,7 +104,7 @@ export default class ProEs extends React.Component {
                     </div>
                     <p className='u-size-4of5 u-center u-color-dark-gray u-margin-Txs'>
                       Toda la documentación de Pro está disponible gratuitamente en
-                      nuestra <a href='https://developer.gocardless.com/' id='track-overview-docs'>documentación de la API</a>.
+                      nuestra <Href to='api_reference_link' id='track-overview-docs'>documentación de la API</Href>.
                       Hemos trabajado muy duro para que la integración de tu empresa sea tan sencilla como sea posible.
                     </p>
                   </div>

--- a/app/pages/pro/pro.fr.js
+++ b/app/pages/pro/pro.fr.js
@@ -8,6 +8,7 @@ import MobileIcon from '../../icons/svg/mobile';
 import WhiteLabelIcon from '../../icons/svg/white-label';
 import PhoneIcon from '../../icons/svg/phone';
 import Link from '../../components/link/link';
+import Href from '../../components/href/href';
 
 export default class ProFr extends React.Component {
   displayName = 'ProFr'
@@ -50,9 +51,9 @@ export default class ProFr extends React.Component {
               }>
               Contactez-nous
             </Link>
-            <a href='https://developer.gocardless.com/' className='u-pull-end u-margin-Txxs u-margin-Rm'>
+            <Href to='api_reference_link' className='u-pull-end u-margin-Txxs u-margin-Rm'>
               Documentation API
-            </a>
+            </Href>
           </div>
         </StickyNav>
         <div className='section-scroll-target' id='en-bref'>
@@ -94,7 +95,7 @@ export default class ProFr extends React.Component {
                   <p className='u-size-4of5 u-center u-color-dark-gray u-margin-Txs'>
                     Intégrez l'API REST de GoCardless rapidement dans votre site web et vos systèmes
                     d'information. Découvrez notre
-                    <a href='https://developer.gocardless.com/'> documentation</a>.
+                    <Href to='api_reference_link'> documentation</Href>.
                   </p>
                 </div>
                 <div className='grid__cell u-size-1of2 u-text-center u-margin-Txxl u-padding-Txxl'>

--- a/app/pages/pro/pro.nl.js
+++ b/app/pages/pro/pro.nl.js
@@ -9,6 +9,7 @@ import WhiteLabelIcon from '../../icons/svg/white-label';
 import MobileIcon from '../../icons/svg/mobile';
 import PhoneIcon from '../../icons/svg/phone';
 import Link from '../../components/link/link';
+import Href from '../../components/href/href';
 
 export default class ProNl extends React.Component {
   displayName = 'ProNl'
@@ -65,10 +66,10 @@ export default class ProNl extends React.Component {
               }>
                 <Message pointer='cta.pro' />
               </Link>
-              <a href='https://developer.gocardless.com/' id='track-sticky-nav-docs'
+              <Href to='api_reference_link' id='track-sticky-nav-docs'
               className='u-pull-end u-margin-Txxs u-margin-Rm'>
                 API documentatie
-              </a>
+              </Href>
             </div>
           </StickyNav>
           <div className='section-scroll-target' id='overview'>
@@ -116,7 +117,7 @@ export default class ProNl extends React.Component {
                     </div>
                     <p className='u-size-4of5 u-center u-color-dark-gray u-margin-Txs'>
                       Alle documentatie voor GoCardless Pro is gratis beschikbaar in onze
-                      <a href='https://developer.gocardless.com/' id='track-overview-docs'> API docs</a>.
+                      <Href to='api_reference_link' id='track-overview-docs'> API docs</Href>.
                       We hebben ons best gedaan om de integratie met jouw systemen zo eenvoudig mogelijk te maken.
                     </p>
                   </div>

--- a/app/pages/stories/stories/smart-pension.js
+++ b/app/pages/stories/stories/smart-pension.js
@@ -79,7 +79,7 @@ export default class StoriesSmartPension extends React.Component {
             The benefits
           </h2>
           <p className='para'>
-            The simple <a href='https://developer.gocardless.com/' className='u-link-color-p u-text-underline'>GoCardless API</a> was easy
+            The simple <Href to='developer_link' className='u-link-color-p u-text-underline'>GoCardless API</Href> was easy
             for Smart Pension to integrate into the existing system, via plug and play integration into the Ruby on Rails platform.
             Smart Pension were up and running with GoCardless in under a week, with help from GoCardless support, which ensured existing
             clients were unaffected by the transition.

--- a/app/pages/stories/stories/smart-pension.js
+++ b/app/pages/stories/stories/smart-pension.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import StoryPageNew from '../story-page-new';
+import Href from '../../../components/href/href';
 
 export default class StoriesSmartPension extends React.Component {
   displayName = 'StoriesSmartPension'


### PR DESCRIPTION
This rationalises how we link to developer resources from the splash pages, storing two URLs (`api_reference_link` and `developer_link` in the locale data) and then using them to build links using the `Href` component.

This allows us to, on the French site, correctly point to the French developer splash page at <https://developer.gocardless.com/fr>.