### PR TITLE
Fix FR developers link and typo

### DIFF
--- a/app/messages/fr.js
+++ b/app/messages/fr.js
@@ -305,8 +305,8 @@ export default {
     path: 'https://developer.gocardless.com/api-reference',
   },
   developers: {
-    title: 'Documentation API',
-    nav_title: 'Documentation API',
+    title: 'Développeurs',
+    nav_title: 'Développeurs',
     description: '',
     path: 'https://developer.gocardless.com/fr',
   },

--- a/app/pages/developers/developers.fr.js
+++ b/app/pages/developers/developers.fr.js
@@ -117,7 +117,7 @@ export default class DevelopersFr extends React.Component {
 
                 <Href to='api_docs.path'
                 className='btn btn--invert-hollow u-margin-Tl'>
-                  Consultez notre documentation pour les developpeurs
+                  Consultez notre documentation pour les développeurs
                 </Href>
           </div>
         </div>


### PR DESCRIPTION
* Link in main nav bar should now say `Développeurs`
* Fix typo on CTA (missing accent)