### PR TITLE
Show local phone numbers underneath Contact Sales forms

### DIFF
--- a/app/pages/direct-debit-api/direct-debit-api.en.js
+++ b/app/pages/direct-debit-api/direct-debit-api.en.js
@@ -266,7 +266,7 @@ export default class DirectDebitApiEn extends React.Component {
           </div>
 
           <p className='u-text-center u-color-dark-gray u-margin-Bs u-text-s'>
-            To speak to us immediately call: <Message pointer='phone_full' />
+            To speak to us immediately call: <Message pointer='phone_local' />
           </p>
         </div>
 

--- a/app/pages/direct-debit-api/direct-debit-api.fr.js
+++ b/app/pages/direct-debit-api/direct-debit-api.fr.js
@@ -285,7 +285,7 @@ export default class DirectDebitApiFr extends React.Component {
           </div>
 
           <p className='u-text-center u-color-dark-gray u-margin-Bs u-text-s'>
-            Prenez contact avec nous: <Message pointer='phone_full' />
+            Prenez contact avec nous: <Message pointer='phone_local' />
           </p>
         </div>
 

--- a/app/pages/existing-direct-debit-user/existing-direct-debit-user.js
+++ b/app/pages/existing-direct-debit-user/existing-direct-debit-user.js
@@ -368,7 +368,7 @@ export default class ExistingDirectDebitUser extends React.Component {
             </div>
 
             <p className='u-text-center u-color-dark-gray u-margin-Bs u-text-s'>
-              To speak to us immediately call: <Message pointer='phone_full' />
+              To speak to us immediately call: <Message pointer='phone_local' />
             </p>
           </div>
         </div>

--- a/app/pages/new-to-direct-debit/new-to-direct-debit.js
+++ b/app/pages/new-to-direct-debit/new-to-direct-debit.js
@@ -364,7 +364,7 @@ export default class NewToDirectDebit extends React.Component {
             </div>
 
             <p className='u-text-center u-color-dark-gray u-margin-Bs u-text-s'>
-              To speak to us immediately call: <Message pointer='phone_full' />
+              To speak to us immediately call: <Message pointer='phone_local' />
             </p>
           </div>
         </div>


### PR DESCRIPTION
Show local phone numbers without IDD code (i.e. without the +44 or +33 prefix) underneath Contact Sales forms