### PR TITLE
Fix onClick not firing on mobile

### DIFF
--- a/app/css/components/popover.scss
+++ b/app/css/components/popover.scss
@@ -53,6 +53,7 @@
 
 .popover-link {
   padding-right: 15px;
+  cursor: pointer;
 }
 
 .popover-link:after {


### PR DESCRIPTION
CSS fix for `<Popover>` not triggering on mobile tap