### PR TITLE
Updating en-GB site nav

### DIFF
--- a/app/components/footer/footer.js
+++ b/app/components/footer/footer.js
@@ -84,8 +84,8 @@ class Footer extends React.Component {
                 <Link to='faq_pro_dashboard' pointer='faq_pro_dashboard.link_title' className='page-footer__link u-link-invert' />
               </IfLinkExists>
               <li>
-                <Href to='developer_link' className='page-footer__link u-link-invert'>
-                  <Message pointer='api_docs.nav_title' />
+                <Href to='developers.path' id='track-footer-api-docs' className='page-footer__link u-link-invert'>
+                  <Message pointer='developers.nav_title' />
                 </Href>
               </li>
               <IfLinkExists to='security' tagName='li'>

--- a/app/components/header/header.js
+++ b/app/components/header/header.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import _ from 'lodash';
 import Link from '../link/link';
 import Href from '../href/href';
 import Message from '../message/message';
@@ -11,7 +12,7 @@ import classNames from 'classnames';
 import { PropTypes } from '../../helpers/prop-types/prop-types';
 import { filterRouteByCategory } from '../../router/route-helpers';
 
-class Header extends React.Component {
+export default class Header extends React.Component {
   displayName = 'Header'
 
   static defaultProps = {
@@ -27,207 +28,422 @@ class Header extends React.Component {
     availableLocales: PropTypes.array.isRequired,
   };
 
-  render() {
-    const { currentLocale, availableLocales } = this.context;
-
-    const isInverted = this.props.isInverted;
-    const linkClass = classNames('u-padding-Vl u-block', {
-      'u-link-invert': isInverted,
-      'u-link-default': !isInverted,
-    });
-
-    const products = (
-      <ul className='u-text-xxs u-padding-Vxs'>
-        <IfLinkExists to='features' tagName='li'>
-          <Link to='features' className='site-header__product-link u-link-clean'>
-            <span className='site-header__product-link-title u-text-semi'><Message pointer='features.nav_title' /></span>
-            <p className='u-color-dark-gray'><Message pointer='features.explainer' /></p>
-          </Link>
-
-          <hr className='u-margin-Vxs' />
-        </IfLinkExists>
-
-        <IfLinkExists to='pro' tagName='li'>
-          <Link to='pro' className='site-header__product-link u-link-clean'>
-            <span className='site-header__product-link-title u-text-semi'><Message pointer='pro.nav_title' /></span>
-            <p className='u-color-dark-gray'><Message pointer='pro.explainer' /></p>
-          </Link>
-        </IfLinkExists>
-
-        <IfLinkExists to='partner_with_us' tagName='li'>
-          <hr className='u-margin-Vxs' />
-
-          <Link to='partner_with_us' className='site-header__product-link u-link-clean'>
-            <span className='site-header__product-link-title u-text-semi'><Message pointer='partner_with_us.nav_title' /></span>
-            <p className='u-color-dark-gray'><Message pointer='partner_with_us.explainer' /></p>
-          </Link>
-        </IfLinkExists>
-      </ul>
-    );
-
-    const industryPages = filterRouteByCategory('industries', currentLocale, availableLocales);
-    const industries = (<ul className='u-text-xxs u-padding-Vxs'> {
-      industryPages.map((page) => {
-        return (
-          <li key={page.routeConfig.name} className='u-text-semi'>
-            <Link to={page.localeConfig.path} pointer={`${page.routeConfig.name}.nav_title`}
-              className='u-padding-Vxs u-padding-Hm u-block' />
-          </li>
-        );
-      })
-    } </ul>);
-
+  renderProductPopover() {
     return (
-      <div className={classNames({'site-header-wrapper': isInverted})}>
+      <Popover className='popover--large'
+      toggle={(
+        <a className={ this.getLinkClassName() }>
+          <div className={ this.getPopoverLinkClassName() }>
+            <Message pointer='header.our_products' />
+          </div>
+        </a>
+      )}>
+        <ul className='u-text-xxs u-padding-Vxs'>
+          { _.map(['features', 'pro', 'partner_with_us'], (link) =>
+            <IfLinkExists to={link}
+            tagName='li'
+            className='site-header__product'>
+              <Link to={link}
+              className='site-header__product-link u-link-clean'>
+                <span className='site-header__product-link-title u-text-semi'>
+                  <Message pointer={`${link}.nav_title`}/>
+                </span>
+
+                <p className='u-color-dark-gray'>
+                  <Message pointer={`${link}.explainer`}/>
+                </p>
+              </Link>
+
+              <hr className='site-header__product-link-hr u-margin-Vxs'/>
+            </IfLinkExists>
+        ) }
+        </ul>
+      </Popover>
+    );
+  }
+
+  getIndustryPages() {
+    return filterRouteByCategory(
+      'industries',
+      this.context.currentLocale,
+      this.context.availableLocales
+    );
+  }
+
+  renderIndustriesLinks() {
+    return _.map(this.getIndustryPages(), (page) => {
+      return (
+        <li key={page.routeConfig.name}>
+          <Link to={page.localeConfig.path}
+          pointer={`${page.routeConfig.name}.nav_title`}
+          className='u-padding-Vxs u-padding-Hm u-block' />
+        </li>
+      );
+    });
+  }
+
+  getHeaderClassName() {
+    return classNames(
+      {
+        'site-header-wrapper': this.props.isInverted,
+      }
+    );
+  }
+
+  getLinkClassName() {
+    return classNames(
+      'u-padding-Vl u-block',
+      {
+        'u-link-invert': this.props.isInverted,
+        'u-link-default': !this.props.isInverted,
+      }
+    );
+  }
+
+  getLogoClassName() {
+    return classNames(
+      'site-logo__image',
+      {
+        'u-fill-invert': this.props.isInverted,
+        'u-fill-primary': !this.props.isInverted,
+      }
+    );
+  }
+
+  getPopoverLinkClassName() {
+    return classNames(
+      'nav__item-link popover-link',
+      {
+        'popover-link--invert': this.props.isInverted,
+      },
+    );
+  }
+
+  renderMorePopover() {
+    return (
+      <Popover toggle={(
+        <a className={ this.getLinkClassName() }>
+          <div className={ this.getPopoverLinkClassName() }>
+            <Message pointer='header.more' />
+          </div>
+        </a>
+      )}>
+        <ul className='u-text-xxs u-padding-Vxs'>
+          <IfLinkExists to='stories'
+          tagName='li'
+          className='u-text-semi'>
+            <Link to='stories'
+            pointer='stories.nav_title'
+            className='u-padding-Vxs u-padding-Hm u-block'/>
+          </IfLinkExists>
+
+          <IfLinkExists to='security'
+          tagName='li'
+          className='u-text-semi'>
+            <Link to='security'
+            className='u-padding-Vxs u-padding-Hm u-block'
+            pointer='security.nav_title' />
+          </IfLinkExists>
+
+          <li className='u-text-semi'>
+            <Href to='guides.path'
+            className='u-padding-Vxs u-padding-Hm u-block'
+            pointer='guides.nav_title' />
+          </li>
+
+          <Translation locales='en-SE'
+          tagName='li'
+          className='u-text-semi'>
+            <Href to='guides_sv.path'
+            className='u-padding-Vxs u-padding-Hm u-block'
+            pointer='guides_sv.nav_title' />
+          </Translation>
+
+          <IfLinkExists to='faq_merchants'
+          tagName='li'
+          className='u-text-semi'>
+            <Link to='faq_merchants'
+            pointer='faq_merchants.link_title'
+            className='u-padding-Vxs u-padding-Hm u-block'/>
+          </IfLinkExists>
+
+          <IfLinkExists to='faq_pro_dashboard'
+          tagName='li'
+          className='u-text-semi'>
+            <Link to='faq_pro_dashboard'
+            pointer='faq_pro_dashboard.link_title'
+            className='u-padding-Vxs u-padding-Hm u-block'/>
+          </IfLinkExists>
+
+          <IfLinkExists to='partners'
+          tagName='li'
+          className='u-text-semi'>
+            <Link to='partners'
+            className='u-padding-Vxs u-padding-Hm u-block'
+            pointer='partners.nav_title' />
+          </IfLinkExists>
+
+          <hr className='u-margin-Vs' />
+
+          <IfLinkExists to='about'
+          tagName='li'>
+            <Link to='about'
+            pointer='about.nav_title'
+            className='u-padding-Vxs u-padding-Hm u-block'/>
+          </IfLinkExists>
+
+          <IfLinkExists to='jobs'
+          tagName='li'>
+            <Link to='jobs'
+            pointer='jobs.nav_title'
+            className='u-padding-Vxs u-padding-Hm u-block'/>
+          </IfLinkExists>
+        </ul>
+      </Popover>
+    );
+  }
+
+  renderAboutUsPopover() {
+    return (
+      <Popover toggle={(
+        <a className={ this.getLinkClassName() }>
+          <div className={ this.getPopoverLinkClassName() }>
+            <Message pointer='header.about_us' />
+          </div>
+        </a>
+      )}>
+        <ul className='u-text-xxs u-padding-Vxs'>
+          <li className='u-text-semi'>
+            <Link to='about'
+            tagName='li'
+            className='u-padding-Vxs u-padding-Hm u-block'
+            pointer='about.nav_title'/>
+          </li>
+
+          <li className='u-text-semi'>
+            <Link to='jobs'
+            tagName='li'
+            className='u-padding-Vxs u-padding-Hm u-block'
+            pointer='jobs.nav_title'/>
+          </li>
+
+          <li className='u-text-semi'>
+            <Href to='blog.path'
+            className='u-padding-Vxs u-padding-Hm u-block'
+            pointer='blog.nav_title' />
+          </li>
+
+          <li className='u-text-semi'>
+            <Link to='partner_with_us'
+            tagName='li'
+            className='u-padding-Vxs u-padding-Hm u-block'
+            pointer='partner_with_us.nav_title'/>
+          </li>
+
+          <li className='u-text-semi'>
+            <Link to='contact_sales'
+            tagName='li'
+            className='u-padding-Vxs u-padding-Hm u-block'
+            pointer='contact_sales.nav_title'/>
+          </li>
+        </ul>
+      </Popover>
+    );
+  }
+
+  renderHelpResourcesPopover() {
+    return (
+      <Popover toggle={(
+        <a id="help-resources-dropdown"  // For e2e test
+        className={ this.getLinkClassName() }>
+          <div className={ this.getPopoverLinkClassName() }>
+            <Message pointer='header.help_resources' />
+          </div>
+        </a>
+      )}>
+        <ul className='u-text-xxs u-padding-Vxs'>
+          <li className='u-text-semi'>
+            <Href to='help.path'
+            className='u-padding-Vxs u-padding-Hm u-block'
+            pointer='help.nav_title' />
+          </li>
+
+          <li className='u-text-semi'>
+            <Href to='guides.path'
+            className='u-padding-Vxs u-padding-Hm u-block'
+            pointer='guides.nav_title' />
+          </li>
+
+          <li className='u-text-semi'>
+            <Href to='api_docs.path'
+            className='u-padding-Vxs u-padding-Hm u-block'
+            pointer='api_docs.nav_title' />
+          </li>
+
+          <li className='u-text-semi'>
+            <Link to='faq_merchants'
+            tagName='li'
+            className='u-padding-Vxs u-padding-Hm u-block'
+            pointer='faq_merchants.nav_title'/>
+          </li>
+
+          <li className='u-text-semi'>
+            <Link to='security'
+            id="security-link" // For e2e test
+            tagName='li'
+            className='u-padding-Vxs u-padding-Hm u-block'
+            pointer='security.nav_title'/>
+          </li>
+        </ul>
+      </Popover>
+    );
+  }
+
+  renderSolutionsPopover() {
+    return (
+      <Popover toggle={(
+        <a className={ this.getLinkClassName() }>
+          <div className={ this.getPopoverLinkClassName() }>
+            <Message pointer='header.solutions' />
+          </div>
+        </a>
+      )}>
+        <ul className='u-text-xxs u-padding-Vxs'>
+          <Link to='small_medium_businesses'
+          tagName='li'
+          pointer='a_simple_direct_debit_solution.nav_title'
+          className='u-padding-Vxs u-padding-Hm u-block u-text-semi'/>
+
+          <Link to='new_to_direct_debit'
+          tagName='li'
+          pointer='new_to_direct_debit.nav_title'
+          className='u-padding-Vxs u-padding-Hm u-block u-text-semi'/>
+
+          <Link to='existing_direct_debit_user'
+          tagName='li'
+          pointer='optimise_your_direct_debit.nav_title'
+          className='u-padding-Vxs u-padding-Hm u-block u-text-semi'/>
+
+          <Link to='partners'
+          tagName='li'
+          pointer='partner_integrations.nav_title'
+          className='u-padding-Vxs u-padding-Hm u-block u-text-semi'/>
+
+          <Link to='integrate_features'
+          tagName='li'
+          pointer='integrate_features.nav_title'
+          className='u-padding-Vxs u-padding-Hm u-block u-text-semi'/>
+        </ul>
+      </Popover>
+    );
+  }
+
+  render() {
+    return (
+      <div className={ this.getHeaderClassName() }>
         <div className='site-header u-relative u-cf'>
           <div className='u-pull-start'>
-            <Link to='home' className='header-logo u-relative u-block u-padding-Vl'>
-              <Logo className={classNames('site-logo__image', {
-                'u-fill-invert': isInverted,
-                'u-fill-primary': !isInverted,
-              })} />
+            <Link to='home'
+            className='header-logo u-relative u-block u-padding-Vl u-pull-start'>
+              <Logo className={ this.getLogoClassName() }/>
             </Link>
-          </div>
-          <div className='u-pull-end align-btn-small'>
-            <nav className='nav u-pull-start u-color-primary u-text-xxs u-text-light u-text-no-smoothing'>
 
-              <Translation locales={availableLocales} exclude={['en-GB']} tagName='div' className='nav__item u-relative'>
-                <Popover className='popover--large' toggle={
-                   (<a className={linkClass}>
-                      <div className={classNames('nav__item-link popover-link', {
-                        'popover-link--invert': isInverted,
-                      })}>
-                        <Message pointer='header.our_products' />
-                      </div>
-                    </a>)
-                  }>
-                  {products}
-                </Popover>
+            <nav className='nav u-pull-start u-margin-Ll u-color-primary u-text-xxs u-text-light u-text-no-smoothing'>
+              <Translation locales={this.context.availableLocales}
+              exclude={['en-GB']}
+              tagName='div'
+              className='nav__item u-relative'>
+                { this.renderProductPopover() }
               </Translation>
 
-              <Translation locales='en-GB' tagName='div' className='nav__item u-relative'>
-                <IfLinkExists to='features'>
-                  <Link to='features' className={linkClass}>
-                    <div className='nav__item-link'>
-                      <Message pointer='features.nav_title' />
-                    </div>
-                  </Link>
-                </IfLinkExists>
+              <Translation locales='en-GB'
+              tagName='div'
+              className='nav__item u-relative'>
+                { this.renderSolutionsPopover() }
               </Translation>
 
-              <IfLinkExists to='pricing' tagName='div' className='nav__item u-relative'>
-                <Link to='pricing' className={linkClass}>
+              <IfLinkExists to='pricing'
+              tagName='div'
+              className='nav__item u-relative'>
+                <Link to='pricing'
+                className={ this.getLinkClassName() }>
                   <div className='nav__item-link'>
                     <Message pointer='pricing.nav_title' />
                   </div>
                 </Link>
               </IfLinkExists>
 
-              <Translation locales={['en-GB']} tagName='div' className='nav__item u-relative'>
-                <Popover toggle={
-                   (<a className={linkClass}>
-                      <div className={classNames('nav__item-link popover-link', {
-                        'popover-link--invert': isInverted,
-                      })}>
-                        <Message pointer='header.industries' />
-                      </div>
-                    </a>)
-                  }>
-                  {industries}
+              <Translation locales={['en-GB']}
+              tagName='div'
+              className='nav__item u-relative'>
+                <Popover toggle={(
+                  <a className={ this.getLinkClassName() }>
+                    <div className={ this.getPopoverLinkClassName() }>
+                      <Message pointer='header.who_uses_us' />
+                    </div>
+                  </a>
+                )}>
+                  <ul className='u-text-xxs u-padding-Vxs'>
+                    <Link to='stories'
+                    tagName='li'
+                    pointer='stories.nav_title'
+                    className='u-padding-Vxs u-padding-Hm u-block u-text-semi'/>
+
+                    <hr className='u-margin-Vs'/>
+
+                    { this.renderIndustriesLinks() }
+                  </ul>
                 </Popover>
               </Translation>
 
               <div className='nav__item u-relative'>
-                <Href to='developer_link' className={linkClass}>
+                <Href to='developers.path'
+                className={ this.getLinkClassName() }>
                   <div className='nav__item-link'>
-                    <Message pointer='api_docs.nav_title' />
+                    <Message pointer='developers.nav_title' />
                   </div>
                 </Href>
               </div>
-
-              <div className='nav__item u-relative'>
-                <Popover toggle={
-                  (<a id='nav-more'
-                  className={linkClass}>{/* id on this element for e2e tests */}
-                    <div className={classNames('nav__item-link popover-link', {
-                      'popover-link--invert': isInverted,
-                    })}>
-                      <Message pointer='header.more' />
-                    </div>
-                  </a>)
-                }>
-                  <ul className='u-text-xxs u-padding-Vxs'>
-                    <IfLinkExists to='stories' tagName='li' className='u-text-semi'>
-                      <Link to='stories' pointer='stories.nav_title'
-                      className='u-padding-Vxs u-padding-Hm u-block' />
-                    </IfLinkExists>
-
-                    <IfLinkExists to='security' tagName='li' className='u-text-semi'>
-                      <Link to='security'
-                      id='nav-security'
-                      className='u-padding-Vxs u-padding-Hm u-block'
-                      pointer='security.nav_title' />{/* id on this element for e2e tests */}
-                    </IfLinkExists>
-
-                    <li className='u-text-semi'>
-                      <Href to='guides.path' className='u-padding-Vxs u-padding-Hm u-block'
-                        pointer='guides.nav_title' />
-                    </li>
-
-                    <Translation locales='en-SE' tagName='li' className='u-text-semi'>
-                      <Href to='guides_sv.path' className='u-padding-Vxs u-padding-Hm u-block' pointer='guides_sv.nav_title' />
-                    </Translation>
-
-                    <Translation locales='en-GB' tagName='li' className='u-text-semi'>
-                      <a href='https://support.gocardless.com' className='u-padding-Vxs u-padding-Hm u-block'>
-                        <Message pointer='help.nav_title' />
-                      </a>
-                    </Translation>
-
-                    <IfLinkExists to='faq_merchants' tagName='li' className='u-text-semi'>
-                      <Link to='faq_merchants' pointer='faq_merchants.link_title'
-                      className='u-padding-Vxs u-padding-Hm u-block' />
-                    </IfLinkExists>
-
-                    <IfLinkExists to='faq_pro_dashboard' tagName='li' className='u-text-semi'>
-                      <Link to='faq_pro_dashboard' pointer='faq_pro_dashboard.link_title'
-                      className='u-padding-Vxs u-padding-Hm u-block' />
-                    </IfLinkExists>
-
-                    <IfLinkExists to='partners' tagName='li' className='u-text-semi'>
-                      <Link to='partners' className='u-padding-Vxs u-padding-Hm u-block'
-                      pointer='partners.nav_title' />
-                    </IfLinkExists>
-
-                    <IfLinkExists to='partner_with_us' tagName='li' className='u-text-semi'>
-                      <Link to='partner_with_us' className='u-padding-Vxs u-padding-Hm u-block'
-                      pointer='partner_with_us.nav_title' />
-                    </IfLinkExists>
-
-                    <hr className='u-margin-Vs' />
-
-                    <IfLinkExists to='about' tagName='li'>
-                      <Link to='about' pointer='about.nav_title'
-                      className='u-padding-Vxs u-padding-Hm u-block' />
-                    </IfLinkExists>
-
-                    <IfLinkExists to='jobs' tagName='li'>
-                      <Link to='jobs' pointer='jobs.nav_title'
-                      className='u-padding-Vxs u-padding-Hm u-block' />
-                    </IfLinkExists>
-                  </ul>
-                </Popover>
-              </div>
             </nav>
-            <IfLocale hasInstantSignup tagName='ul' className='u-pull-start u-cf'>
+          </div>
+
+          <div className='u-pull-end align-btn-small'>
+            <nav className='nav u-pull-start u-color-primary u-text-xxs u-text-light u-text-no-smoothing'>
+              <Translation locales={['en-GB']}
+              tagName='div'
+              className='nav__item u-relative'>
+                { this.renderHelpResourcesPopover() }
+              </Translation>
+
+              <Translation locales={['en-GB']}
+              tagName='div'
+              className='nav__item u-relative'>
+                { this.renderAboutUsPopover() }
+              </Translation>
+
+              <Translation locales={this.context.availableLocales}
+              exclude={['en-GB']}
+              tagName='div'
+              className='nav__item u-relative'>
+                { this.renderMorePopover() }
+              </Translation>
+            </nav>
+
+            <IfLocale hasInstantSignup
+            tagName='ul'
+            className='u-pull-start u-cf'>
               <li className='u-pull-start'>
                 <Href to='signin.path'
-                className={classNames('nav-btn btn btn--small u-text-light u-text-xxs u-relative',
-                  'u-text-transform-none u-text-no-smoothing', {
-                  'btn--invert-hollow': isInverted,
-                  'btn--hollow': !isInverted,
-                })}
-                pointer='header.login_btn' />
+                className={ classNames(
+                    'nav-btn btn btn--small u-text-light u-text-xxs u-relative',
+                    'u-text-transform-none u-text-no-smoothing',
+                    {
+                      'btn--invert-hollow': this.props.isInverted,
+                      'btn--hollow': !this.props.isInverted,
+                    }
+                  )
+                }
+                pointer='header.login_btn'/>
               </li>
             </IfLocale>
           </div>
@@ -236,5 +452,3 @@ class Header extends React.Component {
     );
   }
 }
-
-export default Header;

--- a/app/css/components/header-logo.scss
+++ b/app/css/components/header-logo.scss
@@ -1,3 +1,0 @@
-.header-logo {
-  top: 2px;
-}

--- a/app/css/components/site-header.scss
+++ b/app/css/components/site-header.scss
@@ -11,6 +11,11 @@
 .site-header-wrapper {
   position: absolute;
   width: 100%;
+  min-width: 900px;
+}
+
+.site-header__product:last-of-type .site-header__product-link-hr {
+  display: none;
 }
 
 .site-header__product-link {

--- a/app/css/main.scss
+++ b/app/css/main.scss
@@ -30,7 +30,6 @@
 @import "components/faq-page";
 @import "components/flag-icon";
 @import "components/grid";
-@import "components/header-logo";
 @import "components/highlight";
 @import "components/highlight-text";
 @import "components/horizontal-rule";

--- a/app/messages/de.js
+++ b/app/messages/de.js
@@ -42,6 +42,7 @@ export default {
   phone_full: '+49 30 568373022',
   phone_local: '+49 30 568373022',
   email: 'deutschland@gocardless.com',
+  partners_email: 'partnerships@gocardless.com',
   prospect_form: {
     sales: {
       name_label: 'Ihr Name',
@@ -214,6 +215,11 @@ export default {
   api_docs: {
     title: 'API-Dokumentation',
     nav_title: 'API-Dokumentation',
+    path: 'https://developer.gocardless.com/api-reference',
+  },
+  developers: {
+    nav_title: 'API-Dokumentation',
+    path: 'https://developer.gocardless.com',
   },
   blog: {
     title: 'Blog',

--- a/app/messages/en.js
+++ b/app/messages/en.js
@@ -1,9 +1,12 @@
 export default {
   header: {
     our_products: 'Our products',
-    industries: 'Industries',
+    who_uses_us: 'Who uses us?',
     login_btn: 'Sign in',
     more: 'More',
+    help_resources: 'Help & resources',
+    about_us: 'About us',
+    solutions: 'Solutions',
   },
   footer: {
     description: 'GoCardless is regulated by the Financial Conduct Authority in the United Kingdom as an Authorised Payment Institution to collect payments across Europe.',
@@ -32,6 +35,17 @@ export default {
     desc: 'GoCardless makes collecting by Direct Debit easy for everyone from individuals to multi-national corporations',
   },
   contact_types: ['customer support', 'sales'],
+  postal_address: {
+    street_address: '338-346 Goswell Road',
+    address_locality: 'London',
+    postal_code: 'EC1V 7LQ',
+    address_country: 'United Kingdom',
+    address_country_iso: 'GB',
+  },
+  phone_full: '+44 20 7183 8674',
+  phone_local: '+44 20 7183 8674',
+  email: 'help@gocardless.com',
+  partners_email: 'partnerships@gocardless.com',
   prospect_form: {
     sales: {
       name_label: 'Your name',
@@ -46,6 +60,28 @@ export default {
       submit: 'Contact',
       success_message: 'Thank you, a member of the GoCardless team will be in touch soon.',
     },
+  },
+  a_simple_direct_debit_solution: {
+    title: 'A Simple Direct Debit Solution',
+    nav_title: 'A Simple Direct Debit Solution',
+  },
+  new_to_direct_debit: {
+    title: 'New to Direct Debit',
+    nav_title: 'New to Direct Debit',
+    description: '',
+  },
+  optimise_your_direct_debit: {
+    title: 'Optimise your Direct Debit',
+    nav_title: 'Optimise your Direct Debit',
+  },
+  partner_integrations: {
+    title: 'Partner integrations',
+    nav_title: 'Partner integrations',
+  },
+  integrate_features: {
+    title: 'Integrate with our API',
+    nav_title: 'Integrate with our API',
+    description: '',
   },
   not_found: {
     title: 'Not Found',
@@ -211,10 +247,6 @@ export default {
     nav_title: 'Payout tracking',
     description: '',
   },
-  new_to_direct_debit: {
-    title: 'New to Direct Debit',
-    description: '',
-  },
   existing_direct_debit_user: {
     title: 'Existing Direct Debit user',
     description: '',
@@ -225,10 +257,6 @@ export default {
   },
   developer_features: {
     title: 'GoCardless for Developers',
-    description: '',
-  },
-  integrate_features: {
-    title: 'Integrate with us',
     description: '',
   },
   security: {
@@ -243,7 +271,7 @@ export default {
   },
   stories: {
     title: 'Stories',
-    nav_title: 'Stories',
+    nav_title: 'Customer stories',
     description: '',
     link: 'Read the case study',
     key_benefits: 'Key benefits',
@@ -634,11 +662,18 @@ export default {
   },
   api_docs: {
     title: 'API Documentation',
+    nav_title: 'API Documentation',
+    path: 'https://developer.gocardless.com/api-reference',
+  },
+  developers: {
+    title: 'Developers',
     nav_title: 'Developers',
+    path: 'https://developer.gocardless.com',
   },
   blog: {
     title: 'Blog',
     nav_title: 'Blog',
+    path: '/blog',
     cta: 'Visit our Blog',
   },
   guides: {
@@ -647,8 +682,9 @@ export default {
     path: '/guides',
   },
   help: {
-    title: 'Support',
-    nav_title: 'Support',
+    title: 'Support Centre',
+    nav_title: 'Support Centre',
+    path: 'https://support.gocardless.com',
   },
   'how-to': {
     title: 'How to',

--- a/app/messages/es.js
+++ b/app/messages/es.js
@@ -39,6 +39,7 @@ export default {
     address_country: 'Reino Unido',
     address_country_iso: 'GB',
   },
+  partners_email: 'partnerships@gocardless.com',
   prospect_form: {
     sales: {
       name_label: 'Nombre',
@@ -276,6 +277,11 @@ export default {
   api_docs: {
     title: 'API',
     nav_title: 'API',
+    path: 'https://developer.gocardless.com/api-reference',
+  },
+  developers: {
+    nav_title: 'API',
+    path: 'https://developer.gocardless.com',
   },
   signin: {
     path: 'https://manage.gocardless.com',

--- a/app/messages/fr.js
+++ b/app/messages/fr.js
@@ -302,6 +302,11 @@ export default {
   api_docs: {
     title: 'Documentation API',
     nav_title: 'Documentation API',
+    path: 'https://developer.gocardless.com/api-reference',
+  },
+  developers: {
+    nav_title: 'Documentation API',
+    path: 'https://developer.gocardless.com/fr',
   },
   security: {
     title: 'Sécurité',

--- a/app/messages/nl-BE.js
+++ b/app/messages/nl-BE.js
@@ -23,8 +23,6 @@ export default {
   phone_full: '+32 78 483 170',
   phone_local: '078 483 170',
   partners_email: 'belgium@gocardless.com',
-  api_reference_link: 'https://developer.gocardless.com/api-reference',
-  developer_link: 'https://developer.gocardless.com',
   home: {
     title: 'De eenvoudige manier om terugkerende betalingen te incasseren',
     nav_title: 'Start',

--- a/app/messages/nl.js
+++ b/app/messages/nl.js
@@ -95,9 +95,14 @@ export default {
     description: '',
     nav_title: 'Team',
   },
+  developers: {
+    nav_title: 'API Documentatie',
+    path: 'https://developer.gocardless.com',
+  },
   api_docs: {
     title: 'API Documentatie',
     nav_title: 'API Documentatie',
+    path: 'https://developer.gocardless.com/api-reference',
   },
   blog: {
     title: 'Blog',

--- a/app/messages/pt.js
+++ b/app/messages/pt.js
@@ -55,6 +55,7 @@ export default {
   api_docs: {
     title: 'Documentação da API',
     nav_title: 'API',
+    path: 'https://developer.gocardless.com/api-reference',
   },
   blog: {
     title: 'Blog',
@@ -65,5 +66,9 @@ export default {
     title: 'Guias',
     nav_title: 'Guias',
     path: '/guides',
+  },
+  developers: {
+    nav_title: 'API',
+    path: 'https://developer.gocardless.com',
   },
 };

--- a/app/messages/shared.js
+++ b/app/messages/shared.js
@@ -27,7 +27,11 @@ export default {
   email: 'help@gocardless.com',
   partners_email: 'partnerships@gocardless.com',
   customer_queries_link: 'https://support.gocardless.com/hc/en-us/sections/202581129-Customer-Queries',
-  api_reference_link: 'https://developer.gocardless.com/api-reference',
-  developer_link: 'https://developer.gocardless.com',
+  developers: {
+    path: 'https://developer.gocardless.com',
+  },
+  api_docs: {
+    path: 'https://developer.gocardless.com/api-reference',
+  },
   press_email: 'press@gocardless.com',
 };

--- a/app/pages/developer-features/developer-features.js
+++ b/app/pages/developer-features/developer-features.js
@@ -115,7 +115,7 @@ export default class DeveloperFeatures extends React.Component {
                   Get a sandbox account
                 </a>
 
-                <Href to='developer_link'
+                <Href to='api_docs.path'
                 className='btn btn--invert-hollow u-margin-Tl'>
                   View our developer docs
                 </Href>
@@ -264,7 +264,7 @@ export default class DeveloperFeatures extends React.Component {
 
               <p className='u-color-dark-gray u-margin-Tm'>
                 Want to learn more about getting started?&nbsp;
-                <Href to='developer_link'>
+                <Href to='api_docs.path'>
                   Read our reference docs
                 </Href>
               </p>

--- a/app/pages/faq/merchants/developer-api/faq-merchants-developer-api.de.js
+++ b/app/pages/faq/merchants/developer-api/faq-merchants-developer-api.de.js
@@ -15,7 +15,7 @@ export default class FaqMerchantsDeveloperApiDe extends React.Component {
         </h3>
         <p className='para'>
           Unsere REST API erlaubt es Entwicklern auf einfachstem Weg mit GoCardless zu integrieren. Lernen Sie dazu
-          mehr in unserer <Href to='api_reference_link' className='u-link-color-p u-text-underline'>Dokumentation</Href>.
+          mehr in unserer <Href to='api_docs.path' className='u-link-color-p u-text-underline'>Dokumentation</Href>.
         </p>
         <p className='para'>
           Sie können GoCardless integrieren, um Lastschriften von Ihren Kunden bequem über Ihr CRM Tool oder

--- a/app/pages/faq/merchants/developer-api/faq-merchants-developer-api.en.js
+++ b/app/pages/faq/merchants/developer-api/faq-merchants-developer-api.en.js
@@ -16,7 +16,7 @@ export default class FaqMerchantsDeveloperApiEn extends React.Component {
         </h3>
         <p className='para'>
           Our REST API allows developers to easily create powerful integrations with GoCardless.
-          See our <Href to='api_reference_link' className='u-link-color-p u-text-underline'>documentation</Href> to
+          See our <Href to='api_docs.path' className='u-link-color-p u-text-underline'>documentation</Href> to
           find out more.
         </p>
         <Translation locales={['en']} exclude={['en-GB','en-IE']}>

--- a/app/pages/faq/merchants/developer-api/faq-merchants-developer-api.es.js
+++ b/app/pages/faq/merchants/developer-api/faq-merchants-developer-api.es.js
@@ -18,7 +18,7 @@ export default class FaqMerchantsDeveloperApiEs extends React.Component {
         </h3>
         <p className='para'>
           Nuestra API REST permite a los desarrolladores crear fácilmente integraciones potentes con GoCardless.
-          Consulta nuestra <Href to='api_reference_link' className='u-link-color-p u-text-underline'>documentación</Href> para
+          Consulta nuestra <Href to='api_docs.path' className='u-link-color-p u-text-underline'>documentación</Href> para
           obtener más información.
         </p>
         <p className='para'>

--- a/app/pages/faq/merchants/developer-api/faq-merchants-developer-api.fr.js
+++ b/app/pages/faq/merchants/developer-api/faq-merchants-developer-api.fr.js
@@ -14,7 +14,7 @@ export default class FaqMerchantsDeveloperApiFr extends React.Component {
         </h3>
         <p className='para'>
           Notre API REST donne la possibilité aux développeurs de facilement intégrer GoCardless. Apprenez en
-          plus sur notre <Href to='api_reference_link' className='u-link-color-p u-text-underline'>documentation</Href>.
+          plus sur notre <Href to='api_docs.path' className='u-link-color-p u-text-underline'>documentation</Href>.
         </p>
         <p className='para'>
           Vous pouvez intégrer GoCardless pour prendre des paiements via prélèvement bancaire

--- a/app/pages/faq/merchants/how-it-works/faq-merchants-how-it-works.en.js
+++ b/app/pages/faq/merchants/how-it-works/faq-merchants-how-it-works.en.js
@@ -59,7 +59,7 @@ export default class FaqMerchantsHowItWorksEn extends React.Component {
           Can customers sign up on my website?
         </h3>
         <p className='para'>
-          Yes - you can either do this by integrating with our <Href to="developer_link" className='u-link-color-p u-text-underline'>API</Href> or by generating a link for a payment
+          Yes - you can either do this by integrating with our <Href to="developers.path" className='u-link-color-p u-text-underline'>API</Href> or by generating a link for a payment
           plan and embedding this as a button on your website.
         </p>
         <p className='para'>

--- a/app/pages/faq/merchants/how-it-works/faq-merchants-how-it-works.es.js
+++ b/app/pages/faq/merchants/how-it-works/faq-merchants-how-it-works.es.js
@@ -77,7 +77,7 @@ export default class FaqMerchantsHowItWorksEs extends React.Component {
         </h3>
         <p className='para'>
           Sí - los clientes pueden autorizar el Mandato SEPA en tu propio flujo de venta, bien a través de una integración
-          con nuestra <Href to='developer_link' className='u-link-color-p u-text-underline'>API</Href> o
+          con nuestra <Href to='developers.path' className='u-link-color-p u-text-underline'>API</Href> o
           generando un enlace para un plan de cobros e incrustándolo como botón en tu propio sitio web.
         </p>
         <p className='para'>

--- a/app/pages/faq/merchants/overview/faq-merchants-overview.de.js
+++ b/app/pages/faq/merchants/overview/faq-merchants-overview.de.js
@@ -25,7 +25,7 @@ export default class FaqMerchantsDe extends React.Component {
           </li>
           <li>
             <strong>Über unsere REST API</strong> - Integrieren Sie GoCardless nahtlos in Ihre Website mit
-            unserer <Href to='api_reference_link' className='u-link-color-p u-text-underline'>REST API</Href>.
+            unserer <Href to='api_docs.path' className='u-link-color-p u-text-underline'>REST API</Href>.
           </li>
         </ul>
 
@@ -125,7 +125,7 @@ export default class FaqMerchantsDe extends React.Component {
           <li>
             <strong>Clevere Technik</strong> - Wir bieten Ihnen eine hochklassige Lösung, um Zahlungen zu kreieren, zu bearbeiten
             und zu verwalten. Das funktioniert über unser einfaches Online Dashboard und
-            die <Href to='api_reference_link' className='u-link-color-p u-text-underline'>REST API</Href>.
+            die <Href to='api_docs.path' className='u-link-color-p u-text-underline'>REST API</Href>.
           </li>
           <li>
             <strong>Der persönliche Bezug</strong> - Unser Team ist immer bemüht Sie bestens zu unterstützen und geht dabei regelmäßig

--- a/app/pages/faq/merchants/overview/faq-merchants-overview.en.js
+++ b/app/pages/faq/merchants/overview/faq-merchants-overview.en.js
@@ -26,7 +26,7 @@ export default class FaqMerchantsEn extends React.Component {
             </li>
             <li>
               <strong>Our clean, RESTful API</strong> - Integrate GoCardless into your website using
-              our <Href to='developer_link' className='u-link-color-p u-text-underline'>REST API</Href>.
+              our <Href to='developers.path' className='u-link-color-p u-text-underline'>REST API</Href>.
             </li>
           </ul>
         </Translation>
@@ -46,7 +46,7 @@ export default class FaqMerchantsEn extends React.Component {
             </li>
             <li>
               <strong>Our clean, RESTful API</strong> - Integrate GoCardless into your website using
-              our <Href to='developer_link' className='u-link-color-p u-text-underline'>REST API</Href>.
+              our <Href to='developers.path' className='u-link-color-p u-text-underline'>REST API</Href>.
             </li>
           </ul>
         </Translation>
@@ -161,7 +161,7 @@ export default class FaqMerchantsEn extends React.Component {
           </IfLocale>
           <li>
             <strong>Powerful tools that suit you</strong> - Everything you need to set up, collect
-            and manage Direct Debit payments with our simple online tool or <Href to='developer_link'
+            and manage Direct Debit payments with our simple online tool or <Href to='developers.path'
             className='u-link-color-p u-text-underline'>REST API</Href>.
           </li>
           <li>

--- a/app/pages/faq/merchants/overview/faq-merchants-overview.es.js
+++ b/app/pages/faq/merchants/overview/faq-merchants-overview.es.js
@@ -32,7 +32,7 @@ export default class FaqMerchantsEs extends React.Component {
           </li>
           <li>
             <strong>Nuestra sencilla API REST</strong> - Integra GoCardless en tu sitio web usando
-            nuestra <Href to='developer_link' className='u-link-color-p u-text-underline'>API REST</Href>.
+            nuestra <Href to='developers.path' className='u-link-color-p u-text-underline'>API REST</Href>.
           </li>
         </ul>
         <h3 className='u-color-dark-gray u-margin-Txl u-margin-Bm u-text-s'>
@@ -154,7 +154,7 @@ export default class FaqMerchantsEs extends React.Component {
           </IfLocale>
           <li>
             <strong>Potentes herramientas que se adaptan a tus necesidades</strong> - Tienes todo lo que necesitas para realizar,
-            recaudar y gestionar cobros de Adeudo Directo con nuestro sencillo panel de control o <Href to='developer_link'
+            recaudar y gestionar cobros de Adeudo Directo con nuestro sencillo panel de control o <Href to='developers.path'
             className='u-link-color-p u-text-underline'>nuestra API REST</Href>.
           </li>
           <li>

--- a/app/pages/faq/merchants/overview/faq-merchants-overview.fr.js
+++ b/app/pages/faq/merchants/overview/faq-merchants-overview.fr.js
@@ -23,7 +23,7 @@ export default class FaqMerchantsFr extends React.Component {
           </li>
           <li>
             <strong>GoCardless Pro</strong> - Automatisez vos prélèvements en intégrant
-            notre <Href to='developer_link' className='u-link-color-p u-text-underline'>REST
+            notre <Href to='developers.path' className='u-link-color-p u-text-underline'>REST
             API</Href> dans votre site internet et vos systèmes informatiques.
           </li>
           <li>
@@ -69,7 +69,7 @@ export default class FaqMerchantsFr extends React.Component {
           </li>
           <li>
             <strong>Évoluez facilement</strong> - Notre tableau de bord est propulsé par
-            notre <Href to='developer_link' className='u-link-color-p u-text-underline'>API REST</Href>.
+            notre <Href to='developers.path' className='u-link-color-p u-text-underline'>API REST</Href>.
             Ceci vous permet de facilement évoluer vers l'API afin d'automatiser plus en profondeur au fur et
             à mesure.
           </li>

--- a/app/pages/faq/merchants/signing-up/faq-merchants-signing-up.de.js
+++ b/app/pages/faq/merchants/signing-up/faq-merchants-signing-up.de.js
@@ -48,7 +48,7 @@ export default class FaqMerchantsSigningUpDe extends React.Component {
         <p className='para'>
           Entwickler sollten sich ganz normal <Href to='signup.path' className='u-link-color-p u-text-underline'>anmelden</Href>. Sobald
           Sie angemeldet sind, können Sie Ihren Entwickler Account freischalten. Unsere API Dokumentation
-          ist <Href to='api_reference_link' className='u-link-color-p u-text-underline'>hier</Href> verfügbar.
+          ist <Href to='api_docs.path' className='u-link-color-p u-text-underline'>hier</Href> verfügbar.
         </p>
 
         <h3 className='u-color-dark-gray u-margin-Txl u-margin-Bm u-text-s'>

--- a/app/pages/faq/merchants/signing-up/faq-merchants-signing-up.en.js
+++ b/app/pages/faq/merchants/signing-up/faq-merchants-signing-up.en.js
@@ -53,7 +53,7 @@ export default class FaqMerchantsSigningUpEn extends React.Component {
           </h3>
           <p className='para'>
             Developers should sign up as normal. Our API documentation can be viewed
-            <Href to='api_reference_link' className='u-link-color-p u-text-underline'> here</Href>.
+            <Href to='api_docs.path' className='u-link-color-p u-text-underline'> here</Href>.
           </p>
         </Translation>
 

--- a/app/pages/faq/merchants/signing-up/faq-merchants-signing-up.es.js
+++ b/app/pages/faq/merchants/signing-up/faq-merchants-signing-up.es.js
@@ -66,7 +66,7 @@ export default class FaqMerchantsSigningUpEs extends React.Component {
         </h3>
         <p className='para'>
           Los desarrolladores deberán registrarse normalmente. Nuestra documentación de la API la
-          puedes encontrar <Href to='api_reference_link' className='u-link-color-p u-text-underline'>aquí</Href>.
+          puedes encontrar <Href to='api_docs.path' className='u-link-color-p u-text-underline'>aquí</Href>.
         </p>
 
         <h3 className='u-color-dark-gray u-margin-Txl u-margin-Bm u-text-s'>

--- a/app/pages/features/features.de.js
+++ b/app/pages/features/features.de.js
@@ -167,7 +167,7 @@ export default class FeaturesDe extends React.Component {
                     </div>
                     <p className='u-color-dark-gray u-margin-Txs'>
                       Integrieren Sie GoCardless innerhalb von Minuten in Ihre Website oder App über unsere benutzerfreundlichen
-                      API-Bibliotheken. <Href to='developer_link'>Mehr dazu</Href>.
+                      API-Bibliotheken. <Href to='developers.path'>Mehr dazu</Href>.
                     </p>
                   </div>
                 </div>

--- a/app/pages/features/features.en.js
+++ b/app/pages/features/features.en.js
@@ -280,7 +280,7 @@ export default class FeaturesEn extends React.Component {
                   <p className='u-color-dark-gray u-padding-Vm'>
                     Want to use GoCardless to power payments on your site? Take a look at our REST API in the comprehensive docs.
                   </p>
-                  <Href to='developer_link' className='u-color-primary u-text-upcase u-text-xxs u-text-heading u-text-semi'>
+                  <Href to='developers.path' className='u-color-primary u-text-upcase u-text-xxs u-text-heading u-text-semi'>
                     Learn more
                   </Href>
                 </div>

--- a/app/pages/features/features.es.js
+++ b/app/pages/features/features.es.js
@@ -182,7 +182,7 @@ export default class FeaturesEs extends React.Component {
                     </div>
                       <p className='u-color-dark-gray u-margin-Txs'>
                         Añade GoCardless a tu web o app en minutos con nuestras librerias API.&nbsp;
-                        <Href to='developer_link'>Descubre más</Href>.
+                        <Href to='developers.path'>Descubre más</Href>.
                       </p>
                   </div>
                 </div>

--- a/app/pages/features/features.nl.js
+++ b/app/pages/features/features.nl.js
@@ -166,7 +166,7 @@ export default class FeaturesNl extends React.Component {
                       Gebruiksvriendelijke, RESTful API
                     </div>
                     <p className='u-color-dark-gray u-margin-Txs'>
-                      Voeg GoCardless in enkele minuten toe aan je website of app met onze gebruiksvriendelijke API. <Href to='developer_link'>Lees meer</Href>.
+                      Voeg GoCardless in enkele minuten toe aan je website of app met onze gebruiksvriendelijke API. <Href to='developers.path'>Lees meer</Href>.
                     </p>
                   </div>
                 </div>

--- a/app/pages/home/home.e2e.js
+++ b/app/pages/home/home.e2e.js
@@ -7,8 +7,8 @@ describe('Swapping languages', function() {
   it('lets you navigate to a page and then swap languages', function() {
     browser.get(BASE_URL);
 
-    $('#nav-more').click();
-    $('#nav-security').click();
+    $('#help-resources-dropdown').click();
+    $('#security-link').click();
 
     browser.wait(EC.textToBePresentInElement($('body'), 'Built securely from the ground up'), 5000);
 

--- a/app/pages/integrate-features/integrate-features.js
+++ b/app/pages/integrate-features/integrate-features.js
@@ -84,7 +84,7 @@ export default class IntegrateFeatures extends React.Component {
           </div>
 
           <p className='u-text-s u-text-center u-color-dark-gray u-padding-Vxl'>See our&nbsp;
-            <Href to='developer_link'>
+            <Href to='api_docs.path'>
               API reference docs
             </Href></p>
         </div>

--- a/app/pages/legal/merchants/legal-merchants.en.js
+++ b/app/pages/legal/merchants/legal-merchants.en.js
@@ -335,7 +335,7 @@ export default class LegalMerchantsEn extends React.Component {
 
         <div className='simple-terms'>
           <p className='para'>
-            You can use our API in line with the <Href to='api_reference_link' className='u-link-color-p u-text-underline'>documentation we provide for it</Href>, but not in any other way. We might require you to update certain software to work with the service.
+            You can use our API in line with the <Href to='api_docs.path' className='u-link-color-p u-text-underline'>documentation we provide for it</Href>, but not in any other way. We might require you to update certain software to work with the service.
           </p>
         </div>
 

--- a/app/pages/pro/pro.de.js
+++ b/app/pages/pro/pro.de.js
@@ -57,7 +57,8 @@ export default class ProDe extends React.Component {
               }>
                 <Message pointer='cta.pro' />
               </Link>
-              <Href to='api_reference_link'
+
+              <Href to='api_docs.path'
               className='u-pull-end u-margin-Txxs u-margin-Rm'>
                 API Dokumentation
               </Href>
@@ -100,7 +101,7 @@ export default class ProDe extends React.Component {
                     </div>
                     <p className='u-size-4of5 u-center u-color-dark-gray u-margin-Txs'>
                       Die komplette Dokumentation zu GoCardless Pro ist kostenlos in
-                      unseren <Href to='api_reference_link'>API docs</Href> verfügbar.
+                      unseren <Href to='api_docs.path'>API docs</Href> verfügbar.
                       Wir haben hart daran gearbeitet, die Integration für Sie so einfach wie möglich zu gestalten.
                     </p>
                   </div>

--- a/app/pages/pro/pro.en.js
+++ b/app/pages/pro/pro.en.js
@@ -51,7 +51,8 @@ export default class ProEn extends React.Component {
               }>
                 <Message pointer='cta.pro' />
               </Link>
-              <Href to='api_reference_link'
+
+              <Href to='api_docs.path'
               className='u-pull-end u-margin-Txxs u-margin-Rm'>
                 API Documentation
               </Href>
@@ -89,7 +90,7 @@ export default class ProEn extends React.Component {
                     </div>
                     <p className='u-size-4of5 u-center u-color-dark-gray u-margin-Txs'>
                       All documentation for our Pro product is freely available in
-                      our <Href to='api_reference_link'>API docs</Href>.
+                      our <Href to='api_docs.path'>API docs</Href>.
                       We’ve worked hard to make integrating your systems as painless as possible.
                     </p>
                   </div>

--- a/app/pages/pro/pro.es.js
+++ b/app/pages/pro/pro.es.js
@@ -58,7 +58,8 @@ export default class ProEs extends React.Component {
               }>
                 <Message pointer='cta.pro' />
               </Link>
-              <Href to='api_reference_link'
+
+              <Href to='api_docs.path'
               className='u-pull-end u-margin-Txxs u-margin-Rm'>
                 Documentación API
               </Href>
@@ -102,7 +103,7 @@ export default class ProEs extends React.Component {
                     </div>
                     <p className='u-size-4of5 u-center u-color-dark-gray u-margin-Txs'>
                       Toda la documentación de Pro está disponible gratuitamente en
-                      nuestra <Href to='api_reference_link'>documentación de la API</Href>.
+                      nuestra <Href to='api_docs.path'>documentación de la API</Href>.
                       Hemos trabajado muy duro para que la integración de tu empresa sea tan sencilla como sea posible.
                     </p>
                   </div>

--- a/app/pages/pro/pro.fr.js
+++ b/app/pages/pro/pro.fr.js
@@ -51,7 +51,7 @@ export default class ProFr extends React.Component {
               }>
               Contactez-nous
             </Link>
-            <Href to='api_reference_link' className='u-pull-end u-margin-Txxs u-margin-Rm'>
+            <Href to='api_docs.path' className='u-pull-end u-margin-Txxs u-margin-Rm'>
               Documentation API
             </Href>
           </div>
@@ -95,7 +95,7 @@ export default class ProFr extends React.Component {
                   <p className='u-size-4of5 u-center u-color-dark-gray u-margin-Txs'>
                     Intégrez l'API REST de GoCardless rapidement dans votre site web et vos systèmes
                     d'information. Découvrez notre
-                    <Href to='api_reference_link'> documentation</Href>.
+                    <Href to='api_docs.path'> documentation</Href>.
                   </p>
                 </div>
                 <div className='grid__cell u-size-1of2 u-text-center u-margin-Txxl u-padding-Txxl'>

--- a/app/pages/pro/pro.nl.js
+++ b/app/pages/pro/pro.nl.js
@@ -65,7 +65,8 @@ export default class ProNl extends React.Component {
               }>
                 <Message pointer='cta.pro' />
               </Link>
-              <Href to='api_reference_link'
+
+              <Href to='api_docs.path'
               className='u-pull-end u-margin-Txxs u-margin-Rm'>
                 API documentatie
               </Href>
@@ -116,7 +117,8 @@ export default class ProNl extends React.Component {
                     </div>
                     <p className='u-size-4of5 u-center u-color-dark-gray u-margin-Txs'>
                       Alle documentatie voor GoCardless Pro is gratis beschikbaar in onze
-                      <Href to='api_reference_link'> API docs</Href>.
+
+                      <Href to='api_docs.path'> API docs</Href>.
                       We hebben ons best gedaan om de integratie met jouw systemen zo eenvoudig mogelijk te maken.
                     </p>
                   </div>

--- a/app/pages/stories/stories/smart-pension.js
+++ b/app/pages/stories/stories/smart-pension.js
@@ -80,7 +80,7 @@ export default class StoriesSmartPension extends React.Component {
             The benefits
           </h2>
           <p className='para'>
-            The simple <Href to='developer_link' className='u-link-color-p u-text-underline'>GoCardless API</Href> was easy
+            The simple <Href to='developers.path' className='u-link-color-p u-text-underline'>GoCardless API</Href> was easy
             for Smart Pension to integrate into the existing system, via plug and play integration into the Ruby on Rails platform.
             Smart Pension were up and running with GoCardless in under a week, with help from GoCardless support, which ensured existing
             clients were unaffected by the transition.


### PR DESCRIPTION
**DNM**:

- [x] Add final 'Solutions' dropdown `nav_title` values to `messages/en`, currently using placeholders:

![image](https://cloud.githubusercontent.com/assets/883598/21205838/4adce24a-c256-11e6-9d61-f12dae1ce2c3.png)

---

### New nav contents & layout

This PR updates the en-GB site nav with a new structure — 'Solutions', 'Who uses us?', 'Help & resources' and 'About us' dropdowns — and re-arranges some of the existing links to fit in with this new structure. We also have a new nav layout for the site with main content on the left, and secondary content (eg 'About us', 'More') sitting on the right:

![image](https://cloud.githubusercontent.com/assets/883598/21197837/dda9b7f0-c234-11e6-887b-25ada70814b8.png)

### Developer & API docs messages refactoring

I've also refactored the way we refer to some of the external developer resources in the messages files (and then consequently throughout the templates) as there was some inconsistency with naming & structure that was causing a bit of confusion.

### `header.js` refactoring

Lastly I've taken the opportunity to refactor the file that contains the nav, `header.js` to improve readability & maintainability — when I started working on this template it was initially quite hard to parse due to number of inline functions (for generating popovers, using `classnames` etc) which I refactored into their own functions outside of the template.