### PR TITLE
Set section-divider max-width

### DIFF
--- a/app/css/components/section-divider.scss
+++ b/app/css/components/section-divider.scss
@@ -1,4 +1,4 @@
 .section-divider {
-  width: 940px;
+  max-width: 940px;
   margin: 0 auto;
 }


### PR DESCRIPTION
Fix white space issue in case studies on mobile

![screenshot_20170103-194855](https://cloud.githubusercontent.com/assets/9258365/21646321/99cb9404-d28d-11e6-9596-d8b4be1ea496.png)
