### PR TITLE
fr website change - euro sign

### DIFF
--- a/app/messages/fr.js
+++ b/app/messages/fr.js
@@ -1,6 +1,6 @@
 export default {
   number_of_merchants: '20.000',
-  payments_processed_volume: '€1,6 milliard',
+  payments_processed_volume: '1,6€ milliard',
   header: {
     our_products: 'Nos produits',
     login_btn: 'Se connecter',


### PR DESCRIPTION
Moved Euro sign after 1,6 on the line “Plus de 1,6€ milliard …”