### PR TITLE
Update Direct Debit FR page to link to French SEPA Guide

### DIFF
--- a/app/pages/direct-debit-api/direct-debit-api.fr.js
+++ b/app/pages/direct-debit-api/direct-debit-api.fr.js
@@ -304,7 +304,7 @@ export default class DirectDebitApiFr extends React.Component {
 
                   <hr className='u-margin-Vxl'/>
 
-                  <a href='https://gocardless.com/direct-debit/'>
+                  <a href='https://gocardless.com/fr/guides/sepa/'>
                     <ReadPdf className='u-inline-block useful-resource__icon' />
                     Lire
                   </a>


### PR DESCRIPTION
Changing the link on https://gocardless.com/fr-fr/api-prelevement-automatique/ to point towards the French SEPA Guide rather than UK Bacs Guide